### PR TITLE
Add support to delete existing data in simple grouped write

### DIFF
--- a/docs/docs/connectors/spicedb.md
+++ b/docs/docs/connectors/spicedb.md
@@ -61,6 +61,15 @@ The following event listeners exist that can be used to modify or get the curren
 * **OnWatermarkFunc** - Called after a watermark is recieved and the data has been added to SpiceDB, also contains the last recieved zedtoken from SpiceDB.
 * **OnInitialDataSentFunc** - Called the first time data has been written to SpiceDB.
 
+### Delete existing data if not updated
+
+It is possible to delete existing data in SpiceDB if it is not in the result set of the stream.
+This is done by passing in the property *DeleteExistingDataFilter* which is the filter of what data to fetch.
+If your stream say updates resource type *document* and relation *reader* you should pass that in as the filter if you wish
+to delete existing data that is not from the current stream.
+
+This will cause all data to be downloaded into the stream which will cause a slower performance to read the initial data.
+
 ## Source
 
 The source allows reading data from SpiceDB. The following columns are returned:

--- a/src/FlowtideDotNet.Base/Utils/EmptyAsyncEnumerable.cs
+++ b/src/FlowtideDotNet.Base/Utils/EmptyAsyncEnumerable.cs
@@ -12,7 +12,7 @@
 
 namespace FlowtideDotNet.Base.Utils
 {
-    internal class EmptyAsyncEnumerable<T> : IAsyncEnumerable<T>
+    public class EmptyAsyncEnumerable<T> : IAsyncEnumerable<T>
     {
         public static readonly EmptyAsyncEnumerable<T> Instance = new EmptyAsyncEnumerable<T>();
         private static readonly IAsyncEnumerator<T> EnumeratorInstance = new Enumerator();

--- a/src/FlowtideDotNet.Connector.SpiceDB/Internal/SpiceDbRowEncoder.cs
+++ b/src/FlowtideDotNet.Connector.SpiceDB/Internal/SpiceDbRowEncoder.cs
@@ -25,19 +25,19 @@ namespace FlowtideDotNet.Connector.SpiceDB.Internal
 {
     internal class SpiceDbRowEncoder
     {
-        private readonly List<Action<Relationship, int, FlxValue[]>> encoders;
+        private readonly List<Action<Relationship, int, FlxValue[]>> m_encoders;
 
         public SpiceDbRowEncoder(List<Action<Relationship, int, FlxValue[]>> encoders)
         {
-            this.encoders = encoders;
+            this.m_encoders = encoders;
         }
 
         public RowEvent Encode(Relationship relationship, int weight)
         {
-            FlxValue[] values = new FlxValue[encoders.Count];
-            for (int i = 0; i < encoders.Count; i++)
+            FlxValue[] values = new FlxValue[m_encoders.Count];
+            for (int i = 0; i < m_encoders.Count; i++)
             {
-                encoders[i](relationship, i, values);
+                m_encoders[i](relationship, i, values);
             }
             return new RowEvent(weight, 0, new ArrayRowData(values));
         }

--- a/src/FlowtideDotNet.Connector.SpiceDB/Internal/SpiceDbRowEncoder.cs
+++ b/src/FlowtideDotNet.Connector.SpiceDB/Internal/SpiceDbRowEncoder.cs
@@ -1,0 +1,144 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Authzed.Api.V1;
+using FlexBuffers;
+using FlowtideDotNet.Core;
+using FlowtideDotNet.Substrait.Relations;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Connector.SpiceDB.Internal
+{
+    internal class SpiceDbRowEncoder
+    {
+        private readonly List<Action<Relationship, int, FlxValue[]>> encoders;
+
+        public SpiceDbRowEncoder(List<Action<Relationship, int, FlxValue[]>> encoders)
+        {
+            this.encoders = encoders;
+        }
+
+        public RowEvent Encode(Relationship relationship, int weight)
+        {
+            FlxValue[] values = new FlxValue[encoders.Count];
+            for (int i = 0; i < encoders.Count; i++)
+            {
+                encoders[i](relationship, i, values);
+            }
+            return new RowEvent(weight, 0, new ArrayRowData(values));
+        }
+
+        public static SpiceDbRowEncoder Create(List<string> names)
+        {
+            List<Action<Relationship, int, FlxValue[]>> encoders = new List<Action<Relationship, int, FlxValue[]>>();
+            Dictionary<string, FlxValue> typesAndRelationValues = new Dictionary<string, FlxValue>();
+            FlexBuffer flexBuffer = new FlexBuffer(ArrayPool<byte>.Shared);
+            for (int i = 0; i < names.Count; i++)
+            {
+                var name = names[i];
+                switch (name.ToLower())
+                {
+                    case "subject_type":
+                        encoders.Add((r, i, v) =>
+                        {
+                            if (typesAndRelationValues.TryGetValue(r.Subject.Object.ObjectType, out var value))
+                            {
+                                v[i] = value;
+                                return;
+                            }
+                            flexBuffer.NewObject();
+                            flexBuffer.Add(r.Subject.Object.ObjectType);
+                            var bytes = flexBuffer.Finish();
+                            var flxValue = FlxValue.FromBytes(bytes);
+                            typesAndRelationValues.Add(r.Subject.Object.ObjectType, flxValue);
+                            v[i] = flxValue;
+                        });
+                        break;
+                    case "subject_id":
+                        encoders.Add((r, i, v) =>
+                        {
+                            flexBuffer.NewObject();
+                            flexBuffer.Add(r.Subject.Object.ObjectId);
+                            var bytes = flexBuffer.Finish();
+                            var flxValue = FlxValue.FromBytes(bytes);
+                            v[i] = flxValue;
+                        });
+                        break;
+                    case "subject_relation":
+                        encoders.Add((r, i, v) =>
+                        {
+                            if (typesAndRelationValues.TryGetValue(r.Subject.OptionalRelation, out var value))
+                            {
+                                v[i] = value;
+                                return;
+                            }
+                            flexBuffer.NewObject();
+                            flexBuffer.Add(r.Subject.OptionalRelation);
+                            var bytes = flexBuffer.Finish();
+                            var flxValue = FlxValue.FromBytes(bytes);
+                            typesAndRelationValues.Add(r.Subject.OptionalRelation, flxValue);
+                            v[i] = flxValue;
+                        });
+                        break;
+                    case "relation":
+                        encoders.Add((r, i, v) =>
+                        {
+                            if (typesAndRelationValues.TryGetValue(r.Relation, out var value))
+                            {
+                                v[i] = value;
+                                return;
+                            }
+                            flexBuffer.NewObject();
+                            flexBuffer.Add(r.Relation);
+                            var bytes = flexBuffer.Finish();
+                            var flxValue = FlxValue.FromBytes(bytes);
+                            typesAndRelationValues.Add(r.Relation, flxValue);
+                            v[i] = flxValue;
+                        });
+                        break;
+                    case "resource_type":
+                        encoders.Add((r, i, v) =>
+                        {
+                            if (typesAndRelationValues.TryGetValue(r.Resource.ObjectType, out var value))
+                            {
+                                v[i] = value;
+                                return;
+                            }
+                            flexBuffer.NewObject();
+                            flexBuffer.Add(r.Resource.ObjectType);
+                            var bytes = flexBuffer.Finish();
+                            var flxValue = FlxValue.FromBytes(bytes);
+                            typesAndRelationValues.Add(r.Resource.ObjectType, flxValue);
+                            v[i] = flxValue;
+                        });
+                        break;
+                    case "resource_id":
+                        encoders.Add((r, i, v) =>
+                        {
+                            flexBuffer.NewObject();
+                            flexBuffer.Add(r.Resource.ObjectId);
+                            var bytes = flexBuffer.Finish();
+                            var flxValue = FlxValue.FromBytes(bytes);
+                            v[i] = flxValue;
+                        });
+                        break;
+                }
+            }
+            return new SpiceDbRowEncoder(encoders);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Connector.SpiceDB/Internal/SpiceDbSink.cs
+++ b/src/FlowtideDotNet.Connector.SpiceDB/Internal/SpiceDbSink.cs
@@ -42,7 +42,7 @@ namespace FlowtideDotNet.Connector.SpiceDB.Internal
         private readonly List<int> m_primaryKeys;
         private readonly SpiceDbSinkOptions m_spiceDbSinkOptions;
         private PermissionsService.PermissionsServiceClient? m_client;
-        private SpiceDbRowEncoder? m_existingDataEncoder;
+        private readonly SpiceDbRowEncoder? m_existingDataEncoder;
 
         public SpiceDbSink(SpiceDbSinkOptions spiceDbSinkOptions, WriteRelation writeRelation, ExecutionMode executionMode, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionMode, executionDataflowBlockOptions)
         {

--- a/src/FlowtideDotNet.Connector.SpiceDB/Internal/SpiceDbSink.cs
+++ b/src/FlowtideDotNet.Connector.SpiceDB/Internal/SpiceDbSink.cs
@@ -12,6 +12,7 @@
 
 using Authzed.Api.V1;
 using FlowtideDotNet.Base;
+using FlowtideDotNet.Core;
 using FlowtideDotNet.Core.Flexbuffer;
 using FlowtideDotNet.Core.Operators.Write;
 using FlowtideDotNet.Storage.StateManager;
@@ -41,6 +42,7 @@ namespace FlowtideDotNet.Connector.SpiceDB.Internal
         private readonly List<int> m_primaryKeys;
         private readonly SpiceDbSinkOptions m_spiceDbSinkOptions;
         private PermissionsService.PermissionsServiceClient? m_client;
+        private SpiceDbRowEncoder? m_existingDataEncoder;
 
         public SpiceDbSink(SpiceDbSinkOptions spiceDbSinkOptions, WriteRelation writeRelation, ExecutionMode executionMode, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionMode, executionDataflowBlockOptions)
         {
@@ -73,14 +75,39 @@ namespace FlowtideDotNet.Connector.SpiceDB.Internal
 
             m_primaryKeys = new List<int>() { m_resourceObjectTypeIndex, m_resourceObjectIdIndex, m_relationIndex, m_subjectObjectTypeIndex, m_subjectObjectIdIndex };
             this.m_spiceDbSinkOptions = spiceDbSinkOptions;
+
+            if (m_spiceDbSinkOptions.DeleteExistingDataFilter != null)
+            {
+                m_existingDataEncoder = SpiceDbRowEncoder.Create(writeRelation.TableSchema.Names);
+            }
         }
 
         public override string DisplayName => "SpiceDB Sink";
+
+        protected override bool FetchExistingData => m_spiceDbSinkOptions.DeleteExistingDataFilter != null;
 
         protected override Task<MetadataResult> SetupAndLoadMetadataAsync()
         {
             m_client = new PermissionsService.PermissionsServiceClient(m_spiceDbSinkOptions.Channel);
             return Task.FromResult(new MetadataResult(m_primaryKeys));
+        }
+
+        protected override async IAsyncEnumerable<RowEvent> GetExistingData()
+        {
+            Debug.Assert(m_client != null);
+            Debug.Assert(m_existingDataEncoder != null);
+            Metadata? metadata = default;
+            if (m_spiceDbSinkOptions.GetMetadata != null)
+            {
+                metadata = m_spiceDbSinkOptions.GetMetadata();
+            }
+            var relationshipsStream = m_client.ReadRelationships(m_spiceDbSinkOptions.DeleteExistingDataFilter, metadata);
+            var readAllEnumerable = relationshipsStream.ResponseStream.ReadAllAsync();
+
+            await foreach(var rel in readAllEnumerable)
+            {
+                yield return m_existingDataEncoder.Encode(rel.Relationship, 1);
+            }
         }
 
         private static string ColumnToString(scoped in FlxValueRef flxValue)

--- a/src/FlowtideDotNet.Connector.SpiceDB/SpiceDbSinkOptions.cs
+++ b/src/FlowtideDotNet.Connector.SpiceDB/SpiceDbSinkOptions.cs
@@ -30,6 +30,12 @@ namespace FlowtideDotNet.Connector.SpiceDB
         public int BatchSize { get; set; } = 50;
 
         /// <summary>
+        /// If set, all relationships returned by this filter that are not in the result set
+        /// will be deleted after the initial loading of data has completed.
+        /// </summary>
+        public ReadRelationshipsRequest? DeleteExistingDataFilter { get; set; }
+
+        /// <summary>
         /// Called before each write to SpiceDB.
         /// Makes it possible to modify any data before it is sent.
         /// </summary>

--- a/src/FlowtideDotNet.Core/Operators/Read/BatchableReadBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/BatchableReadBaseOperator.cs
@@ -286,7 +286,7 @@ namespace FlowtideDotNet.Core.Operators.Read
                 {
                     hasNew = await tmpEnumerator.MoveNextAsync();
                 }
-                if (!hasNew || comparison > 0)
+                else if (!hasNew || comparison > 0)
                 {
                     await _deletionsTree.Upsert(persistentEnumerator.Current.Key, 1);
                     // Deletion

--- a/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
@@ -16,6 +16,7 @@ using FlowtideDotNet.Core.Storage;
 using FlowtideDotNet.Storage.Serializers;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
+using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using System.Threading.Tasks.Dataflow;
 
@@ -272,10 +273,12 @@ namespace FlowtideDotNet.Core.Operators.Write
                     KeySerializer = new StreamEventBPlusTreeSerializer()
                 });
 
+                Logger.LogInformation("Fetching existing data in SpiceDB");
                 await foreach(var row in GetExistingData())
                 {
                     await m_existingData.Upsert(row, 1);
                 }
+                Logger.LogInformation("Done fetching existing data");
             }
         }
 

--- a/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Base;
 using FlowtideDotNet.Base.Metrics;
+using FlowtideDotNet.Base.Utils;
 using FlowtideDotNet.Core.Storage;
 using FlowtideDotNet.Storage.Serializers;
 using FlowtideDotNet.Storage.StateManager;
@@ -194,7 +195,7 @@ namespace FlowtideDotNet.Core.Operators.Write
                 }
             }
 
-            if (_state!.SentInitialData == false &&
+            if (!_state!.SentInitialData &&
                 FetchExistingData)
             {
                 await foreach (var row in DeleteExistingData())
@@ -206,9 +207,9 @@ namespace FlowtideDotNet.Core.Operators.Write
 
         protected virtual bool FetchExistingData => false;
 
-        protected virtual async IAsyncEnumerable<RowEvent> GetExistingData()
+        protected virtual IAsyncEnumerable<RowEvent> GetExistingData()
         {
-            yield break;
+            return new EmptyAsyncEnumerable<RowEvent>();
         }
 
         protected override Task OnWatermark(Watermark watermark)

--- a/tests/FlowtideDotNet.Connector.SpiceDB.Tests/SpiceDbTestStream.cs
+++ b/tests/FlowtideDotNet.Connector.SpiceDB.Tests/SpiceDbTestStream.cs
@@ -10,16 +10,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Authzed.Api.V1;
 using FlowtideDotNet.AcceptanceTests.Internal;
 using FlowtideDotNet.Connector.SpiceDB.Extensions;
 using FlowtideDotNet.Core.Engine;
 using Grpc.Core;
 using Grpc.Net.Client;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Connector.SpiceDB.Tests
 {
@@ -28,16 +24,19 @@ namespace FlowtideDotNet.Connector.SpiceDB.Tests
         private readonly GrpcChannel grpcChannel;
         private readonly bool addWriteResolver;
         private readonly bool addReadResolver;
+        private readonly ReadRelationshipsRequest? deleteExistingFilter;
 
         public SpiceDbTestStream(
             string testName, 
             GrpcChannel grpcChannel,
             bool addWriteResolver,
-            bool addReadResolver) : base(testName)
+            bool addReadResolver,
+            ReadRelationshipsRequest? deleteExistingFilter = null) : base(testName)
         {
             this.grpcChannel = grpcChannel;
             this.addWriteResolver = addWriteResolver;
             this.addReadResolver = addReadResolver;
+            this.deleteExistingFilter = deleteExistingFilter;
         }
 
         protected override void AddWriteResolvers(ReadWriteFactory factory)
@@ -47,6 +46,7 @@ namespace FlowtideDotNet.Connector.SpiceDB.Tests
                 factory.AddSpiceDbSink("*", new SpiceDbSinkOptions()
                 {
                     Channel = grpcChannel,
+                    DeleteExistingDataFilter = deleteExistingFilter,
                     GetMetadata = () =>
                     {
                         var metadata = new Metadata();


### PR DESCRIPTION
This adds support for connectors to fetch existing data that will be compared against and deleted if not touched in the write step.