### PR TITLE
Remove left join weights from merge join

### DIFF
--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -122,6 +122,24 @@ namespace FlowtideDotNet.AcceptanceTests
                     subuser?.FirstName,
                     subuser?.LastName
                 });
+
+            // Create a crash to check that the update is persisted
+            await Crash();
+
+            AddOrUpdateUser(firstUser);
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(
+                from order in Orders
+                join user in Users on order.UserKey equals user.UserKey into gj
+                from subuser in gj.DefaultIfEmpty()
+                select new
+                {
+                    order.OrderKey,
+                    subuser?.FirstName,
+                    subuser?.LastName
+                });
         }
 
         [Fact]


### PR DESCRIPTION
This removes the in memory structure which could cause out of memory exceptions if a right event touches all the left events for instance. Since all events touched had to stay in memory.