### PR TITLE
Add kafka event processor and oninitialdatasent functions

### DIFF
--- a/docs/docs/connectors/kafka.md
+++ b/docs/docs/connectors/kafka.md
@@ -71,3 +71,47 @@ Available key serializers:
 Available value serializers:
 
 * **FlowtideKafkaUpsertJsonSerializer** - Outputs the value as json, if it is a delete, it outputs null as the value.
+
+### Extend event processing logic
+
+There are two properties in the options that can help add extra logic to the kafka sink.
+
+* **EventProcessor** - Called on all events that will be sent to kafka.
+* **OnInitialDataSent** - Called once on a new stream when the first data has been sent (usually after the first checkpoint).
+
+These functions can help implement logic such as having an external state store for a kafka topic that keeps track of all the data
+that has been sent to the topic. If a stream is modified and republished and has to start from the beginning, this state store
+can then make sure only delta valeus are sent to the kafka topic, and deletions of events that no longer exists.
+
+Example:
+
+```csharp
+factory.AddKafkaSink("your regexp on table names",  new FlowtideKafkaSinkOptions()
+    {
+        ...
+        EventProcessor = async (events) => {
+            for (int i = 0; i < events.Count; i++) {
+                // Check if the event exists with the exact key and value in the store
+                var exists = await dbLookup.ExistAsync(events[i].Key, events[i].Value);
+                if (exists) {
+                    events.RemoveAt(i);
+                    i--;
+                }
+                // Add the data with a run version that should be unique of this stream version.
+                await dbLookup.Add(events[i].Key, events[i].Value, runVersion);
+            }
+        },
+        OnInitialDataSent = (producer, writeRelation, topicName) => {
+            // Get all events that does not have the latest run version
+            await foreach (var e in dbLookup.GetEventsNotMatchingVersion(runVersion)) {
+                // Send delete on all events that no longer exist
+                await producer.SendAsync(new Message<byte[], byte[]?>() {
+                    Key = e.Key,
+                    Value = null
+                });
+            }
+            // Delete the events from the state store. 
+            await dbLookup.DeleteNotMatchingVersion(runVersion);
+        }
+    });
+```

--- a/src/FlowtideDotNet.Connector.Kafka/FlowtideKafkaSinkOptions.cs
+++ b/src/FlowtideDotNet.Connector.Kafka/FlowtideKafkaSinkOptions.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using Confluent.Kafka;
+using FlowtideDotNet.Substrait.Relations;
 
 namespace FlowtideDotNet.Connector.Kafka
 {
@@ -21,5 +22,15 @@ namespace FlowtideDotNet.Connector.Kafka
         public required IFlowtideKafkaKeySerializer KeySerializer { get; set; }
 
         public required IFlowtideKafkaValueSerializer ValueSerializer { get; set; }
+
+        /// <summary>
+        /// A method that gets called before events are sent to kafka.
+        /// It is possible here to remove or add events from the list before they are sent to kafka.
+        /// 
+        /// One use case is to look up sent events in a database and remove them from the list if they ere already sent.
+        /// </summary>
+        public Func<List<KeyValuePair<byte[], byte[]?>>, Task>? EventProcessor { get; set; }
+
+        public Func<IProducer<byte[], byte[]?>, WriteRelation, string, Task>? OnInitialDataSent { get; set; }
     }
 }

--- a/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaTestStream.cs
+++ b/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaTestStream.cs
@@ -42,7 +42,15 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
             {
                 KeySerializer = new FlowtideKafkaStringKeySerializer(),
                 ProducerConfig = kafkaFixture.GetProducerConfig(),
-                ValueSerializer = new FlowtideKafkaUpsertJsonSerializer()
+                ValueSerializer = new FlowtideKafkaUpsertJsonSerializer(),
+                EventProcessor = (events) =>
+                {
+                    return Task.CompletedTask;
+                },
+                OnInitialDataSent = (producer, writeRel, topicName) =>
+                {
+                    return Task.CompletedTask;
+                }
             });
         }
     }


### PR DESCRIPTION
These functions can be used to modify data that gets sent, and add extra logic such as having an external store on which events that have been sent.