### PR TITLE
Add clearing of file cache on commit and reset

### DIFF
--- a/src/FlowtideDotNet.Core/Sinks/BlackholeSink.cs
+++ b/src/FlowtideDotNet.Core/Sinks/BlackholeSink.cs
@@ -1,0 +1,57 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.Operators.Write;
+using FlowtideDotNet.Storage.StateManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace FlowtideDotNet.Core.Sinks
+{
+    internal class BlackholeSink : WriteBaseOperator<object?>
+    {
+        public BlackholeSink(ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionDataflowBlockOptions)
+        {
+        }
+
+        public override string DisplayName => "Blackhole";
+
+        public override Task Compact()
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task DeleteAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override Task InitializeOrRestore(long restoreTime, object? state, IStateManagerClient stateManagerClient)
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override Task<object?> OnCheckpoint(long checkpointTime)
+        {
+            return Task.FromResult<object?>(null);
+        }
+
+        protected override Task OnRecieve(StreamEventBatch msg, long time)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Sinks/ReadWriteFactoryExtensions.cs
+++ b/src/FlowtideDotNet.Core/Sinks/ReadWriteFactoryExtensions.cs
@@ -33,5 +33,25 @@ namespace FlowtideDotNet.Core.Engine
 
             return readWriteFactory;
         }
+
+        public static ReadWriteFactory AddBlackholeSink(this ReadWriteFactory readWriteFactory, string regexPattern)
+        {
+            if (regexPattern == "*")
+            {
+                regexPattern = ".*";
+            }
+            readWriteFactory.AddWriteResolver((relation, opt) =>
+            {
+                var regexResult = Regex.Match(relation.NamedObject.DotSeperated, regexPattern, RegexOptions.IgnoreCase);
+                if (!regexResult.Success)
+                {
+                    return null;
+                }
+
+                return new BlackholeSink(opt);
+            });
+
+            return readWriteFactory;
+        }
     }
 }

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/FileCache.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/FileCache.cs
@@ -217,6 +217,18 @@ namespace FlowtideDotNet.Storage.FileCache
             }
         }
 
+        public void FreeAll()
+        {
+            lock (m_lock)
+            {
+                var keys = allocatedPages.Keys.ToList();
+                foreach (var key in keys)
+                {
+                    Free_NoLock(key);
+                }
+            }
+        }
+
         public void Allocate(long pageKey, int size)
         {
             lock (m_lock)

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/Unix/FileCacheUnixDirectWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/Unix/FileCacheUnixDirectWriter.cs
@@ -158,7 +158,10 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
         {
             lock (_lock)
             {
-                alignedBuffer.Dispose();
+                if (alignedBuffer != null)
+                {
+                    alignedBuffer.Dispose();
+                }
                 if (fileDescriptor != -1)
                 {
                     close(fileDescriptor);

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/LruTableSync.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/LruTableSync.cs
@@ -58,7 +58,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             _currentProcess = Process.GetCurrentProcess();
 
             meter.CreateObservableGauge("lru_table_size", () => Volatile.Read(ref m_count));
-            meter.CreateObservableGauge("lru_table_max_size", () => maxSize);
+            meter.CreateObservableGauge("lru_table_max_size", () => this.maxSize);
             meter.CreateObservableGauge("lru_table_cleanup_start", () => cleanupStart);
         }
 
@@ -211,7 +211,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             var currentCount = Volatile.Read(ref m_count);
             int cleanupStartLocal = cleanupStart;
             bool isCleanup = false;
-            if (currentCount < cleanupStartLocal)
+            if (currentCount <= cleanupStartLocal)
             {
                 var cacheHitsLocal = Volatile.Read(ref m_cacheHits);
                 if (m_lastSeenCacheHits == cacheHitsLocal)

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -105,7 +105,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
                 .SetGetTimestampUpdateInterval(timestampInterval.Value)
                 .WithStateOptions(new Storage.StateManager.StateManagerOptions()
                 {
-                    CachePageCount = 1000000,
+                    CachePageCount = 1000,
                     SerializeOptions = stateSerializeOptions,
                     PersistentStorage = _fileCachePersistence,
                     TemporaryStorageOptions = new Storage.FileCacheOptions()


### PR DESCRIPTION
This can also be solved with a semaphore during these steps. But it would cause more locking during eviction if an operator is commiting it can stop all other operators.