### PR TITLE
Clear flexbuffer stack on new object

### DIFF
--- a/src/FlowtideDotNet.Core/Flexbuffer/FlexBuffer.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlexBuffer.cs
@@ -53,6 +53,10 @@ namespace FlexBuffers
 
         public void NewObject()
         {
+            if (_stack.Count > 0)
+            {
+                Clear();
+            }
             _bytes = pool.Rent((int)_size);
             Array.Clear(_bytes);
         }


### PR DESCRIPTION
This can be caused on exceptions, that the stack is not cleared correctly.