### PR TITLE
Fix bug where left side only conditions where pushed down on left join

### DIFF
--- a/src/FlowtideDotNet.Core/Optimizer/FIlterPushdown/JoinFilterPushdownVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/FIlterPushdown/JoinFilterPushdownVisitor.cs
@@ -31,7 +31,7 @@ namespace FlowtideDotNet.Core.Optimizer.FilterPushdown
             if (!visitor.unknownCase)
             {
                 // Only fields from left is used
-                if (visitor.fieldInLeft && !visitor.fieldInRight)
+                if (visitor.fieldInLeft && !visitor.fieldInRight && joinRelation.Type != JoinType.Left)
                 {
                     joinRelation.Left = new FilterRelation()
                     {
@@ -63,7 +63,7 @@ namespace FlowtideDotNet.Core.Optimizer.FilterPushdown
                     var expr = andFunctionScalar.Arguments[i];
                     var andVisitor = new JoinExpressionVisitor(joinRelation.Left.OutputLength);
                     andVisitor.Visit(expr, state);
-                    if (andVisitor.fieldInLeft && !andVisitor.fieldInRight)
+                    if (andVisitor.fieldInLeft && !andVisitor.fieldInRight && joinRelation.Type != JoinType.Left)
                     {
                         leftPushDown.Add(expr);
                         andFunctionScalar.Arguments.RemoveAt(i);

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -343,5 +343,49 @@ namespace FlowtideDotNet.AcceptanceTests
             }
             AssertCurrentDataEqual(expected);
         }
+
+        [Fact]
+        public async Task LeftJoinWithConditionOnlyLeft()
+        {
+            GenerateData(100);
+            await StartStream(@"
+                INSERT INTO output 
+                SELECT 
+                    u.userkey, c.name
+                FROM users u
+                LEFT JOIN companies c
+                ON u.companyid = '123123'");
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(
+                from user in Users
+                select new
+                {
+                    user.UserKey,
+                    companyName = default(string)
+                });
+        }
+
+        [Fact]
+        public async Task LeftJoinWithConditionEqualsAndOnlyLeftCondition()
+        {
+            GenerateData(100);
+            await StartStream(@"
+                INSERT INTO output 
+                SELECT 
+                    u.userkey, c.name
+                FROM users u
+                LEFT JOIN companies c
+                ON u.companyid = '123123' AND u.companyid = c.companyid");
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(
+                from user in Users
+                select new
+                {
+                    user.UserKey,
+                    companyName = default(string)
+                });
+        }
     }
 }


### PR DESCRIPTION
This issue caused rows to be completely removed instead as a normal where condition.