### PR TITLE
Change so the default watermark number for multi input is -1

### DIFF
--- a/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
@@ -305,7 +305,7 @@ namespace FlowtideDotNet.Base.Vertices.MultipleInput
                     }
                 }
                 _targetWatermarkNames = targetsWatermarks.ToArray();
-                _currentWatermark = new Watermark(uniqueNames.Select(x => new KeyValuePair<string, long>(x, 0)).ToImmutableDictionary(), DateTimeOffset.UtcNow);
+                _currentWatermark = new Watermark(uniqueNames.Select(x => new KeyValuePair<string, long>(x, -1)).ToImmutableDictionary(), DateTimeOffset.UtcNow);
                 
 
                 return initWatermarksEvent;


### PR DESCRIPTION
SQL Server has change version 0 when enabling change tracking, even with existing data.