### PR TITLE
Add support for gettimestamp function

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test ./tests/FlowtideDotNet.AcceptanceTests/FlowtideDotNet.AcceptanceTests.csproj --no-build --verbosity normal
+      run: dotnet test ./tests/FlowtideDotNet.AcceptanceTests/FlowtideDotNet.AcceptanceTests.csproj --no-build --verbosity normal -p:ParallelizeTestCollections=false

--- a/docs/docs/expressions/scalarfunctions/datetime.md
+++ b/docs/docs/expressions/scalarfunctions/datetime.md
@@ -24,3 +24,56 @@ SELECT
     strftime(Orderdate, '%Y-%m-%d %H:%M:%S') as Orderdate
 FROM Orders
 ```
+
+## Get timestamp
+
+*This function has no substrait equivalent*
+
+:::warning
+
+Get timestamp is not yet supported inside of join conditions.
+
+:::
+
+Get the current timestamp (current datetime).
+
+This is a meta function that itself does no computation, but is instead replaced during the optimization step with
+joins against a timestamp data source.
+
+Example:
+
+```kroki type=blockdiag
+  blockdiag {
+    Source -> Project -> Write
+  }
+```
+
+Where if project uses gettimestamp becomes:
+
+```kroki type=blockdiag
+  blockdiag {
+    Source -> CrossJoin -> Project -> Write;
+    TimestampProvider -> CrossJoin;
+  }
+```
+
+This means that all rows that are evaluated will have the same value of *gettimestamp* to ensure consistent results.
+
+The timestamp provider also publishes a watermark called '__timestamp' which can be used to see the current time that has been evaluted in the stream.
+
+By default the timestamp is updated every hour. This is configurable during the stream setup:
+
+```csharp
+streamBuilder
+    .SetGetTimestampUpdateInterval(TimeSpan.FromHours(12))
+```
+
+### SQL Usage
+
+```sql
+INSERT INTO output
+SELECT
+    gettimestamp() as CurrentDateTime
+FROM Orders
+```
+

--- a/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
+++ b/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
@@ -32,6 +32,7 @@ namespace FlowtideDotNet.Core.Engine
         private int _queueSize = 100;
         private FunctionsRegister _functionsRegister;
         private int _parallelism = 1;
+        private TimeSpan _getTimestampInterval = TimeSpan.FromHours(1);
 
         public FlowtideBuilder(string streamName)
         {
@@ -103,6 +104,12 @@ namespace FlowtideDotNet.Core.Engine
             return this;
         }
 
+        public FlowtideBuilder SetGetTimestampUpdateInterval(TimeSpan interval)
+        {
+            _getTimestampInterval = interval;
+            return this;
+        }
+
         private string ComputePlanHash()
         {
             using (SHA256 sha256 = SHA256.Create())
@@ -134,7 +141,15 @@ namespace FlowtideDotNet.Core.Engine
             var hash = ComputePlanHash();
             dataflowStreamBuilder.SetVersionInformation(1, hash);
 
-            SubstraitVisitor visitor = new SubstraitVisitor(_plan, dataflowStreamBuilder, _readWriteFactory, _queueSize, _functionsRegister, _parallelism);
+            SubstraitVisitor visitor = new SubstraitVisitor(
+                _plan, 
+                dataflowStreamBuilder, 
+                _readWriteFactory, 
+                _queueSize, 
+                _functionsRegister, 
+                _parallelism, 
+                _getTimestampInterval);
+
             visitor.BuildPlan();
 
             return dataflowStreamBuilder.Build();

--- a/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
+++ b/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
@@ -30,6 +30,7 @@ using FlowtideDotNet.Core.Operators.Iteration;
 using FlowtideDotNet.Core.Operators.Partition;
 using FlowtideDotNet.Base.Vertices.PartitionVertices;
 using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Core.Operators.TimestampProvider;
 
 namespace FlowtideDotNet.Core.Engine
 {
@@ -54,6 +55,7 @@ namespace FlowtideDotNet.Core.Engine
         private readonly int queueSize;
         private readonly FunctionsRegister functionsRegister;
         private readonly int parallelism;
+        private readonly TimeSpan getTimestampInterval;
         private int _operatorId = 0;
         private Dictionary<int, RelationTree> _doneRelations;
         private Dictionary<string, IterationOperator> _iterationOperators = new Dictionary<string, IterationOperator>();
@@ -98,7 +100,8 @@ namespace FlowtideDotNet.Core.Engine
             IReadWriteFactory readFactory, 
             int queueSize, 
             FunctionsRegister functionsRegister,
-            int parallelism)
+            int parallelism,
+            TimeSpan getTimestampInterval)
         {
             this.plan = plan;
             this.dataflowStreamBuilder = dataflowStreamBuilder;
@@ -106,6 +109,7 @@ namespace FlowtideDotNet.Core.Engine
             this.queueSize = queueSize;
             this.functionsRegister = functionsRegister;
             this.parallelism = parallelism;
+            this.getTimestampInterval = getTimestampInterval;
             _doneRelations = new Dictionary<int, RelationTree>();
         }
 
@@ -348,8 +352,32 @@ namespace FlowtideDotNet.Core.Engine
             return op;
         }
 
+        private IStreamVertex VisitGetTimestampTable(ITargetBlock<IStreamEvent>? state)
+        {
+            var id = _operatorId++;
+            var op = new TimestampProviderOperator(getTimestampInterval, new DataflowBlockOptions() { BoundedCapacity = queueSize });
+            if (op is ISourceBlock<IStreamEvent> sourceBlock)
+            {
+                if (state != null)
+                {
+                    sourceBlock.LinkTo(state);
+                }
+            }
+            else
+            {
+                throw new NotSupportedException("Read relation operator must implement ISourceBlock<IStreamEvent>");
+            }
+            dataflowStreamBuilder.AddIngressBlock(id.ToString(), op);
+            return op;
+        }
+
         public override IStreamVertex VisitReadRelation(ReadRelation readRelation, ITargetBlock<IStreamEvent>? state)
         {
+            if (readRelation.NamedTable.DotSeperated == "__gettimestamp")
+            {
+                return VisitGetTimestampTable(state);
+            }
+
             var info = readFactory.GetReadOperator(readRelation, new DataflowBlockOptions() { BoundedCapacity = queueSize });
 
             var previousState = state;

--- a/src/FlowtideDotNet.Core/Operators/TimestampProvider/TimestampProviderOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TimestampProvider/TimestampProviderOperator.cs
@@ -1,0 +1,128 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Base.Vertices.Ingress;
+using FlowtideDotNet.Core.Operators.Read;
+using FlowtideDotNet.Storage.StateManager;
+using System.Diagnostics;
+using System.Threading.Tasks.Dataflow;
+
+namespace FlowtideDotNet.Core.Operators.TimestampProvider
+{
+    internal class TimestampProviderState
+    {
+        public long? LastSentTimestamp { get; set; } 
+    }
+    internal class TimestampProviderOperator : ReadBaseOperator<TimestampProviderState>
+    {
+        private readonly TimeSpan interval;
+        private IReadOnlySet<string> _watermarks;
+        private TimestampProviderState? _state;
+
+        public TimestampProviderOperator(TimeSpan interval, DataflowBlockOptions options) : base(options)
+        {
+            _watermarks = new HashSet<string>()
+            {
+                "__timestamp"
+            };
+            this.interval = interval;
+        }
+
+        public override string DisplayName => "Timestamp provider";
+
+        public override Task DeleteAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task OnTrigger(string triggerName, object? state)
+        {
+            RunTask(UpdateTimestamp);
+            return Task.CompletedTask;
+        }
+
+        protected override Task<IReadOnlySet<string>> GetWatermarkNames()
+        {
+            return Task.FromResult(_watermarks);
+        }
+
+        protected override async Task InitializeOrRestore(long restoreTime, TimestampProviderState? state, IStateManagerClient stateManagerClient)
+        {
+            if (state != null)
+            {
+                _state = state;
+            }
+            else
+            {
+                _state = new TimestampProviderState();
+            }
+            await RegisterTrigger("update", interval);
+        }
+
+        protected override Task<TimestampProviderState> OnCheckpoint(long checkpointTime)
+        {
+            Debug.Assert(_state != null);
+            return Task.FromResult(_state);
+        }
+
+        private async Task UpdateTimestamp(IngressOutput<StreamEventBatch> output, object? state)
+        {
+            Debug.Assert(_state != null);
+
+            await output.EnterCheckpointLock();
+
+            var currentTimestamp = DateTime.UtcNow.Subtract(DateTime.UnixEpoch).Ticks;
+            if (!_state.LastSentTimestamp.HasValue)
+            {
+                await output.SendAsync(new StreamEventBatch(null, new List<StreamEvent>()
+                {
+                    StreamEvent.Create(1, 0, b =>
+                    {
+                        b.Add(currentTimestamp);
+                    })
+                }));
+            }
+            else
+            {
+                await output.SendAsync(new StreamEventBatch(null, new List<StreamEvent>()
+                {
+                    StreamEvent.Create(1, 0, b =>
+                    {
+                        b.Add(currentTimestamp);
+                    })
+                }));
+                // Remove the previous row
+                await output.SendAsync(new StreamEventBatch(null, new List<StreamEvent>()
+                {
+                    StreamEvent.Create(-1, 0, b =>
+                    {
+                        b.Add(_state.LastSentTimestamp.Value);
+                    })
+                }));
+            }
+
+            _state.LastSentTimestamp = currentTimestamp;
+
+            // Set the watermark to the current timetamp
+            await output.SendWatermark(new Base.Watermark("__timestamp", currentTimestamp));
+
+            output.ExitCheckpointLock();
+            // Schedule a checkpoint since data has changed
+            ScheduleCheckpoint(TimeSpan.FromSeconds(1));
+        }
+
+        protected override async Task SendInitial(IngressOutput<StreamEventBatch> output)
+        {
+            await UpdateTimestamp(output, default);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/GetTimestamp/GetTimestampReplacer.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/GetTimestamp/GetTimestampReplacer.cs
@@ -1,0 +1,149 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.IfThen;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+using FlowtideDotNet.Substrait.FunctionExtensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Optimizer.GetTimestamp
+{
+    internal class GetTimestampReplacer : ExpressionVisitor<Expression, object>
+    {
+        private readonly int fieldIndex;
+
+        public bool ContainsGetTimestamp { get; private set; }
+
+        public GetTimestampReplacer(int fieldIndex)
+        {
+            this.fieldIndex = fieldIndex;
+        }
+        public override Expression? VisitScalarFunction(ScalarFunction scalarFunction, object state)
+        {
+            if (scalarFunction.ExtensionUri == FunctionsDatetime.Uri &&
+                scalarFunction.ExtensionName == FunctionsDatetime.GetTimestamp)
+            {
+                ContainsGetTimestamp = true;
+                return new DirectFieldReference()
+                {
+                    ReferenceSegment = new StructReferenceSegment()
+                    {
+                        Field = fieldIndex
+                    }
+                };
+            }
+
+            for (int i = 0; i < scalarFunction.Arguments.Count; i++)
+            {
+                scalarFunction.Arguments[i] = Visit(scalarFunction.Arguments[i], state)!;
+            }
+
+            return scalarFunction;
+        }
+
+        public override Expression? VisitArrayLiteral(ArrayLiteral arrayLiteral, object state)
+        {
+            return arrayLiteral;
+        }
+
+        public override Expression? VisitBoolLiteral(BoolLiteral boolLiteral, object state)
+        {
+            return boolLiteral;
+        }
+
+        public override Expression? VisitDirectFieldReference(DirectFieldReference directFieldReference, object state)
+        {
+            return directFieldReference;
+        }
+
+        public override Expression? VisitIfThen(IfThenExpression ifThenExpression, object state)
+        {
+            ifThenExpression.Else = Visit(ifThenExpression.Else, state)!;
+
+            for (int i = 0; i < ifThenExpression.Ifs.Count; i++)
+            {
+                ifThenExpression.Ifs[i].If = Visit(ifThenExpression.Ifs[i].If, state)!;
+                ifThenExpression.Ifs[i].Then = Visit(ifThenExpression.Ifs[i].Then, state)!;
+            }
+
+            return ifThenExpression;
+        }
+
+        public override Expression? VisitListNestedExpression(ListNestedExpression listNestedExpression, object state)
+        {
+            for (int i = 0; i < listNestedExpression.Values.Count; i++)
+            {
+                listNestedExpression.Values[i] = Visit(listNestedExpression.Values[i], state)!;
+            }
+            return listNestedExpression;
+        }
+
+        public override Expression? VisitMapNestedExpression(MapNestedExpression mapNestedExpression, object state)
+        {
+            for (int i = 0; i < mapNestedExpression.KeyValues.Count; i++) 
+            {
+                mapNestedExpression.KeyValues[i] = new KeyValuePair<Expression, Expression>(
+                    Visit(mapNestedExpression.KeyValues[i].Key, state)!,
+                    Visit(mapNestedExpression.KeyValues[i].Value, state)!
+                    );
+            }
+            return mapNestedExpression;
+        }
+
+        public override Expression? VisitMultiOrList(MultiOrListExpression multiOrList, object state)
+        {
+            for (int i = 0; i < multiOrList.Value.Count; i++)
+            {
+                multiOrList.Value[i] = Visit(multiOrList.Value[i], state)!;
+            }
+
+            for (int i = 0; i < multiOrList.Options.Count; i++)
+            {
+                for (int k = 0; k < multiOrList.Options[i].Fields.Count; k++)
+                {
+                    multiOrList.Options[i].Fields[k] = Visit(multiOrList.Options[i].Fields[k], state)!;
+                }
+            }
+            return multiOrList;
+        }
+
+        public override Expression? VisitNullLiteral(NullLiteral nullLiteral, object state)
+        {
+            return nullLiteral;
+        }
+
+        public override Expression? VisitNumericLiteral(NumericLiteral numericLiteral, object state)
+        {
+            return numericLiteral;
+        }
+
+        public override Expression? VisitSingularOrList(SingularOrListExpression singularOrList, object state)
+        {
+            for (int i = 0; i < singularOrList.Options.Count; i++)
+            {
+                singularOrList.Options[i] = Visit(singularOrList.Options[i], state)!;
+            }
+            singularOrList.Value = Visit(singularOrList.Value, state)!;
+            return singularOrList;
+        }
+
+        public override Expression? VisitStringLiteral(StringLiteral stringLiteral, object state)
+        {
+            return stringLiteral;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/GetTimestamp/GetTimestampVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/GetTimestamp/GetTimestampVisitor.cs
@@ -143,7 +143,7 @@ namespace FlowtideDotNet.Core.Optimizer.GetTimestamp
 
             if (!aggregateRelation.EmitSet)
             {
-                // Add all fields but before adding the join, to make sure that 
+                // Add all fields but before adding the join, so the get timestamp value is not included in the output
                 List<int> emitList = new List<int>();
                 for (int i = 0; i < aggregateRelation.OutputLength; i++)
                 {

--- a/src/FlowtideDotNet.Core/Optimizer/GetTimestamp/GetTimestampVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/GetTimestamp/GetTimestampVisitor.cs
@@ -1,0 +1,239 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+using FlowtideDotNet.Substrait.Relations;
+using FlowtideDotNet.Substrait.Type;
+
+namespace FlowtideDotNet.Core.Optimizer.GetTimestamp
+{
+    /// <summary>
+    /// This optimizer expects to be run before merge join
+    /// </summary>
+    internal class GetTimestampVisitor : OptimizerBaseVisitor
+    {
+        private readonly Plan plan;
+        private int? referenceIndex;
+
+        public GetTimestampVisitor(Plan plan)
+        {
+            this.plan = plan;
+        }
+
+        private int GetReferenceIndex()
+        {
+            if (referenceIndex != null)
+            {
+                return referenceIndex.Value;
+            }
+            else
+            {
+                // Add a read relation to the plan to get the current timestamp
+                referenceIndex = plan.Relations.Count;
+                plan.Relations.Add(new ReadRelation()
+                {
+                    BaseSchema = new NamedStruct
+                    {
+                        Names = new List<string>() { "timestamp" },
+                        Struct = new Struct()
+                        {
+                            Types = new List<SubstraitBaseType>()
+                            {
+                                new DateType()
+                            }
+                        }
+                    },
+                    NamedTable = new NamedTable()
+                    {
+                        Names = new List<string>() { "__gettimestamp" },
+                    }
+                });
+                return referenceIndex.Value;
+            }
+        }
+
+        public override Relation VisitFilterRelation(FilterRelation filterRelation, object state)
+        {
+            // TODO: It might be possible here to move the filter that contains the date to the join instead.
+            // This would reduce the amount of data that is sent out.
+            // For now this implementation just injects the timestamp
+
+            filterRelation.Input = Visit(filterRelation.Input, state);
+
+            var replacer = new GetTimestampReplacer(filterRelation.Input.OutputLength);
+
+            filterRelation.Condition = replacer.Visit(filterRelation.Condition, state)!;
+
+            if (!replacer.ContainsGetTimestamp)
+            {
+                return filterRelation;
+            }
+
+            var emit = filterRelation.Emit;
+
+            if (emit == null)
+            {
+                emit = new List<int>();
+                for (int i = 0; i < filterRelation.OutputLength; i++)
+                {
+                    emit.Add(i);
+                }
+            }
+
+            var tmpInput = filterRelation.Input;
+
+            var join = new JoinRelation()
+            {
+                Emit = emit,
+                Left = tmpInput,
+                Right = new ReferenceRelation()
+                {
+                    ReferenceOutputLength = 1,
+                    RelationId = GetReferenceIndex()
+                },
+                Expression = filterRelation.Condition,
+                Type = JoinType.Inner
+            };
+
+            return join;
+        }
+
+        public override Relation VisitAggregateRelation(AggregateRelation aggregateRelation, object state)
+        {
+            aggregateRelation.Input = Visit(aggregateRelation.Input, state);
+
+            var replacer = new GetTimestampReplacer(aggregateRelation.Input.OutputLength);
+
+            if (aggregateRelation.Groupings != null)
+            {
+                for (int i = 0; i < aggregateRelation.Groupings.Count; i++)
+                {
+                    for (int k = 0; k < aggregateRelation.Groupings[i].GroupingExpressions.Count; k++)
+                    {
+                        aggregateRelation.Groupings[i].GroupingExpressions[k] = replacer.Visit(aggregateRelation.Groupings[i].GroupingExpressions[k], state)!;
+                    }
+                }
+            }
+
+            for (int i = 0; i < aggregateRelation.Measures.Count; i++)
+            {
+                aggregateRelation.Measures[i].Filter = replacer.Visit(aggregateRelation.Measures[i].Filter, state)!;
+                for (int k = 0; k < aggregateRelation.Measures[i].Measure.Arguments.Count; k++)
+                {
+                    aggregateRelation.Measures[i].Measure.Arguments[k] = replacer.Visit(aggregateRelation.Measures[i].Measure.Arguments[k], state)!;
+                }
+            }
+
+            if (!replacer.ContainsGetTimestamp)
+            {
+                return aggregateRelation;
+            }
+
+            var tmpInput = aggregateRelation.Input;
+
+            if (!aggregateRelation.EmitSet)
+            {
+                // Add all fields but before adding the join, to make sure that 
+                List<int> emitList = new List<int>();
+                for (int i = 0; i < aggregateRelation.OutputLength; i++)
+                {
+                    emitList.Add(i);
+                }
+                aggregateRelation.Emit = emitList;
+            }
+
+            var crossJoin = new JoinRelation()
+            {
+                Left = tmpInput,
+                Right = new ReferenceRelation()
+                {
+                    ReferenceOutputLength = 1,
+                    RelationId = GetReferenceIndex()
+                },
+                Expression = new BoolLiteral() { Value = true },
+                Type = JoinType.Inner
+            };
+
+            aggregateRelation.Input = crossJoin;
+
+            return aggregateRelation;
+        }
+
+        public override Relation VisitJoinRelation(JoinRelation joinRelation, object state)
+        {
+            joinRelation.Left = Visit(joinRelation.Left, state);
+            joinRelation.Right = Visit(joinRelation.Right, state);
+
+            var replacer = new GetTimestampReplacer(joinRelation.Left.OutputLength + joinRelation.Right.OutputLength);
+            replacer.Visit(joinRelation.Expression, state);
+
+            if (replacer.ContainsGetTimestamp)
+            {
+                // Skip joins for now, requires more advanced logic on how to inject the timestamp
+                throw new InvalidOperationException("gettimestamp is not supported in join conditions yet.");
+            }
+
+            return base.VisitJoinRelation(joinRelation, state);
+        }
+
+        public override Relation VisitProjectRelation(ProjectRelation projectRelation, object state)
+        {
+            // Check if the project relation contains get_timestamp
+            // If it does, we replace it with a column reference.
+            // Add a join infront of the project relation against a reference
+
+            projectRelation.Input = Visit(projectRelation.Input, state);
+
+            var replacer = new GetTimestampReplacer(projectRelation.Input.OutputLength);
+            
+            for (int i = 0; i < projectRelation.Expressions.Count; i++)
+            {
+                projectRelation.Expressions[i] = replacer.Visit(projectRelation.Expressions[i], state)!;
+            }
+
+            if (!replacer.ContainsGetTimestamp)
+            {
+                return projectRelation;
+            }
+
+            var tmpInput = projectRelation.Input;
+            // If emit is already set, we dont need to do anything more, only more fields are appended to the right
+            if (!projectRelation.EmitSet)
+            {
+                // Add all fields but before adding the join, to make sure that 
+                List<int> emitList = new List<int>();
+                for (int i = 0; i < projectRelation.OutputLength; i++)
+                {
+                    emitList.Add(i);
+                }
+                projectRelation.Emit = emitList;
+            }
+
+            var crossJoin = new JoinRelation()
+            {
+                Left = tmpInput,
+                Right = new ReferenceRelation()
+                {
+                    ReferenceOutputLength = 1,
+                    RelationId = GetReferenceIndex()
+                },
+                Expression = new BoolLiteral() { Value = true },
+                Type = JoinType.Inner
+            };
+
+            projectRelation.Input = crossJoin;
+
+            return projectRelation;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/GetTimestamp/TimestampToJoin.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/GetTimestamp/TimestampToJoin.cs
@@ -10,18 +10,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Core.Optimizer.FIlterPushdown;
+using FlowtideDotNet.Substrait;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace FlowtideDotNet.Substrait.FunctionExtensions
+namespace FlowtideDotNet.Core.Optimizer.GetTimestamp
 {
-    public static class FunctionsDatetime
+    internal static class TimestampToJoin
     {
-        public const string Uri = "/functions_datetime.yaml";
-        public const string Strftime = "strftime";
-        public const string GetTimestamp = "gettimestamp";
+        private static readonly object _emptyObject = new object();
+
+        public static Plan Optimize(Plan plan)
+        {
+            var visitor = new GetTimestampVisitor(plan);
+            for (int i = 0; i < plan.Relations.Count; i++)
+            {
+                var relation = plan.Relations[i];
+                
+                relation = visitor.Visit(relation, _emptyObject);
+
+                plan.Relations[i] = relation;
+            }
+
+            return plan;
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.Optimizer.FIlterPushdown;
+using FlowtideDotNet.Core.Optimizer.GetTimestamp;
 using FlowtideDotNet.Substrait;
 
 namespace FlowtideDotNet.Core.Optimizer
@@ -23,7 +24,14 @@ namespace FlowtideDotNet.Core.Optimizer
             {
                 settings = new PlanOptimizerSettings();
             }
-            for(int i = 0; i < plan.Relations.Count; i++)
+
+            // Start with timestamp to join since its actual logic and not only optimization
+            if (settings.GetTimestampToJoin)
+            {
+                plan = TimestampToJoin.Optimize(plan);
+            }
+
+            for (int i = 0; i < plan.Relations.Count; i++)
             {
                 var relation = plan.Relations[i];
 

--- a/src/FlowtideDotNet.Core/Optimizer/PlanOptimizerSettings.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/PlanOptimizerSettings.cs
@@ -15,5 +15,7 @@ namespace FlowtideDotNet.Core.Optimizer
     public class PlanOptimizerSettings
     {
         public bool NoMergeJoin { get; set; } = false;
+
+        public bool GetTimestampToJoin { get; set; } = true;
     }
 }

--- a/src/FlowtideDotNet.Substrait/Expressions/ExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/ExpressionVisitor.cs
@@ -20,6 +20,10 @@ namespace FlowtideDotNet.Substrait.Expressions
     {
         public virtual TOutput? Visit(Expression expression, TState state)
         {
+            if (expression == null)
+            {
+                return default;
+            }
             return expression.Accept(this, state);
         }
 

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
@@ -308,6 +308,16 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
                     throw new NotImplementedException("stftime does not support the input parameter");
                 }
             });
+            
+            sqlFunctionRegister.RegisterScalarFunction("gettimestamp", (f, visitor, emitData) =>
+            {
+                return new ScalarFunction()
+                {
+                    ExtensionUri = FunctionsDatetime.Uri,
+                    ExtensionName = FunctionsDatetime.GetTimestamp,
+                    Arguments = new List<Expressions.Expression>()
+                };
+            });
 
             sqlFunctionRegister.RegisterScalarFunction("map", (f, visitor, emitData) =>
             {


### PR DESCRIPTION
This is a meta function that is replaced by a field reading during optimization. The return value comes from a timestamp provider source.