### PR TITLE
Change page serialization to share strings and keys between all events in a page

### DIFF
--- a/src/FlowtideDotNet.Core/Flexbuffer/FlexBuffer.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlexBuffer.cs
@@ -457,7 +457,14 @@ namespace FlexBuffers
                     _stack.Add(StackValue.Value(flxValue.AsDouble));
                     return Type.Float;
                 case Type.String:
-                    return AddFlxValueString(flxValue); //Add(flxValue.AsString);
+                    if (_options.HasFlag(Options.ShareStrings))
+                    {
+                        return Add(flxValue.AsString);
+                    }
+                    else
+                    {
+                        return AddFlxValueString(flxValue); //Add(flxValue.AsString);
+                    }
                 case Type.Null:
                     return AddNull();
                 case Type.Vector:

--- a/src/FlowtideDotNet.Core/Flexbuffer/FlexBuffer.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlexBuffer.cs
@@ -463,7 +463,7 @@ namespace FlexBuffers
                     }
                     else
                     {
-                        return AddFlxValueString(flxValue); //Add(flxValue.AsString);
+                        return AddFlxValueString(flxValue);
                     }
                 case Type.Null:
                     return AddNull();

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateRowState.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateRowState.cs
@@ -24,7 +24,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
         /// <summary>
         /// State for each measure
         /// </summary>
-        public byte[][] MeasureStates { get; set; }
+        public byte[]?[] MeasureStates { get; set; }
 
         /// <summary>
         /// Total weight of all input events.

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateRowStateSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateRowStateSerializer.cs
@@ -22,10 +22,10 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
     internal class AggregateRowStateSerializer : IBplusTreeSerializer<AggregateRowState>
     {
 
-        private AggregateRowState Deserialize(in BinaryReader reader)
+        private static AggregateRowState Deserialize(in BinaryReader reader)
         {
             var measureLength = reader.ReadInt32();
-            var measureStates = new byte[measureLength][];
+            byte[]?[] measureStates = new byte[measureLength][];
             for (int i = 0; i < measureLength; i++)
             {
                 var length = reader.ReadInt32();
@@ -54,7 +54,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
             };
         }
 
-        public void Serialize(in BinaryWriter writer, in AggregateRowState value)
+        private static void Serialize(in BinaryWriter writer, in AggregateRowState value)
         {
             writer.Write(value.MeasureStates.Length);
             foreach (var measureState in value.MeasureStates)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateRowStateSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateRowStateSerializer.cs
@@ -21,7 +21,8 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
 {
     internal class AggregateRowStateSerializer : IBplusTreeSerializer<AggregateRowState>
     {
-        public AggregateRowState Deserialize(in BinaryReader reader)
+
+        private AggregateRowState Deserialize(in BinaryReader reader)
         {
             var measureLength = reader.ReadInt32();
             var measureStates = new byte[measureLength][];
@@ -75,6 +76,24 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
             {
                 writer.Write(value.PreviousValue.Length);
                 writer.Write(value.PreviousValue);
+            }
+        }
+
+        public void Deserialize(in BinaryReader reader, in List<AggregateRowState> values)
+        {
+            var count = reader.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                values.Add(Deserialize(reader));
+            }
+        }
+
+        public void Serialize(in BinaryWriter writer, in List<AggregateRowState> values)
+        {
+            writer.Write(values.Count);
+            foreach (var value in values)
+            {
+                Serialize(writer, value);
             }
         }
     }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinStreamEvenBPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinStreamEvenBPlusTreeSerializer.cs
@@ -18,27 +18,36 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 {
     internal class JoinStreamEvenBPlusTreeSerializer : IBplusTreeSerializer<JoinStreamEvent>
     {
-        public JoinStreamEvent Deserialize(in BinaryReader reader)
+        public void Deserialize(in BinaryReader reader, in List<JoinStreamEvent> values)
         {
-            var targetId = reader.ReadByte();
-            var iteration = reader.ReadUInt32();
-            var length = reader.ReadInt32();
-            var bytes = reader.ReadBytes(length);
+            var byteCount = reader.ReadInt32();
+            var bytes = reader.ReadBytes(byteCount);
             var vector = FlxValue.FromMemory(bytes).AsVector;
-            return new JoinStreamEvent(iteration, targetId, new CompactRowData(bytes, vector));
+
+            for (var i = 0; i < vector.Length; i++)
+            {
+                values.Add(new JoinStreamEvent(0, 0, new VectorRowData(vector.Get(i).AsVector)));
+            }
         }
 
-        public void Serialize(in BinaryWriter writer, in JoinStreamEvent value)
+        public void Serialize(in BinaryWriter writer, in List<JoinStreamEvent> values)
         {
-            writer.Write(value.TargetId);
-            writer.Write(value.Iteration);
-
-            var rowEv = new RowEvent(0, 0, value.RowData);
-            // TODO: This can be done much better
-            var compactEvent = rowEv.Compact(new FlexBuffer(ArrayPool<byte>.Shared));
-            var compactRowData = (CompactRowData)compactEvent.RowData;
-            writer.Write(compactRowData.Span.Length);
-            writer.Write(compactRowData.Span);
+            var builder = new FlexBuffer(ArrayPool<byte>.Shared, options: FlexBuffer.Options.ShareKeys | FlexBuffer.Options.ShareStrings | FlexBuffer.Options.ShareKeyVectors);
+            builder.NewObject();
+            var startRoot = builder.StartVector();
+            foreach (var value in values)
+            {
+                var elementStart = builder.StartVector();
+                for (int i = 0; i < value.Length; i++)
+                {
+                    builder.Add(value.GetColumn(i));
+                }
+                builder.EndVector(elementStart, false, false);
+            }
+            builder.EndVector(startRoot, false, false);
+            var bytes = builder.Finish();
+            writer.Write(bytes.Length);
+            writer.Write(bytes);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Read/IngressDataStateSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/IngressDataStateSerializer.cs
@@ -24,11 +24,29 @@ namespace FlowtideDotNet.Core.Operators.Read
             return new IngressData(bytes, isDeleted);
         }
 
+        public void Deserialize(in BinaryReader reader, in List<IngressData> values)
+        {
+            var count = reader.ReadInt32();
+            for (var i = 0; i < count; i++)
+            {
+                values.Add(Deserialize(reader));
+            }
+        }
+
         public void Serialize(in BinaryWriter writer, in IngressData value)
         {
             writer.Write(value.IsDeleted);
             writer.Write(value.Span.Length);
             writer.Write(value.Span);
+        }
+
+        public void Serialize(in BinaryWriter writer, in List<IngressData> values)
+        {
+            writer.Write(values.Count);
+            foreach (var value in values)
+            {
+                Serialize(writer, value);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Read/IngressDataStateSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/IngressDataStateSerializer.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Core.Operators.Read
 {
     internal class IngressDataStateSerializer : IBplusTreeSerializer<IngressData>
     {
-        public IngressData Deserialize(in BinaryReader reader)
+        private static IngressData Deserialize(in BinaryReader reader)
         {
             var isDeleted = reader.ReadBoolean();
             var length = reader.ReadInt32();
@@ -33,7 +33,7 @@ namespace FlowtideDotNet.Core.Operators.Read
             }
         }
 
-        public void Serialize(in BinaryWriter writer, in IngressData value)
+        private static void Serialize(in BinaryWriter writer, in IngressData value)
         {
             writer.Write(value.IsDeleted);
             writer.Write(value.Span.Length);

--- a/src/FlowtideDotNet.Core/Operators/Write/GroupedStreamEventBPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/GroupedStreamEventBPlusTreeSerializer.cs
@@ -18,7 +18,7 @@ namespace FlowtideDotNet.Core.Operators.Write
 {
     internal class GroupedStreamEventBPlusTreeSerializer : IBplusTreeSerializer<GroupedStreamEvent>
     {
-        public GroupedStreamEvent Deserialize(in BinaryReader reader)
+        private static GroupedStreamEvent Deserialize(in BinaryReader reader)
         {
             var targetId = reader.ReadByte();
             var length = reader.ReadInt32();
@@ -36,7 +36,7 @@ namespace FlowtideDotNet.Core.Operators.Write
             }
         }
 
-        public void Serialize(in BinaryWriter writer, in GroupedStreamEvent value)
+        private static void Serialize(in BinaryWriter writer, in GroupedStreamEvent value)
         {
             writer.Write(value.TargetId);
 

--- a/src/FlowtideDotNet.Core/Operators/Write/GroupedStreamEventBPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/GroupedStreamEventBPlusTreeSerializer.cs
@@ -27,6 +27,15 @@ namespace FlowtideDotNet.Core.Operators.Write
             return new GroupedStreamEvent(targetId, new CompactRowData(bytes, vector));
         }
 
+        public void Deserialize(in BinaryReader reader, in List<GroupedStreamEvent> values)
+        {
+            var count = reader.ReadInt32();
+            for (var i = 0; i < count; i++)
+            {
+                values.Add(Deserialize(reader));
+            }
+        }
+
         public void Serialize(in BinaryWriter writer, in GroupedStreamEvent value)
         {
             writer.Write(value.TargetId);
@@ -36,6 +45,15 @@ namespace FlowtideDotNet.Core.Operators.Write
 
             writer.Write(compactData.Span.Length);
             writer.Write(compactData.Span);
+        }
+
+        public void Serialize(in BinaryWriter writer, in List<GroupedStreamEvent> values)
+        {
+            writer.Write(values.Count);
+            foreach (var value in values)
+            {
+                Serialize(writer, value);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Storage/StreamEventBPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Core/Storage/StreamEventBPlusTreeSerializer.cs
@@ -18,7 +18,7 @@ namespace FlowtideDotNet.Core.Storage
 {
     public class StreamEventBPlusTreeSerializer : IBplusTreeSerializer<RowEvent>
     {
-        public RowEvent Deserialize(in BinaryReader reader)
+        private static RowEvent Deserialize(in BinaryReader reader)
         {
             var weight = reader.ReadInt32();
             var iteration = reader.ReadUInt32();
@@ -36,7 +36,7 @@ namespace FlowtideDotNet.Core.Storage
             }
         }
 
-        public void Serialize(in BinaryWriter writer, in RowEvent value)
+        private static void Serialize(in BinaryWriter writer, in RowEvent value)
         {
             writer.Write(value.Weight);
             writer.Write(value.Iteration);

--- a/src/FlowtideDotNet.Core/Storage/StreamEventBPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Core/Storage/StreamEventBPlusTreeSerializer.cs
@@ -27,6 +27,15 @@ namespace FlowtideDotNet.Core.Storage
             return new RowEvent(weight, iteration, new CompactRowData(bytes));
         }
 
+        public void Deserialize(in BinaryReader reader, in List<RowEvent> values)
+        {
+            var count = reader.ReadInt32();
+            for (var i = 0; i < count; i++)
+            {
+                values.Add(Deserialize(reader));
+            }
+        }
+
         public void Serialize(in BinaryWriter writer, in RowEvent value)
         {
             writer.Write(value.Weight);
@@ -39,6 +48,15 @@ namespace FlowtideDotNet.Core.Storage
 
             writer.Write(compact.Span.Length);
             writer.Write(compact.Span);
+        }
+
+        public void Serialize(in BinaryWriter writer, in List<RowEvent> values)
+        {
+            writer.Write(values.Count);
+            foreach (var value in values)
+            {
+                Serialize(writer, value);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Core/VectorRowData.cs
+++ b/src/FlowtideDotNet.Core/VectorRowData.cs
@@ -1,0 +1,44 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlexBuffers;
+using FlowtideDotNet.Core.Flexbuffer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core
+{
+    internal struct VectorRowData : IRowData
+    {
+        private readonly FlxVector m_vector;
+
+        public VectorRowData(FlxVector vector)
+        {
+            this.m_vector = vector;
+        }
+
+        public int Length => m_vector.Length;
+
+        public FlxValue GetColumn(int index)
+        {
+            return m_vector.Get(index);
+        }
+
+        public FlxValueRef GetColumnRef(scoped in int index)
+        {
+            return m_vector.GetRef(index);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/Serializers/IntSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Serializers/IntSerializer.cs
@@ -16,14 +16,22 @@ namespace FlowtideDotNet.Storage.Serializers
 {
     public class IntSerializer : IBplusTreeSerializer<int>
     {
-        public int Deserialize(in BinaryReader reader)
+        public void Deserialize(in BinaryReader reader, in List<int> values)
         {
-            return reader.ReadInt32();
+            var count = reader.ReadInt32();
+            for (var i = 0; i < count; i++)
+            {
+                values.Add(reader.ReadInt32());
+            }
         }
 
-        public void Serialize(in BinaryWriter writer, in int value)
+        public void Serialize(in BinaryWriter writer, in List<int> value)
         {
-            writer.Write(value);
+            writer.Write(value.Count);
+            foreach (var item in value)
+            {
+                writer.Write(item);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Serializers/LongSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Serializers/LongSerializer.cs
@@ -16,14 +16,22 @@ namespace FlowtideDotNet.Storage.Serializers
 {
     public class LongSerializer : IBplusTreeSerializer<long>
     {
-        public long Deserialize(in BinaryReader reader)
+        public void Deserialize(in BinaryReader reader, in List<long> values)
         {
-            return reader.ReadInt64();
+            var count = reader.ReadInt32();
+            for (var i = 0; i < count; i++)
+            {
+                values.Add(reader.ReadInt64());
+            }
         }
 
-        public void Serialize(in BinaryWriter writer, in long value)
+        public void Serialize(in BinaryWriter writer, in List<long> values)
         {
-            writer.Write(value);
+            writer.Write(values.Count);
+            foreach (var value in values)
+            {
+                writer.Write(value);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Serializers/StringSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Serializers/StringSerializer.cs
@@ -16,14 +16,22 @@ namespace FlowtideDotNet.Storage.Serializers
 {
     public class StringSerializer : IBplusTreeSerializer<string>
     {
-        public string Deserialize(in BinaryReader reader)
+        public void Deserialize(in BinaryReader reader, in List<string> values)
         {
-            return reader.ReadString();
+            var count = reader.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                values.Add(reader.ReadString());
+            }
         }
 
-        public void Serialize(in BinaryWriter writer, in string value)
+        public void Serialize(in BinaryWriter writer, in List<string> values)
         {
-            writer.Write(value);
+            writer.Write(values.Count);
+            foreach (var value in values)
+            {
+                writer.Write(value);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IBplusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBplusTreeSerializer.cs
@@ -14,8 +14,8 @@ namespace FlowtideDotNet.Storage.Tree
 {
     public interface IBplusTreeSerializer<T>
     {
-        T Deserialize(in BinaryReader reader);
+        void Deserialize(in BinaryReader reader, in List<T> values);
 
-        void Serialize(in BinaryWriter writer, in T value);
+        void Serialize(in BinaryWriter writer, in List<T> values);
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeSerializer.cs
@@ -49,21 +49,24 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 var leaf = new LeafNode<K, V>(id);
                 leaf.next = reader.ReadInt64();
 
-                var keyLength = reader.ReadInt32();
+                _keySerializer.Deserialize(reader, leaf.keys);
+                _valueSerializer.Deserialize(reader, leaf.values);
+                //var keyLength = reader.ReadInt32();
 
-                for (int i = 0; i < keyLength; i++)
-                {
-                    var key = _keySerializer.Deserialize(reader);
-                    leaf.keys.Add(key);
-                }
+                
+                //for (int i = 0; i < keyLength; i++)
+                //{
+                //    var key = _keySerializer.Deserialize(reader);
+                //    leaf.keys.Add(key);
+                //}
 
-                var valueLength = reader.ReadInt32();
+                //var valueLength = reader.ReadInt32();
 
-                for (int i = 0; i < valueLength; i++)
-                {
-                    var value = _valueSerializer.Deserialize(reader);
-                    leaf.values.Add(value);
-                }
+                //for (int i = 0; i < valueLength; i++)
+                //{
+                //    var value = _valueSerializer.Deserialize(reader);
+                //    leaf.values.Add(value);
+                //}
                 return leaf;
             }
             if (typeId == 3)
@@ -72,13 +75,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                 var parent = new InternalNode<K, V>(id);
 
-                var keyLength = reader.ReadInt32();
-
-                for (int i = 0; i < keyLength; i++)
-                {
-                    var key = _keySerializer.Deserialize(reader);
-                    parent.keys.Add(key);
-                }
+                _keySerializer.Deserialize(reader, parent.keys);
 
                 var childrenLength = reader.ReadInt32();
                 for (int i = 0; i < childrenLength; i++)
@@ -114,18 +111,20 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 writer.Write(leaf.Id);
                 writer.Write(leaf.next);
 
-                writer.Write(leaf.keys.Count);
+                _keySerializer.Serialize(writer, leaf.keys);
+                _valueSerializer.Serialize(writer, leaf.values);
+                //writer.Write(leaf.keys.Count);
 
-                for (int i = 0; i < leaf.keys.Count; i++)
-                {
-                    _keySerializer.Serialize(writer, leaf.keys[i]);
-                }
-                writer.Write(leaf.values.Count);
+                //for (int i = 0; i < leaf.keys.Count; i++)
+                //{
+                //    _keySerializer.Serialize(writer, leaf.keys[i]);
+                //}
+                //writer.Write(leaf.values.Count);
 
-                for (int i = 0; i < leaf.values.Count; i++)
-                {
-                    _valueSerializer.Serialize(writer, leaf.values[i]);
-                }
+                //for (int i = 0; i < leaf.values.Count; i++)
+                //{
+                //    _valueSerializer.Serialize(writer, leaf.values[i]);
+                //}
 
                 writer.Flush();
                 writeMemStream.Close();
@@ -136,11 +135,12 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 writer.Write((byte)3);
                 writer.Write(parent.Id);
 
-                writer.Write(parent.keys.Count);
-                for (int i = 0; i < parent.keys.Count; i++)
-                {
-                    _keySerializer.Serialize(writer, parent.keys[i]);
-                }
+                _keySerializer.Serialize(writer, parent.keys);
+                //writer.Write(parent.keys.Count);
+                //for (int i = 0; i < parent.keys.Count; i++)
+                //{
+                //    _keySerializer.Serialize(writer, parent.keys[i]);
+                //}
 
                 writer.Write(parent.children.Count);
                 for (int i = 0; i < parent.children.Count; i++)

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeSerializer.cs
@@ -51,22 +51,6 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                 _keySerializer.Deserialize(reader, leaf.keys);
                 _valueSerializer.Deserialize(reader, leaf.values);
-                //var keyLength = reader.ReadInt32();
-
-                
-                //for (int i = 0; i < keyLength; i++)
-                //{
-                //    var key = _keySerializer.Deserialize(reader);
-                //    leaf.keys.Add(key);
-                //}
-
-                //var valueLength = reader.ReadInt32();
-
-                //for (int i = 0; i < valueLength; i++)
-                //{
-                //    var value = _valueSerializer.Deserialize(reader);
-                //    leaf.values.Add(value);
-                //}
                 return leaf;
             }
             if (typeId == 3)
@@ -113,18 +97,6 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                 _keySerializer.Serialize(writer, leaf.keys);
                 _valueSerializer.Serialize(writer, leaf.values);
-                //writer.Write(leaf.keys.Count);
-
-                //for (int i = 0; i < leaf.keys.Count; i++)
-                //{
-                //    _keySerializer.Serialize(writer, leaf.keys[i]);
-                //}
-                //writer.Write(leaf.values.Count);
-
-                //for (int i = 0; i < leaf.values.Count; i++)
-                //{
-                //    _valueSerializer.Serialize(writer, leaf.values[i]);
-                //}
 
                 writer.Flush();
                 writeMemStream.Close();
@@ -136,11 +108,6 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 writer.Write(parent.Id);
 
                 _keySerializer.Serialize(writer, parent.keys);
-                //writer.Write(parent.keys.Count);
-                //for (int i = 0; i < parent.keys.Count; i++)
-                //{
-                //    _keySerializer.Serialize(writer, parent.keys[i]);
-                //}
 
                 writer.Write(parent.children.Count);
                 for (int i = 0; i < parent.children.Count; i++)


### PR DESCRIPTION
The purpose of this change is to reduce the size of a page when stored in disk or loaded from disk and stored in memory.
This can help improve performance when loading in pages from persistent storage.