### PR TITLE
Add support to set minimum time between checkpoints.

### DIFF
--- a/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
@@ -110,6 +110,12 @@ namespace FlowtideDotNet.Base.Engine
             return this;
         }
 
+        public DataflowStreamBuilder SetMinimumTimeBetweenCheckpoint(TimeSpan timeSpan)
+        {
+            _dataflowStreamOptions.MinimumTimeBetweenCheckpoints = timeSpan;
+            return this;
+        }
+
         public DataflowStream Build()
         {
             if (_stateManagerOptions == null)

--- a/src/FlowtideDotNet.Base/Engine/Internal/DataflowStreamOptions.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/DataflowStreamOptions.cs
@@ -21,5 +21,7 @@ namespace FlowtideDotNet.Base.Engine.Internal
     internal class DataflowStreamOptions
     {
         public bool WaitForCheckpointAfterInitialData { get; set; } = true;
+
+        public TimeSpan? MinimumTimeBetweenCheckpoints { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
@@ -128,6 +128,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
             lock (_context._checkpointLock)
             {
+                _context._initialCheckpointTaken = true;
                 if (_context.checkpointTask != null)
                 {
                     _context._scheduleCheckpointTask = null;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -81,6 +81,8 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         internal FlowtideDotNet.Storage.StateManager.StateManagerSync<StreamState> _stateManager;
         internal readonly ILogger<StreamContext> _logger;
+
+        internal bool _initialCheckpointTaken = false;
         
 
         public StreamContext(
@@ -339,6 +341,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
             // Check if minimum time has been set, if so default it to the minimum time.
             if (_dataflowStreamOptions.MinimumTimeBetweenCheckpoints != null &&
+                _initialCheckpointTaken &&
                 _dataflowStreamOptions.MinimumTimeBetweenCheckpoints.Value.CompareTo(timeSpan) > 0)
             {
                 timeSpan = _dataflowStreamOptions.MinimumTimeBetweenCheckpoints.Value;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -338,12 +338,10 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             Debug.Assert(Monitor.IsEntered(_checkpointLock));
 
             // Check if minimum time has been set, if so default it to the minimum time.
-            if (_dataflowStreamOptions.MinimumTimeBetweenCheckpoints != null)
+            if (_dataflowStreamOptions.MinimumTimeBetweenCheckpoints != null &&
+                _dataflowStreamOptions.MinimumTimeBetweenCheckpoints.Value.CompareTo(timeSpan) > 0)
             {
-                if (_dataflowStreamOptions.MinimumTimeBetweenCheckpoints.Value.CompareTo(timeSpan) > 0)
-                {
-                    timeSpan = _dataflowStreamOptions.MinimumTimeBetweenCheckpoints.Value;
-                }
+                timeSpan = _dataflowStreamOptions.MinimumTimeBetweenCheckpoints.Value;
             }
 
             var triggerTime = DateTime.Now.Add(timeSpan);

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -336,6 +336,16 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         internal bool TryScheduleCheckpointIn_NoLock(TimeSpan timeSpan)
         {
             Debug.Assert(Monitor.IsEntered(_checkpointLock));
+
+            // Check if minimum time has been set, if so default it to the minimum time.
+            if (_dataflowStreamOptions.MinimumTimeBetweenCheckpoints != null)
+            {
+                if (_dataflowStreamOptions.MinimumTimeBetweenCheckpoints.Value.CompareTo(timeSpan) > 0)
+                {
+                    timeSpan = _dataflowStreamOptions.MinimumTimeBetweenCheckpoints.Value;
+                }
+            }
+
             var triggerTime = DateTime.Now.Add(timeSpan);
 
             // Check if a checkpoint is already running, if so, add that a checkpoint is waiting

--- a/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
+++ b/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
@@ -110,6 +110,12 @@ namespace FlowtideDotNet.Core.Engine
             return this;
         }
 
+        public FlowtideBuilder SetMinimumTimeBetweenCheckpoint(TimeSpan timeSpan)
+        {
+            dataflowStreamBuilder.SetMinimumTimeBetweenCheckpoint(timeSpan);
+            return this;
+        }
+
         private string ComputePlanHash()
         {
             Debug.Assert(_plan != null, "Plan should not be null.");


### PR DESCRIPTION
This is useful when uploading data on watermark or in hybrid mode.