### PR TITLE
Allow fetching existing data in kafka sink to compare against

### DIFF
--- a/docs/docs/connectors/kafka.md
+++ b/docs/docs/connectors/kafka.md
@@ -72,6 +72,19 @@ Available value serializers:
 
 * **FlowtideKafkaUpsertJsonSerializer** - Outputs the value as json, if it is a delete, it outputs null as the value.
 
+### Compare against existing data in Kafka
+
+It is possible to fetch all existing data in Kafka when a new stream is starting. This data will be used on the initial result set
+to compare against to see if the data is already in kafka (the lateset message on a key).
+
+It will also send delete operations for any keys that no longer exist in the result set.
+
+To use this feature you must set the following properties:
+
+* **FetchExistingConfig** - Consumer config that will be used when fetching existing data.
+* **FetchExistingValueDeserializer** - Deserializer that will be used, when deserializing existing data.
+* **FetchExistingKeyDeserializer** - Deserializer for the key field in a kafka message.
+
 ### Extend event processing logic
 
 There are two properties in the options that can help add extra logic to the kafka sink.

--- a/src/FlowtideDotNet.Connector.Kafka/FlowtideKafkaSinkOptions.cs
+++ b/src/FlowtideDotNet.Connector.Kafka/FlowtideKafkaSinkOptions.cs
@@ -23,6 +23,22 @@ namespace FlowtideDotNet.Connector.Kafka
 
         public required IFlowtideKafkaValueSerializer ValueSerializer { get; set; }
 
+
+        public ConsumerConfig? FetchExistingConfig { get; set; }
+
+        /// <summary>
+        /// If set will fetch existing data before starting which will be used to compare the
+        /// result of the stream against.
+        /// 
+        /// If set, FetchExistingValueDeserializer must also be set.
+        /// </summary>
+        public IFlowtideKafkaKeyDeserializer? FetchExistingKeyDeserializer { get; set; }
+
+        /// <summary>
+        /// If set, FetchExistingKeyDeserializer must also be set.
+        /// </summary>
+        public IFlowtideKafkaDeserializer? FetchExistingValueDeserializer { get; set; }
+
         /// <summary>
         /// A method that gets called before events are sent to kafka.
         /// It is possible here to remove or add events from the list before they are sent to kafka.

--- a/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaDataSource.cs
+++ b/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaDataSource.cs
@@ -209,24 +209,7 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
             Debug.Assert(_eventsProcessed != null);
 
             await output.EnterCheckpointLock();
-            Dictionary<int, long> beforeStartOffsets = new Dictionary<int, long>();
-            //Dictionary<int, long> currentOffsets = new Dictionary<int, long>();
-            foreach(var topicPartition in _topicPartitions)
-            {
-                var offsets = _consumer.QueryWatermarkOffsets(topicPartition, TimeSpan.FromSeconds(10));
-                var offset = offsets.High.Value - 1;
-                if (beforeStartOffsets.TryGetValue(topicPartition.Partition.Value, out var currentOffset))
-                {
-                    if (currentOffset < offset)
-                    {
-                        beforeStartOffsets[topicPartition.Partition.Value] = offset;
-                    }
-                }
-                else
-                {
-                    beforeStartOffsets.Add(topicPartition.Partition.Value, offset);
-                }
-            }
+            Dictionary<int, long> beforeStartOffsets = KafkaReadClient.GetCurrentWatermarks(_consumer, _topicPartitions);
 
             List<RowEvent> rows = new List<RowEvent>();
             while (true)

--- a/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaReadClient.cs
+++ b/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaReadClient.cs
@@ -38,14 +38,11 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
 
             var adminClient = new AdminClientBuilder(adminConf).Build();
             var metadata = adminClient.GetMetadata(topicName, TimeSpan.FromSeconds(10));
-            HashSet<string> watermarkNames = new HashSet<string>();
-            var topic = metadata.Topics.First();
-            var partitions = metadata.Topics.First().Partitions;
+            var topic = metadata.Topics[0];
+            var partitions = metadata.Topics[0].Partitions;
             List<TopicPartitionOffset> topicPartitionOffsets = new List<TopicPartitionOffset>();
             foreach (var partition in partitions)
             {
-                watermarkNames.Add(topicName + "_" + partition.PartitionId);
-
                 var topicPartition = new TopicPartition(topic.Topic, new Partition(partition.PartitionId));
                 _topicPartitions.Add(topicPartition);
                 topicPartitionOffsets.Add(new TopicPartitionOffset(topicPartition, new Offset(0)));
@@ -58,11 +55,10 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
             this.keyDeserializer = keyDeserializer;
         }
 
-        public async IAsyncEnumerable<RowEvent> ReadInitial()
+        public IEnumerable<RowEvent> ReadInitial()
         {
             Dictionary<int, long> currentOffsets = new Dictionary<int, long>();
             Dictionary<int, long> beforeStartOffsets = new Dictionary<int, long>();
-            //Dictionary<int, long> currentOffsets = new Dictionary<int, long>();
             foreach (var topicPartition in _topicPartitions)
             {
                 var offsets = _consumer.QueryWatermarkOffsets(topicPartition, TimeSpan.FromSeconds(10));

--- a/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaReadClient.cs
+++ b/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaReadClient.cs
@@ -1,0 +1,119 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Confluent.Kafka;
+using FlowtideDotNet.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static Confluent.Kafka.ConfigPropertyNames;
+
+namespace FlowtideDotNet.Connector.Kafka.Internal
+{
+    public class KafkaReadClient
+    {
+        private readonly IFlowtideKafkaDeserializer valueDeserializer;
+        private readonly IFlowtideKafkaKeyDeserializer keyDeserializer;
+        private readonly IConsumer<byte[], byte[]> _consumer;
+        private readonly List<TopicPartition> _topicPartitions = new List<TopicPartition>();
+
+        public KafkaReadClient(
+            ConsumerConfig consumerConfig, 
+            string topicName,
+            IFlowtideKafkaDeserializer valueDeserializer,
+            IFlowtideKafkaKeyDeserializer keyDeserializer)
+        {
+            var adminConf = new AdminClientConfig(consumerConfig);
+
+            var adminClient = new AdminClientBuilder(adminConf).Build();
+            var metadata = adminClient.GetMetadata(topicName, TimeSpan.FromSeconds(10));
+            HashSet<string> watermarkNames = new HashSet<string>();
+            var topic = metadata.Topics.First();
+            var partitions = metadata.Topics.First().Partitions;
+            List<TopicPartitionOffset> topicPartitionOffsets = new List<TopicPartitionOffset>();
+            foreach (var partition in partitions)
+            {
+                watermarkNames.Add(topicName + "_" + partition.PartitionId);
+
+                var topicPartition = new TopicPartition(topic.Topic, new Partition(partition.PartitionId));
+                _topicPartitions.Add(topicPartition);
+                topicPartitionOffsets.Add(new TopicPartitionOffset(topicPartition, new Offset(0)));
+            }
+
+            _consumer = new ConsumerBuilder<byte[], byte[]>(consumerConfig).Build();
+
+            _consumer.Assign(topicPartitionOffsets);
+            this.valueDeserializer = valueDeserializer;
+            this.keyDeserializer = keyDeserializer;
+        }
+
+        public async IAsyncEnumerable<RowEvent> ReadInitial()
+        {
+            Dictionary<int, long> currentOffsets = new Dictionary<int, long>();
+            Dictionary<int, long> beforeStartOffsets = new Dictionary<int, long>();
+            //Dictionary<int, long> currentOffsets = new Dictionary<int, long>();
+            foreach (var topicPartition in _topicPartitions)
+            {
+                var offsets = _consumer.QueryWatermarkOffsets(topicPartition, TimeSpan.FromSeconds(10));
+                var offset = offsets.High.Value - 1;
+                if (beforeStartOffsets.TryGetValue(topicPartition.Partition.Value, out var currentOffset))
+                {
+                    if (currentOffset < offset)
+                    {
+                        beforeStartOffsets[topicPartition.Partition.Value] = offset;
+                    }
+                }
+                else
+                {
+                    beforeStartOffsets.Add(topicPartition.Partition.Value, offset);
+                }
+            }
+
+            while (true)
+            {
+                var result = _consumer.Consume(TimeSpan.FromMilliseconds(100));
+                if (result != null)
+                {
+                    // Parse the result
+                    currentOffsets[result.Partition.Value] = result.Offset.Value;
+                    var ev = this.valueDeserializer.Deserialize(keyDeserializer, result.Message.Value, result.Message.Key);
+                    yield return ev;
+                }
+                if (result == null)
+                {
+                    bool offsetsReached = true;
+                    foreach (var kv in beforeStartOffsets)
+                    {
+                        if (currentOffsets.TryGetValue(kv.Key, out var currentOffset))
+                        {
+                            if (currentOffset < kv.Value)
+                            {
+                                offsetsReached = false;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            offsetsReached = false;
+                        }
+                    }
+                    if (offsetsReached)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaSink.cs
+++ b/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaSink.cs
@@ -12,6 +12,7 @@
 
 using Confluent.Kafka;
 using FlowtideDotNet.Base;
+using FlowtideDotNet.Core;
 using FlowtideDotNet.Core.Operators.Write;
 using FlowtideDotNet.Substrait.Relations;
 using System.Diagnostics;
@@ -30,6 +31,11 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
 
         public KafkaSink(WriteRelation writeRelation, FlowtideKafkaSinkOptions flowtideKafkaSinkOptions, ExecutionMode executionMode, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionMode, executionDataflowBlockOptions)
         {
+            if ((flowtideKafkaSinkOptions.FetchExistingKeyDeserializer != null || flowtideKafkaSinkOptions.FetchExistingValueDeserializer != null) &&
+                (flowtideKafkaSinkOptions.FetchExistingValueDeserializer == null || flowtideKafkaSinkOptions.FetchExistingKeyDeserializer == null))
+            {
+                throw new InvalidOperationException("Both FetchExistingKeyDeserializer and FetchExistingValueDeserializer must be set or both must be null");
+            }
             int keyIndex = -1;
             topicName = writeRelation.NamedObject.DotSeperated;
             for (int i = 0; i < writeRelation.TableSchema.Names.Count; i++)
@@ -56,6 +62,17 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
         {
             await flowtideKafkaSinkOptions.ValueSerializer.Initialize(_writeRelation);
             _producer = new ProducerBuilder<byte[], byte[]?>(flowtideKafkaSinkOptions.ProducerConfig).Build();
+
+            if (flowtideKafkaSinkOptions.FetchExistingConfig != null)
+            {
+                var readRel = new ReadRelation()
+                {
+                    BaseSchema = _writeRelation.TableSchema,
+                    NamedTable = _writeRelation.NamedObject
+                };
+                await flowtideKafkaSinkOptions.FetchExistingValueDeserializer.Initialize(readRel);
+            }
+
             return new MetadataResult(_primaryKeys);
         }
 
@@ -66,6 +83,32 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
             {
                 await flowtideKafkaSinkOptions.OnInitialDataSent(_producer, _writeRelation, topicName);
             }
+        }
+
+        protected override bool FetchExistingData => flowtideKafkaSinkOptions.FetchExistingConfig != null;
+
+        protected override IAsyncEnumerable<RowEvent> GetExistingData()
+        {
+            if (flowtideKafkaSinkOptions.FetchExistingConfig == null)
+            {
+                throw new InvalidOperationException("FetchExistingConfig must be set for the kafka sink");
+            }
+            if (flowtideKafkaSinkOptions.FetchExistingValueDeserializer == null)
+            {
+                throw new InvalidOperationException("FetchExistingValueDeserializer must be set for the kafka sink");
+            }
+            if (flowtideKafkaSinkOptions.FetchExistingKeyDeserializer == null)
+            {
+                throw new InvalidOperationException("FetchExistingKeyDeserializer must be set for the kafka sink");
+            }
+
+            var client = new KafkaReadClient(
+                flowtideKafkaSinkOptions.FetchExistingConfig,
+                topicName,
+                flowtideKafkaSinkOptions.FetchExistingValueDeserializer,
+                flowtideKafkaSinkOptions.FetchExistingKeyDeserializer);
+
+            return client.ReadInitial();
         }
 
         protected override async Task UploadChanges(IAsyncEnumerable<SimpleChangeEvent> rows, Watermark watermark, CancellationToken cancellationToken)
@@ -86,6 +129,16 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
             List<KeyValuePair<byte[], byte[]?>> output = new List<KeyValuePair<byte[], byte[]?>>();
             await foreach(var row in rows)
             {
+                if (FetchExistingData && !row.IsDeleted)
+                {
+                    // Compare against existing
+                    var (exist, existingVal) = await GetExistingData(row.Row);
+                    // Check if the rows completely match, then do nothing since the data is already in the stream
+                    if (RowEvent.Compare(existingVal, row.Row) == 0)
+                    {
+                        continue;
+                    }
+                }
                 var key = flowtideKafkaSinkOptions.KeySerializer.Serialize(row.Row.GetColumn(_primaryKeyIndex));
                 var val = flowtideKafkaSinkOptions.ValueSerializer.Serialize(row.Row, row.IsDeleted);
 

--- a/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaSink.cs
+++ b/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaSink.cs
@@ -31,10 +31,14 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
 
         public KafkaSink(WriteRelation writeRelation, FlowtideKafkaSinkOptions flowtideKafkaSinkOptions, ExecutionMode executionMode, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionMode, executionDataflowBlockOptions)
         {
-            if ((flowtideKafkaSinkOptions.FetchExistingKeyDeserializer != null || flowtideKafkaSinkOptions.FetchExistingValueDeserializer != null) &&
-                (flowtideKafkaSinkOptions.FetchExistingValueDeserializer == null || flowtideKafkaSinkOptions.FetchExistingKeyDeserializer == null))
+            if ((flowtideKafkaSinkOptions.FetchExistingKeyDeserializer != null || 
+                flowtideKafkaSinkOptions.FetchExistingValueDeserializer != null ||
+                flowtideKafkaSinkOptions.FetchExistingConfig != null) &&
+                (flowtideKafkaSinkOptions.FetchExistingValueDeserializer == null || 
+                flowtideKafkaSinkOptions.FetchExistingKeyDeserializer == null ||
+                flowtideKafkaSinkOptions.FetchExistingConfig == null))
             {
-                throw new InvalidOperationException("Both FetchExistingKeyDeserializer and FetchExistingValueDeserializer must be set or both must be null");
+                throw new InvalidOperationException("FetchExistingConfig, FetchExistingKeyDeserializer and FetchExistingValueDeserializer must be set or all must be null");
             }
             int keyIndex = -1;
             topicName = writeRelation.NamedObject.DotSeperated;

--- a/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
@@ -270,7 +270,7 @@ namespace FlowtideDotNet.Core.Operators.Write
             });
             await m_modified.Clear();
 
-            if (FetchExistingData)
+            if (FetchExistingData && _state!.SentInitialData == false)
             {
                 // Create a tree to store existing data in the destination
                 // This will be used to check written data to existing data if it should be removed from the destination.

--- a/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
@@ -270,7 +270,7 @@ namespace FlowtideDotNet.Core.Operators.Write
             });
             await m_modified.Clear();
 
-            if (FetchExistingData && _state!.SentInitialData == false)
+            if (FetchExistingData && !_state!.SentInitialData)
             {
                 // Create a tree to store existing data in the destination
                 // This will be used to check written data to existing data if it should be removed from the destination.

--- a/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
@@ -234,7 +234,7 @@ namespace FlowtideDotNet.Core.Operators.Write
             return m_metadataResult.PrimaryKeyColumns;
         }
 
-        protected ValueTask<(bool found, RowEvent key)> GetExistingData(RowEvent e)
+        protected ValueTask<(bool found, RowEvent key)> GetExistingDataRow(RowEvent e)
         {
             Debug.Assert(m_existingData != null);
             return m_existingData.GetKey(e);

--- a/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
@@ -234,6 +234,12 @@ namespace FlowtideDotNet.Core.Operators.Write
             return m_metadataResult.PrimaryKeyColumns;
         }
 
+        protected ValueTask<(bool found, RowEvent key)> GetExistingData(RowEvent e)
+        {
+            Debug.Assert(m_existingData != null);
+            return m_existingData.GetKey(e);
+        }
+
         protected override async Task Initialize(long restoreTime, SimpleWriteState? state, IStateManagerClient stateManagerClient)
         {
             Debug.Assert(PrimaryKeyComparer != null);

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTree.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTree.cs
@@ -37,6 +37,8 @@ namespace FlowtideDotNet.Storage.Tree
 
         ValueTask<(bool found, V? value)> GetValue(in K key);
 
+        ValueTask<(bool found, K? key)> GetKey(in K key);
+
         IBPlusTreeIterator<K, V> CreateIterator();
 
         /// <summary>

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
@@ -125,6 +125,22 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             return (true, leaf.values[index]);
         }
 
+        public ValueTask<(bool found, K? key)> GetKey(in K key)
+        {
+            return GetKey_Internal(key);
+        }
+
+        private async ValueTask<(bool found, K? key)> GetKey_Internal(K key)
+        {
+            var leaf = await SearchRoot(key, m_keyComparer);
+            var index = leaf.keys.BinarySearch(key, m_keyComparer);
+            if (index < 0)
+            {
+                return (false, default);
+            }
+            return (true, leaf.keys[index]);
+        }
+
         public IBPlusTreeIterator<K, V> CreateIterator()
         {
             return new BPlusTreeIterator<K, V>(this);

--- a/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaFixture.cs
+++ b/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaFixture.cs
@@ -32,12 +32,12 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
             };
         }
 
-        public ConsumerConfig GetConsumerConfig()
+        public ConsumerConfig GetConsumerConfig(string groupId)
         {
             return new ConsumerConfig()
             {
                 BootstrapServers = _container.GetBootstrapAddress(),
-                GroupId = "test-group",
+                GroupId = groupId,
                 AutoOffsetReset = AutoOffsetReset.Earliest,
                 EnableAutoCommit = false
             };

--- a/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaSourceTests.cs
+++ b/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaSourceTests.cs
@@ -35,7 +35,7 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
             // Create the output topic
             await new AdminClientBuilder(new AdminClientConfig(kafkaFixture.GetConfig())).Build().CreateTopicsAsync(new List<TopicSpecification>() { new TopicSpecification() { Name = "output", NumPartitions = 1, ReplicationFactor = 1 } });
 
-            var consumer = new ConsumerBuilder<string, string>(kafkaFixture.GetConsumerConfig()).Build();
+            var consumer = new ConsumerBuilder<string, string>(kafkaFixture.GetConsumerConfig("testkafka")).Build();
 
             KafkaTestStream kafkaTestStream = new KafkaTestStream(kafkaFixture, topic, "testkafka", false);
 
@@ -96,7 +96,7 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
         {
             var producer = new ProducerBuilder<string, string>(kafkaFixture.GetProducerConfig()).Build();
 
-            var topic = "test-topic";
+            var topic = "test-topic2";
 
             var jsonData = @"{""firstName"":""testFirst"",""lastName"":""testLast""}";
 
@@ -107,43 +107,43 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
             });
 
             // Create the output topic
-            await new AdminClientBuilder(new AdminClientConfig(kafkaFixture.GetConfig())).Build().CreateTopicsAsync(new List<TopicSpecification>() { new TopicSpecification() { Name = "output", NumPartitions = 1, ReplicationFactor = 1 } });
+            await new AdminClientBuilder(new AdminClientConfig(kafkaFixture.GetConfig())).Build().CreateTopicsAsync(new List<TopicSpecification>() { new TopicSpecification() { Name = "output2", NumPartitions = 1, ReplicationFactor = 1 } });
 
 
-            await producer.ProduceAsync("output", new Message<string, string>()
+            await producer.ProduceAsync("output2", new Message<string, string>()
             {
                 Key = "key",
                 Value = jsonData
             });
 
-            await producer.ProduceAsync("output", new Message<string, string>()
+            await producer.ProduceAsync("output2", new Message<string, string>()
             {
                 Key = "key2",
                 Value = @"{""firstName"":""testSecond"",""lastName"":""testSecond""}"
             });
 
             
-            var consumer = new ConsumerBuilder<string, string>(kafkaFixture.GetConsumerConfig()).Build();
+            var consumer = new ConsumerBuilder<string, string>(kafkaFixture.GetConsumerConfig("testwithexistingdata")).Build();
 
-            KafkaTestStream kafkaTestStream = new KafkaTestStream(kafkaFixture, topic, "testkafka", true);
+            KafkaTestStream kafkaTestStream = new KafkaTestStream(kafkaFixture, topic, "testwithexistingdata", true);
 
             await kafkaTestStream.StartStream(@"
-                CREATE TABLE [test-topic] (
+                CREATE TABLE [test-topic2] (
                     _key,
                     firstName,
                     lastName
                 );
 
-                INSERT INTO output
+                INSERT INTO output2
                 SELECT 
                     _key,
                     firstName,
                     lastName
-                FROM [test-topic]
+                FROM [test-topic2]
             ");
 
 
-            consumer.Subscribe("output");
+            consumer.Subscribe("output2");
 
             var msg1 = consumer.Consume();
 

--- a/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaSourceTests.cs
+++ b/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaSourceTests.cs
@@ -37,7 +37,7 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
 
             var consumer = new ConsumerBuilder<string, string>(kafkaFixture.GetConsumerConfig()).Build();
 
-            KafkaTestStream kafkaTestStream = new KafkaTestStream(kafkaFixture, topic, "testkafka");
+            KafkaTestStream kafkaTestStream = new KafkaTestStream(kafkaFixture, topic, "testkafka", false);
 
             await kafkaTestStream.StartStream(@"
                 CREATE TABLE [test-topic] (
@@ -88,6 +88,71 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
             var msg3 = consumer.Consume();
             
             Assert.Equal("key", msg3.Message.Key);
+            Assert.Null(msg3.Message.Value);
+        }
+
+        [Fact]
+        public async Task TestWithExistingData()
+        {
+            var producer = new ProducerBuilder<string, string>(kafkaFixture.GetProducerConfig()).Build();
+
+            var topic = "test-topic";
+
+            var jsonData = @"{""firstName"":""testFirst"",""lastName"":""testLast""}";
+
+            await producer.ProduceAsync(topic, new Message<string, string>()
+            {
+                Key = "key",
+                Value = jsonData
+            });
+
+            // Create the output topic
+            await new AdminClientBuilder(new AdminClientConfig(kafkaFixture.GetConfig())).Build().CreateTopicsAsync(new List<TopicSpecification>() { new TopicSpecification() { Name = "output", NumPartitions = 1, ReplicationFactor = 1 } });
+
+
+            await producer.ProduceAsync("output", new Message<string, string>()
+            {
+                Key = "key",
+                Value = jsonData
+            });
+
+            await producer.ProduceAsync("output", new Message<string, string>()
+            {
+                Key = "key2",
+                Value = @"{""firstName"":""testSecond"",""lastName"":""testSecond""}"
+            });
+
+            
+            var consumer = new ConsumerBuilder<string, string>(kafkaFixture.GetConsumerConfig()).Build();
+
+            KafkaTestStream kafkaTestStream = new KafkaTestStream(kafkaFixture, topic, "testkafka", true);
+
+            await kafkaTestStream.StartStream(@"
+                CREATE TABLE [test-topic] (
+                    _key,
+                    firstName,
+                    lastName
+                );
+
+                INSERT INTO output
+                SELECT 
+                    _key,
+                    firstName,
+                    lastName
+                FROM [test-topic]
+            ");
+
+
+            consumer.Subscribe("output");
+
+            var msg1 = consumer.Consume();
+
+            Assert.Equal("key", msg1.Message.Key);
+            Assert.Equal("{\"firstName\":\"testFirst\",\"lastName\":\"testLast\"}", msg1.Message.Value);
+
+            var msg2 = consumer.Consume();
+            var msg3 = consumer.Consume();
+            Assert.Equal("key2", msg3.Message.Key);
             Assert.Null(msg3.Message.Value);
         }
     }

--- a/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaTestStream.cs
+++ b/tests/FlowtideDotNet.Connector.Kafka.Tests/KafkaTestStream.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.AcceptanceTests.Internal;
 using FlowtideDotNet.Core.Engine;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace FlowtideDotNet.Connector.Kafka.Tests
 {
@@ -19,12 +20,14 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
     {
         private readonly KafkaFixture kafkaFixture;
         private readonly string topic;
+        private readonly string testName;
         private readonly bool fetchExisting;
 
         public KafkaTestStream(KafkaFixture kafkaFixture, string topic, string testName, bool fetchExisting) : base(testName)
         {
             this.kafkaFixture = kafkaFixture;
             this.topic = topic;
+            this.testName = testName;
             this.fetchExisting = fetchExisting;
         }
 
@@ -32,7 +35,7 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
         {
             factory.AddKafkaSource("*", new FlowtideKafkaSourceOptions()
             {
-                ConsumerConfig = kafkaFixture.GetConsumerConfig(),
+                ConsumerConfig = kafkaFixture.GetConsumerConfig(testName),
                 KeyDeserializer = new FlowtidekafkaStringKeyDeserializer(),
                 ValueDeserializer = new FlowtideKafkaUpsertJsonDeserializer()
             });
@@ -56,7 +59,7 @@ namespace FlowtideDotNet.Connector.Kafka.Tests
             };
             if (fetchExisting)
             {
-                opt.FetchExistingConfig = kafkaFixture.GetConsumerConfig();
+                opt.FetchExistingConfig = kafkaFixture.GetConsumerConfig(testName);
                 opt.FetchExistingValueDeserializer = new FlowtideKafkaUpsertJsonDeserializer();
                 opt.FetchExistingKeyDeserializer = new FlowtidekafkaStringKeyDeserializer();
             }


### PR DESCRIPTION
This will check if any sent already exist in the stream and will not send it. It will also delete any events that are no longer in the result set if this is enabled.