### PR TITLE
Add events to mongodb event that the user can listen to

### DIFF
--- a/src/FlowtideDotNet.Connector.ElasticSearch/Internal/ElasticSearchSink.cs
+++ b/src/FlowtideDotNet.Connector.ElasticSearch/Internal/ElasticSearchSink.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using Elasticsearch.Net;
+using FlowtideDotNet.Base;
 using FlowtideDotNet.Core.Operators.Write;
 using FlowtideDotNet.Substrait.Relations;
 using Microsoft.Extensions.Logging;
@@ -70,7 +71,7 @@ namespace FlowtideDotNet.Connector.ElasticSearch.Internal
             return new MetadataResult(m_primaryKeys);
         }
 
-        protected override async Task UploadChanges(IAsyncEnumerable<SimpleChangeEvent> rows, CancellationToken cancellationToken)
+        protected override async Task UploadChanges(IAsyncEnumerable<SimpleChangeEvent> rows, Watermark watermark, CancellationToken cancellationToken)
         {
             Debug.Assert(m_client != null);
             Debug.Assert(m_serializer != null);

--- a/src/FlowtideDotNet.Connector.MongoDB/FlowtideMongoDBSinkOptions.cs
+++ b/src/FlowtideDotNet.Connector.MongoDB/FlowtideMongoDBSinkOptions.cs
@@ -10,6 +10,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base;
+using MongoDB.Bson;
+using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,5 +30,11 @@ namespace FlowtideDotNet.Connector.MongoDB
         public string Collection { get; set; }
 
         public List<string> PrimaryKeys { get; set; }
+
+        public Action<BsonDocument>? TransformDocument { get; set; }
+
+        public Func<IMongoCollection<BsonDocument>, Task>? OnInitialDataSent { get; set; }
+
+        public Func<Watermark, Task>? OnWatermarkUpdate { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Connector.MongoDB/Internal/MongoDBSink.cs
+++ b/src/FlowtideDotNet.Connector.MongoDB/Internal/MongoDBSink.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base;
 using FlowtideDotNet.Core.Operators.Write;
 using FlowtideDotNet.Substrait.Relations;
 using Microsoft.Extensions.Logging;
@@ -41,6 +42,19 @@ namespace FlowtideDotNet.Connector.MongoDB.Internal
         }
 
         public override string DisplayName => "MongoDB Sink";
+
+        protected override Task OnInitialDataSent()
+        {
+            if (options.OnInitialDataSent != null)
+            {
+                collection.DeleteManyAsync(Builders<BsonDocument>.Filter.Not(Builders<BsonDocument>.Filter.Eq("metadata", "123")));
+                return options.OnInitialDataSent(collection);
+            }
+            else
+            {
+                return Task.CompletedTask;
+            }
+        }
 
         protected override Task<MetadataResult> SetupAndLoadMetadataAsync()
         {
@@ -104,7 +118,7 @@ namespace FlowtideDotNet.Connector.MongoDB.Internal
             }
         }
 
-        protected override async Task UploadChanges(IAsyncEnumerable<SimpleChangeEvent> rows, CancellationToken cancellationToken)
+        protected override async Task UploadChanges(IAsyncEnumerable<SimpleChangeEvent> rows, Watermark watermark, CancellationToken cancellationToken)
         {
             List<WriteModel<BsonDocument>> writes = new List<WriteModel<BsonDocument>>();
             List<Task> writeTasks = new List<Task>();
@@ -135,6 +149,10 @@ namespace FlowtideDotNet.Connector.MongoDB.Internal
                 else
                 {
                     var doc = streamEventToBson.ToBson(row.Row);
+                    if (options.TransformDocument != null)
+                    {
+                        options.TransformDocument(doc);
+                    }
                     writes.Add(new ReplaceOneModel<BsonDocument>(filter, doc) { IsUpsert = true });
                 }
 
@@ -176,7 +194,13 @@ namespace FlowtideDotNet.Connector.MongoDB.Internal
             {
                 writeTasks.Add(collection.BulkWriteAsync(writes));
             }
+
             await Task.WhenAll(writeTasks);
+
+            if (options.OnWatermarkUpdate != null)
+            {
+                await options.OnWatermarkUpdate(watermark);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
@@ -29,6 +29,7 @@ namespace FlowtideDotNet.Core.Operators.Write
     public class SimpleWriteState : IStatefulWriteState
     {
         public long StorageSegmentId { get; set; }
+        public bool SentInitialData { get; set; }
     }
 
     public class MetadataResult
@@ -69,6 +70,8 @@ namespace FlowtideDotNet.Core.Operators.Write
         private IBPlusTree<StreamEvent, int>? m_modified;
         private bool m_hasModified;
         private readonly ExecutionMode m_executionMode;
+        private SimpleWriteState? _state;
+        private Watermark _latestWatermark;
 
         protected SimpleGroupedWriteOperator(ExecutionMode executionMode, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionDataflowBlockOptions)
         {
@@ -90,13 +93,23 @@ namespace FlowtideDotNet.Core.Operators.Write
             if (m_hasModified)
             {
                 var rowIterator = GetChangedRows();
-                await UploadChanges(rowIterator, CancellationToken);
+                await UploadChanges(rowIterator, _latestWatermark, CancellationToken);
                 await m_modified.Clear();
                 m_hasModified = false;
             }
+            if (_state!.SentInitialData == false)
+            {
+                await OnInitialDataSent();
+                _state.SentInitialData = true;
+            }
         }
 
-        protected abstract Task UploadChanges(IAsyncEnumerable<SimpleChangeEvent> rows, CancellationToken cancellationToken);
+        protected virtual Task OnInitialDataSent()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected abstract Task UploadChanges(IAsyncEnumerable<SimpleChangeEvent> rows, Watermark watermark, CancellationToken cancellationToken);
 
         private async IAsyncEnumerable<SimpleChangeEvent> GetChangedRows()
         {
@@ -128,6 +141,7 @@ namespace FlowtideDotNet.Core.Operators.Write
 
         protected override Task OnWatermark(Watermark watermark)
         {
+            _latestWatermark = watermark;
             if (m_executionMode == ExecutionMode.OnWatermark)
             {
                 return SendData();
@@ -151,6 +165,17 @@ namespace FlowtideDotNet.Core.Operators.Write
             if (m_metadataResult == null)
             {
                 m_metadataResult = await SetupAndLoadMetadataAsync();
+            }
+            if (state != null)
+            {
+                _state = state;
+            }
+            else
+            {
+                _state = new SimpleWriteState()
+                {
+                    SentInitialData = false
+                };
             }
             m_modified = await stateManagerClient.GetOrCreateTree("temporary", new BPlusTreeOptions<StreamEvent, int>()
             {


### PR DESCRIPTION
This allows a user to implement features such as appending metadata, cleaning up old data from a previous run, etc.