### PR TITLE
Set a max output limit of 100 events per batch from join and agg

### DIFF
--- a/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateOperator.cs
@@ -124,6 +124,12 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
                     {
                         outputs.Add(outputEvent);
                     }
+
+                    if (outputs.Count > 100)
+                    {
+                        yield return new StreamEventBatch(null, outputs);
+                    }
+                    outputs = new List<StreamEvent>();
                     // Replace the previous value with the new value
                     val.PreviousValue = outputData;
                 }
@@ -144,6 +150,12 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
                     var outputData = _flexBufferNewValue.Finish();
                     val.PreviousValue = outputData;
                     outputs.Add(new StreamEvent(1, 0, outputData));
+
+                    if (outputs.Count > 100)
+                    {
+                        yield return new StreamEventBatch(null, outputs);
+                    }
+                    outputs = new List<StreamEvent>();
                 }
                 await _tree.Upsert(new StreamEvent(0, 0, EmptyVector), val);
             }
@@ -205,6 +217,12 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
                         {
                             outputs.Add(new StreamEvent(1, 0, newObjectValue));
                         }
+
+                        if (outputs.Count > 100)
+                        {
+                            yield return new StreamEventBatch(null, outputs);
+                        }
+                        outputs = new List<StreamEvent>();
 
                         val.PreviousValue = newObjectValue;
                         await _tree.Upsert(kv.Key, val);

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateOperator.cs
@@ -128,8 +128,9 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
                     if (outputs.Count > 100)
                     {
                         yield return new StreamEventBatch(null, outputs);
+                        outputs = new List<StreamEvent>();
                     }
-                    outputs = new List<StreamEvent>();
+                    
                     // Replace the previous value with the new value
                     val.PreviousValue = outputData;
                 }
@@ -154,8 +155,9 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
                     if (outputs.Count > 100)
                     {
                         yield return new StreamEventBatch(null, outputs);
+                        outputs = new List<StreamEvent>();
                     }
-                    outputs = new List<StreamEvent>();
+                    
                 }
                 await _tree.Upsert(new StreamEvent(0, 0, EmptyVector), val);
             }
@@ -221,8 +223,9 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
                         if (outputs.Count > 100)
                         {
                             yield return new StreamEventBatch(null, outputs);
+                            outputs = new List<StreamEvent>();
                         }
-                        outputs = new List<StreamEvent>();
+                        
 
                         val.PreviousValue = newObjectValue;
                         await _tree.Upsert(kv.Key, val);

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinOperatorBase.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinOperatorBase.cs
@@ -220,6 +220,12 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                 int outputWeight = e.Weight * kv.Value.Weight;
                                 output.Add(OnConditionSuccess(joinEventCheck, kv.Key, outputWeight));
                                 joinWeight += outputWeight;
+
+                                if (output.Count > 100)
+                                {
+                                    yield return new StreamEventBatch(null, output);
+                                }
+                                output = new List<StreamEvent>();
                             }
                         }
                         else
@@ -239,7 +245,11 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 {
                     // Emit null if left join or full outer join
                     output.Add(CreateLeftWithNullRightEvent(e.Weight, joinEventCheck));
-
+                    if (output.Count > 100)
+                    {
+                        yield return new StreamEventBatch(null, output);
+                    }
+                    output = new List<StreamEvent>();
                     await _leftTree.RMW(joinEvent, new JoinStorageValue() { Weight = e.Weight, JoinWeight = joinWeight }, (input, current, found) =>
                     {
                         if (found)
@@ -335,6 +345,12 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                         leftJoinWeight.Add(kv.Key, outputWeight);
                                     }
                                 }
+
+                                if (output.Count > 100)
+                                {
+                                    yield return new StreamEventBatch(null, output);
+                                }
+                                output = new List<StreamEvent>();
                             }
                         }
                         else
@@ -393,6 +409,12 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     {
                         output.Add(CreateLeftWithNullRightEvent(val.Weight, kv.Key));
                     }
+
+                    if (output.Count > 100)
+                    {
+                        yield return new StreamEventBatch(null, output);
+                    }
+                    output = new List<StreamEvent>();
                 }
                 leftJoinWeight.Clear();
             }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinOperatorBase.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinOperatorBase.cs
@@ -224,8 +224,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                 if (output.Count > 100)
                                 {
                                     yield return new StreamEventBatch(null, output);
+                                    output = new List<StreamEvent>();
                                 }
-                                output = new List<StreamEvent>();
+                                
                             }
                         }
                         else
@@ -248,8 +249,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     if (output.Count > 100)
                     {
                         yield return new StreamEventBatch(null, output);
+                        output = new List<StreamEvent>();
                     }
-                    output = new List<StreamEvent>();
+                    
                     await _leftTree.RMW(joinEvent, new JoinStorageValue() { Weight = e.Weight, JoinWeight = joinWeight }, (input, current, found) =>
                     {
                         if (found)
@@ -349,8 +351,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                 if (output.Count > 100)
                                 {
                                     yield return new StreamEventBatch(null, output);
+                                    output = new List<StreamEvent>();
                                 }
-                                output = new List<StreamEvent>();
+                                
                             }
                         }
                         else
@@ -413,8 +416,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     if (output.Count > 100)
                     {
                         yield return new StreamEventBatch(null, output);
+                        output = new List<StreamEvent>();
                     }
-                    output = new List<StreamEvent>();
+                    
                 }
                 leftJoinWeight.Clear();
             }


### PR DESCRIPTION
This should reduce memory consumption