### PR TITLE
Fix invalid restores in storage system on crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ builder.Services.AddFlowtideStream(b =>
 {
     b.AddPlan(plan)
     .AddReadWriteFactory(factory)
-    .WithStateOptions(() => new StateManagerOptions()
+    .WithStateOptions(new StateManagerOptions()
     {
         // This is non persistent storage, use FasterKV persistence storage instead if you want persistent storage
         PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions()

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -73,7 +73,7 @@ builder.Services.AddFlowtideStream(b =>
 {
     b.AddPlan(plan)
     .AddReadWriteFactory(factory)
-    .WithStateOptions(() => new StateManagerOptions()
+    .WithStateOptions(new StateManagerOptions()
     {
         // This is non persistent storage, use FasterKV persistence storage instead if you want persistent storage
         PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions()
@@ -146,7 +146,7 @@ builder.Services.AddFlowtideStream(b =>
 {
     b.AddPlan(plan)
     .AddReadWriteFactory(factory)
-    .WithStateOptions(() => new StateManagerOptions()
+    .WithStateOptions(new StateManagerOptions()
     {
         // This is non persistent storage, use FasterKV persistence storage instead if you want persistent storage
         PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions()

--- a/samples/MonitoringAzureMonitor/Program.cs
+++ b/samples/MonitoringAzureMonitor/Program.cs
@@ -59,7 +59,7 @@ builder.Services.AddFlowtideStream(b =>
 {
     b.AddPlan(plan)
     .AddReadWriteFactory(factory)
-    .WithStateOptions(() => new StateManagerOptions()
+    .WithStateOptions(new StateManagerOptions()
     {
         // This is non persistent storage, use FasterKV persistence storage instead if you want persistent storage
         PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions()

--- a/samples/MonitoringPrometheus/Program.cs
+++ b/samples/MonitoringPrometheus/Program.cs
@@ -53,7 +53,7 @@ builder.Services.AddFlowtideStream(b =>
 {
     b.AddPlan(plan)
     .AddReadWriteFactory(factory)
-    .WithStateOptions(() => new StateManagerOptions()
+    .WithStateOptions(new StateManagerOptions()
     {
         // This is non persistent storage, use FasterKV persistence storage instead if you want persistent storage
         PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions()

--- a/samples/SqlSampleWithUI/Program.cs
+++ b/samples/SqlSampleWithUI/Program.cs
@@ -56,7 +56,7 @@ builder.Services.AddFlowtideStream(b =>
 {
     b.AddPlan(plan)
     .AddReadWriteFactory(factory)
-    .WithStateOptions(() => new StateManagerOptions()
+    .WithStateOptions(new StateManagerOptions()
     {
         // This is non persistent storage, use FasterKV persistence storage instead if you want persistent storage
         PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions()

--- a/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
@@ -30,7 +30,7 @@ namespace FlowtideDotNet.Base.Engine
         private readonly string _streamName;
         private IStreamScheduler? _streamScheduler;
         private IStreamNotificationReciever? _streamNotificationReciever;
-        private Func<StateManagerOptions>? _stateManagerOptions;
+        private StateManagerOptions? _stateManagerOptions;
         private ILoggerFactory? _loggerFactory;
         private StreamVersionInformation? _streamVersionInformation;
 
@@ -78,7 +78,7 @@ namespace FlowtideDotNet.Base.Engine
             return this;
         }
 
-        public DataflowStreamBuilder WithStateOptions(Func<StateManagerOptions> stateManagerOptions)
+        public DataflowStreamBuilder WithStateOptions(StateManagerOptions stateManagerOptions)
         {
             _stateManagerOptions = stateManagerOptions;
             return this;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -90,7 +90,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             StreamState? fromState,
             IStreamScheduler streamScheduler,
             IStreamNotificationReciever? notificationReciever,
-            Func<StateManagerOptions> stateManagerOptions,
+            StateManagerOptions stateManagerOptions,
             ILoggerFactory? loggerFactory,
             StreamVersionInformation? streamVersionInformation)
         {

--- a/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
+++ b/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
@@ -60,7 +60,7 @@ namespace FlowtideDotNet.Core.Engine
             return this;
         }
 
-        public FlowtideBuilder WithStateOptions(Func<StateManagerOptions> stateManagerOptions)
+        public FlowtideBuilder WithStateOptions(StateManagerOptions stateManagerOptions)
         {
             dataflowStreamBuilder.WithStateOptions(stateManagerOptions);
             return this;

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
@@ -27,6 +27,10 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
             return Task.CompletedTask;
         }
 
+        public void Dispose()
+        {
+        }
+
         public ValueTask<byte[]> Read(long key)
         {
             return ValueTask.FromResult(fileCache.Read(key));

--- a/src/FlowtideDotNet.Storage/Persistence/FasterStorage/FasterKVPersistentSession.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/FasterStorage/FasterKVPersistentSession.cs
@@ -31,6 +31,11 @@ namespace FlowtideDotNet.Storage.Persistence.FasterStorage
             _ = result.Complete();
         }
 
+        public void Dispose()
+        {
+            session.Dispose();
+        }
+
         public async ValueTask<byte[]> Read(long key)
         {
             var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/src/FlowtideDotNet.Storage/Persistence/FasterStorage/FasterKvPersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/FasterStorage/FasterKvPersistentStorage.cs
@@ -80,8 +80,6 @@ namespace FlowtideDotNet.Storage.Persistence.FasterStorage
         public async ValueTask CompactAsync()
         {
             m_adminSession.Compact(m_persistentStorage.Log.SafeReadOnlyAddress, CompactionType.Lookup);
-            m_persistentStorage.Log.Truncate();
-            await m_persistentStorage.TakeFullCheckpointAsync(CheckpointType.Snapshot);
         }
 
         public ValueTask ResetAsync()

--- a/src/FlowtideDotNet.Storage/Persistence/IPersistentStorageSession.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/IPersistentStorageSession.cs
@@ -12,7 +12,7 @@
 
 namespace FlowtideDotNet.Storage.Persistence
 {
-    public interface IPersistentStorageSession
+    public interface IPersistentStorageSession : IDisposable
     {
         ValueTask<byte[]> Read(long key);
 

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -96,7 +96,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
                 .AddPlan(plan)
                 .SetParallelism(parallelism)
                 .AddReadWriteFactory(factory)
-                .WithStateOptions(() => new Storage.StateManager.StateManagerOptions()
+                .WithStateOptions(new Storage.StateManager.StateManagerOptions()
                 {
                     SerializeOptions = stateSerializeOptions,
                     PersistentStorage = _fileCachePersistence,

--- a/tests/FlowtideDotNet.AspNetCore.WebTest/Program.cs
+++ b/tests/FlowtideDotNet.AspNetCore.WebTest/Program.cs
@@ -40,7 +40,7 @@ builder.Services.AddFlowtideStream(b =>
 {
     b.AddPlan(plan);
     b.AddReadWriteFactory(factory);
-    b.WithStateOptions(() => new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
+    b.WithStateOptions(new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
     {
         PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions()
         {

--- a/tests/FlowtideDotNet.Core.Tests/BuilderValidationTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/BuilderValidationTests.cs
@@ -122,7 +122,7 @@ namespace FlowtideDotNet.Core.Tests
             var stream = new FlowtideBuilder("test")
                     .AddPlan(plan)
                     .AddReadWriteFactory(factory)
-                    .WithStateOptions(() => new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
+                    .WithStateOptions(new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
                     {
                         PersistentStorage = cache
                     })
@@ -141,7 +141,7 @@ namespace FlowtideDotNet.Core.Tests
             var stream2 = new FlowtideBuilder("test")
                     .AddPlan(plan2)
                     .AddReadWriteFactory(factory)
-                    .WithStateOptions(() => new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
+                    .WithStateOptions(new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
                     {
                         PersistentStorage = cache
                     })

--- a/tests/FlowtideDotNet.Core.Tests/Failure/FailureTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/Failure/FailureTests.cs
@@ -285,7 +285,7 @@ namespace FlowtideDotNet.Core.Tests.Failure
             var tmpStorage = new InMemoryDeviceFactory();
             tmpStorage.Initialize("./data/tmp");
             FlowtideBuilder differentialComputeBuilder = new FlowtideBuilder("teststream")
-                .WithStateOptions(() => new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
+                .WithStateOptions(new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
                 {
                     CachePageCount = 100,
                     CheckpointDir = "./data",

--- a/tests/FlowtideDotNet.Core.Tests/Operators/Normalization/NormalizationOperatorTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/Operators/Normalization/NormalizationOperatorTests.cs
@@ -59,7 +59,7 @@ namespace FlowtideDotNet.Core.Tests.Operators.Normalization
 
             var localStorage = new LocalStorageNamedDeviceFactory(deleteOnClose: true);
             localStorage.Initialize("./data/temp");
-            stateManager = new StateManagerSync<object>(() => new StateManagerOptions()
+            stateManager = new StateManagerSync<object>(new StateManagerOptions()
             {
                 CachePageCount = 1000,
                 PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions())

--- a/tests/FlowtideDotNet.Core.Tests/SmokeTests/QuerySmokeTestBase.cs
+++ b/tests/FlowtideDotNet.Core.Tests/SmokeTests/QuerySmokeTestBase.cs
@@ -89,7 +89,7 @@ namespace FlowtideDotNet.Core.Tests.SmokeTests
                 .AddPlan(modifiedPlan, false)
                 .AddReadWriteFactory(readWriteFactory)
                 .WithScheduler(_streamScheduler)
-                .WithStateOptions(() => new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
+                .WithStateOptions(new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
                 {
                     CachePageCount = 100000,
                     LogDevice = logDevice,

--- a/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
@@ -154,7 +154,7 @@ namespace FlowtideDotNet.SqlServer.Tests.Acceptance
                 var stream = new FlowtideBuilder("stream")
                 .AddPlan(plan)
                 .AddReadWriteFactory(readWriteFactory)
-                .WithStateOptions(() => new Storage.StateManager.StateManagerOptions()
+                .WithStateOptions(new Storage.StateManager.StateManagerOptions()
                 {
                     PersistentStorage = new FileCachePersistentStorage(new Storage.FileCacheOptions())
                 })
@@ -198,7 +198,7 @@ namespace FlowtideDotNet.SqlServer.Tests.Acceptance
                 }
             };
 
-            var stateManager = new StateManagerSync<object>(() => new StateManagerOptions()
+            var stateManager = new StateManagerSync<object>(new StateManagerOptions()
             {
                 CachePageCount = 1000,
                 PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions())

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeTests.cs
@@ -33,7 +33,7 @@ namespace FlowtideDotNet.Storage.Tests
         {
             var localStorage = new LocalStorageNamedDeviceFactory(deleteOnClose: true);
             localStorage.Initialize("./data/temp");
-            stateManager = new StateManager.StateManagerSync<object>(() => new StateManagerOptions()
+            stateManager = new StateManager.StateManagerSync<object>(new StateManagerOptions()
             {
                 CachePageCount = 10,
                 PersistentStorage = new FileCachePersistentStorage(new FileCacheOptions())

--- a/tests/FlowtideDotNet.Storage.Tests/DeviceFailureTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/DeviceFailureTests.cs
@@ -244,9 +244,8 @@ namespace FlowtideDotNet.Storage.Tests
         public async Task TestWriteFailure()
         {
             var nullFactory = new NullLoggerFactory();
-            var manager = new StateManagerSync<object>(() =>
-            {
-                return new StateManagerOptions()
+            var manager = new StateManagerSync<object>(
+                new StateManagerOptions()
                 {
                     PersistentStorage = new FasterKvPersistentStorage(new FasterKVSettings<long, SpanByte>()
                     {
@@ -254,8 +253,7 @@ namespace FlowtideDotNet.Storage.Tests
                         MemorySize = 128,
                         PageSize = 128,
                         
-                    }),
-                };
+                    })
             }, nullFactory.CreateLogger("logger"));
             await manager.InitializeAsync();
             var client = manager.GetOrCreateClient("test");
@@ -296,9 +294,8 @@ namespace FlowtideDotNet.Storage.Tests
         {
             var logger = new LoggerFactory(new List<ILoggerProvider>() { new DebugLoggerProvider() }).CreateLogger("test");
             var device = new ReadFailureDevice(Devices.CreateLogDevice("test", deleteOnClose: true));
-            var manager = new StateManagerSync<object>(() =>
-            {
-                return new StateManagerOptions()
+            var manager = new StateManagerSync<object>(
+                new StateManagerOptions()
                 {
                     PersistentStorage = new FasterKvPersistentStorage(new FasterKVSettings<long, SpanByte>()
                     {
@@ -306,8 +303,7 @@ namespace FlowtideDotNet.Storage.Tests
                         MemorySize = 512,
                         PageSize = 512,
 
-                    }),
-                };
+                    })
             }, logger);
             await manager.InitializeAsync();
             var client = manager.GetOrCreateClient("test");


### PR DESCRIPTION
This removes the change to pass in a function for state options. It fixes so compaction cannot cause an invalid state. It also makes sure all state metadata is restored correctly.