### PR TITLE
Fix sql server identifier handling to always add brackets

### DIFF
--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerSink.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerSink.cs
@@ -214,7 +214,7 @@ namespace FlowtideDotNet.SqlServer.SqlServer
             }
 
             m_mapRowFunc = SqlServerUtils.GetDataRowMapFunc(dbSchema, m_primaryKeys);
-            var mergeIntoStatement = SqlServerUtils.CreateMergeIntoProcedure(tmpTableName, writeRelation.NamedObject.DotSeperated, m_primaryKeyNames.ToHashSet(), m_dataTable);
+            var mergeIntoStatement = SqlServerUtils.CreateMergeIntoProcedure(tmpTableName, string.Join(".", writeRelation.NamedObject.Names.Select(x => $"[{x}]")), m_primaryKeyNames.ToHashSet(), m_dataTable);
             m_sqlBulkCopy = new SqlBulkCopy(connection);
             m_sqlBulkCopy.DestinationTableName = tmpTableName;
 

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerUtils.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerUtils.cs
@@ -18,6 +18,7 @@ using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
 using System.Text;
+using Microsoft.Extensions.Primitives;
 
 namespace FlowtideDotNet.Substrait.Tests.SqlServer
 {
@@ -308,7 +309,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
             stringBuilder.Append(string.Join(", ", readRelation.BaseSchema.Names.Select(x => $"[{x}]")));
 
             stringBuilder.Append(" FROM ");
-            stringBuilder.Append(readRelation.NamedTable.DotSeperated);
+            stringBuilder.Append(string.Join(".", readRelation.NamedTable.Names.Select(x => $"[{x}]")));
 
             return stringBuilder.ToString();
         }
@@ -322,7 +323,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
             stringBuilder.Append(string.Join(", ", readRelation.BaseSchema.Names.Select(x => $"[{x}]")));
 
             stringBuilder.Append(" FROM ");
-            stringBuilder.Append(readRelation.NamedTable.DotSeperated);
+            stringBuilder.Append(string.Join(".", readRelation.NamedTable.Names.Select(x => $"[{x}]")));
 
             return stringBuilder.ToString();
         }
@@ -336,7 +337,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
             stringBuilder.Append(string.Join(", ", readRelation.BaseSchema.Names.Select(x => $"[{x}]")));
 
             stringBuilder.Append(" FROM ");
-            stringBuilder.AppendLine(readRelation.NamedTable.DotSeperated);
+            stringBuilder.AppendLine(string.Join(".", readRelation.NamedTable.Names.Select(x => $"[{x}]")));
 
             string? filters = filter;
             if (includePkParameters)
@@ -375,7 +376,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
             stringBuilder.Append(string.Join(", ", writeRelation.TableSchema.Names.Select(x => $"[{x}]")));
 
             stringBuilder.Append(" FROM ");
-            stringBuilder.Append(writeRelation.NamedObject.DotSeperated);
+            stringBuilder.Append(string.Join(".", writeRelation.NamedObject.Names.Select(x => $"[{x}]")));
 
             var cmd = stringBuilder.ToString();
             using var command = connection.CreateCommand();
@@ -411,10 +412,10 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
             stringBuilder.Append(string.Join(", ", columnSelects));
 
             stringBuilder.Append(", c.SYS_CHANGE_VERSION, c.SYS_CHANGE_OPERATION from CHANGETABLE(CHANGES ");
-            stringBuilder.Append(readRelation.NamedTable.DotSeperated);
+            stringBuilder.Append(string.Join(".", readRelation.NamedTable.Names.Select(x => $"[{x}]")));
             stringBuilder.AppendLine(", @ChangeVersion) as c");
             stringBuilder.Append("LEFT JOIN ");
-            stringBuilder.Append(readRelation.NamedTable.DotSeperated);
+            stringBuilder.Append(string.Join(".", readRelation.NamedTable.Names.Select(x => $"[{x}]")));
             stringBuilder.AppendLine(" t");
             stringBuilder.Append("ON ");
             stringBuilder.AppendLine(joinCondition);
@@ -440,7 +441,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
             List<string> pkComparisons = new List<string>();
             foreach (var pkColumn in primaryKeys)
             {
-                pkComparisons.Add($"src.{pkColumn} = tgt.{pkColumn}");
+                pkComparisons.Add($"src.[{pkColumn}] = tgt.[{pkColumn}]");
             }
 
             stringBuilder.AppendLine(string.Join(" AND ", pkComparisons));
@@ -454,7 +455,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
                     continue;
                 }
 
-                updateNotEquals.Add($"src.{col.ColumnName} != tgt.{col.ColumnName}");
+                updateNotEquals.Add($"src.[{col.ColumnName}] != tgt.[{col.ColumnName}]");
             }
 
             // Add update statement
@@ -474,7 +475,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
                         continue;
                     }
 
-                    updateSets.Add($"tgt.{col.ColumnName} = src.{col.ColumnName}");
+                    updateSets.Add($"tgt.[{col.ColumnName}] = src.[{col.ColumnName}]");
                 }
                 stringBuilder.AppendLine(string.Join(", ", updateSets));
             }
@@ -493,8 +494,8 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
                 columnNames.Add(col.ColumnName);
             }
 
-            stringBuilder.AppendLine($"INSERT ({string.Join(", ", columnNames)})");
-            stringBuilder.AppendLine($"VALUES ({string.Join(", ", columnNames)});");
+            stringBuilder.AppendLine($"INSERT ({string.Join(", ", columnNames.Select(x => $"[{x}]"))})");
+            stringBuilder.AppendLine($"VALUES ({string.Join(", ", columnNames.Select(x => $"[{x}]"))});");
 
             stringBuilder.Append("DELETE FROM ");
             stringBuilder.Append(tmpTableName);
@@ -578,7 +579,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
                     columnType = $"{columnType}({column.NumericPrecision}, {column.NumericScale})";
                 }
 
-                columnsData.Add($"{column.ColumnName} {columnType}");
+                columnsData.Add($"[{column.ColumnName}] {columnType}");
             }
             stringBuilder.AppendLine("(");
             stringBuilder.AppendLine(string.Join(",\r\n", columnsData));

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/SqlSubstraitVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/SqlSubstraitVisitor.cs
@@ -513,7 +513,7 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
                 {
                     NamedTable = new FlowtideDotNet.Substrait.Type.NamedTable()
                     {
-                        Names = new List<string>() { tableName }
+                        Names = table.Name.Values.Select(x => x.Value).ToList()
                     },
                     BaseSchema = new FlowtideDotNet.Substrait.Type.NamedStruct()
                     {

--- a/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
@@ -108,7 +108,7 @@ namespace FlowtideDotNet.SqlServer.Tests.Acceptance
                             {
                                 NamedTable = new NamedTable()
                                 {
-                                    Names = new List<string>() { "tpch.dbo.orders" }
+                                    Names = new List<string>() { "tpch", "dbo", "orders" }
                                 },
                                 BaseSchema = new Substrait.Type.NamedStruct()
                                 {
@@ -194,7 +194,7 @@ namespace FlowtideDotNet.SqlServer.Tests.Acceptance
                 },
                 NamedObject = new NamedTable()
                 {
-                    Names = new List<string>() { "tpch.dbo.notracking" }
+                    Names = new List<string>() { "tpch", "dbo", "notracking" }
                 },
                 TableSchema = new NamedStruct()
                 {

--- a/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerE2ETests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerE2ETests.cs
@@ -1,0 +1,87 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Sql;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.SqlServer.Tests.e2e
+{
+    public class SqlServerE2ETests : IClassFixture<SqlServerEndToEndFixture>
+    {
+        private readonly SqlServerEndToEndFixture _fixture;
+
+        public SqlServerE2ETests(SqlServerEndToEndFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task SelectFromSqlServerIntoSqlServerWithDash()
+        {
+            var testName = "SelectFromSqlServerIntoSqlServer";
+
+
+            await _fixture.RunCommand(@"
+            CREATE TABLE [test-db].[dbo].[test-table] (
+                [id] [int] primary key,
+                [name] [nvarchar](50) NOT NULL,
+                [guid-dash] [uniqueidentifier] NOT NULL
+            )");
+            await _fixture.RunCommand("ALTER TABLE [test-db].[dbo].[test-table] ENABLE CHANGE_TRACKING WITH (TRACK_COLUMNS_UPDATED = OFF)");
+            await _fixture.RunCommand(@"
+            CREATE TABLE [test-db].[dbo].[test-dest] (
+                [id] [int] primary key,
+                [name] [nvarchar](50) NOT NULL,
+                [guid-dash] [uniqueidentifier] NOT NULL
+            )");
+
+            // Insert some data
+            await _fixture.RunCommand(@"
+            INSERT INTO [test-db].[dbo].[test-table] ([id], [name], [guid-dash]) VALUES (1, 'test1', '57f20bbe-3a17-45a7-bacc-614d89bde120');
+            ");
+
+            var testStream = new SqlServerTestStream(testName, _fixture.ConnectionString);
+            testStream.RegisterTableProviders((builder) =>
+            {
+                builder.AddSqlServerProvider(() => _fixture.ConnectionString);
+            });
+            await testStream.StartStream(@"
+                INSERT INTO [test-db].[dbo].[test-dest]
+                SELECT
+                    [id],
+                    [name],
+                    [guid-dash] 
+                FROM [test-db].[dbo].[test-table]
+            ");
+
+            var count = 0;
+            while (true)
+            {
+                await testStream.SchedulerTick();
+                count = await _fixture.ExecuteReader("SELECT count(*) from [test-db].[dbo].[test-dest]", (reader) =>
+                {
+                    reader.Read();
+                    return reader.GetInt32(0);
+                });
+                if (count > 0)
+                {
+                    break;
+                }
+            }
+            Assert.Equal(1, count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerEndToEndFixture.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerEndToEndFixture.cs
@@ -1,0 +1,79 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Testcontainers.MsSql;
+
+namespace FlowtideDotNet.SqlServer.Tests.e2e
+{
+    public class SqlServerEndToEndFixture : IAsyncLifetime
+    {
+        MsSqlContainer _msSqlContainer;
+        public SqlServerEndToEndFixture()
+        {
+            _msSqlContainer = new MsSqlBuilder()
+                .Build();
+        }
+
+        public string ConnectionString
+        {
+            get
+            {
+                var connectionStringBuilder = new SqlConnectionStringBuilder(_msSqlContainer.GetConnectionString());
+                connectionStringBuilder.InitialCatalog = "test-db";
+                var tpchConnectionString = connectionStringBuilder.ToString();
+                return tpchConnectionString;
+
+            }
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _msSqlContainer.DisposeAsync();
+        }
+
+        public async Task InitializeAsync()
+        {
+            await _msSqlContainer.StartAsync();
+
+            await RunCommand("CREATE DATABASE [test-db]");
+            await RunCommand("ALTER DATABASE [test-db] SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON)");
+        }
+
+        public async Task RunCommand(string command)
+        {
+            using (SqlConnection sqlConnection = new SqlConnection(_msSqlContainer.GetConnectionString()))
+            {
+                await sqlConnection.OpenAsync();
+                using var cmd = sqlConnection.CreateCommand();
+                cmd.CommandText = command;
+                await cmd.ExecuteNonQueryAsync();
+            }
+        }
+
+        public async Task<T> ExecuteReader<T>(string command, Func<SqlDataReader, T> func)
+        {
+            using (SqlConnection sqlConnection = new SqlConnection(_msSqlContainer.GetConnectionString()))
+            {
+                await sqlConnection.OpenAsync();
+                using var cmd = sqlConnection.CreateCommand();
+                cmd.CommandText = command;
+                return func(await cmd.ExecuteReaderAsync());
+            }
+        }
+    }
+}

--- a/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerTestStream.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerTestStream.cs
@@ -1,0 +1,43 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.AcceptanceTests.Internal;
+using FlowtideDotNet.Core.Engine;
+using FlowtideDotNet.Substrait.Sql;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.SqlServer.Tests.e2e
+{
+    internal class SqlServerTestStream : FlowtideTestStream
+    {
+        private readonly string connectionString;
+
+        public SqlServerTestStream(string testName, string connectionString) : base(testName)
+        {
+            this.connectionString = connectionString;
+        }
+
+        protected override void AddReadResolvers(ReadWriteFactory factory)
+        {
+            factory.AddSqlServerSource("*", () => connectionString);
+        }
+
+        protected override void AddWriteResolvers(ReadWriteFactory factory)
+        {
+            factory.AddSqlServerSink("*", () => connectionString);
+        }
+    }
+}


### PR DESCRIPTION
This solves any issues with '-' for instance in database, schema or table name.
