### PR TITLE
Add page version to reduce rewriting pages to disk

### DIFF
--- a/src/FlowtideDotNet.Storage/StateManager/Internal/IStateClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/IStateClient.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
     {
         TMetadata? Metadata { get; set; }
         long GetNewPageId();
-        bool AddOrUpdate(in long key, in V value);
+        bool AddOrUpdate(in long key, V value);
         Task WaitForNotFullAsync();
         ValueTask<V?> GetValue(in long key, string from);
         ValueTask Commit();


### PR DESCRIPTION
This change should reduce the number of page writes to disk greatly when running with low memory. It does not reduce page reads, but should allow the cache to evict pages faster.