### PR TITLE
Add support for custom primary keys in Sql Server

### DIFF
--- a/docs/docs/connectors/sqlserver.md
+++ b/docs/docs/connectors/sqlserver.md
@@ -127,7 +127,7 @@ If there are multiple rows in the result with the same primary key, only the lat
 ### Custom Primary Keys
 
 In some scenarios you may want to override the tables primary keys or the table might not have a primary key configured.
-In this scenario you can provide column names if the columns you want Flowtide to use as primary keys.
+In this scenario you can provide column names for the columns you want Flowtide to use as primary keys.
 
 Ex:
 

--- a/docs/docs/connectors/sqlserver.md
+++ b/docs/docs/connectors/sqlserver.md
@@ -124,6 +124,20 @@ If there are multiple rows in the result with the same primary key, only the lat
 
 :::
 
+### Custom Primary Keys
+
+In some scenarios you may want to override the tables primary keys or the table might not have a primary key configured.
+In this scenario you can provide column names if the columns you want Flowtide to use as primary keys.
+
+Ex:
+
+```csharp
+factory.AddSqlServerSink("your regexp on table names", new SqlServerSinkOptions() {
+  ConnectionStringFunc = () => connectionString,
+  CustomPrimaryKeys = new List<string>() { "my_column1", "my_column2" }
+});
+```
+
 ## SQL Table Provider
 
 The SQL table provider is added to the *SQL plan builder* which will try and look after used tables in its configured *SQL Server*.

--- a/docs/docs/connectors/sqlserver.md
+++ b/docs/docs/connectors/sqlserver.md
@@ -126,7 +126,7 @@ If there are multiple rows in the result with the same primary key, only the lat
 
 ### Custom Primary Keys
 
-In some scenarios you may want to override the tables primary keys or the table might not have a primary key configured.
+In some scenarios you may want to override the table's primary keys or the table might not have a primary key configured.
 In this scenario you can provide column names for the columns you want Flowtide to use as primary keys.
 
 Ex:

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerFactory.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerFactory.cs
@@ -55,7 +55,10 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
 
         public IStreamEgressVertex GetWriteOperator(WriteRelation readRelation, IFunctionsRegister functionsRegister, ExecutionDataflowBlockOptions executionDataflowBlockOptions)
         {
-            return new SqlServerSink(() => connectionString, readRelation, executionDataflowBlockOptions);
+            return new SqlServerSink(new Connector.SqlServer.SqlServerSinkOptions()
+            {
+                ConnectionStringFunc = () => connectionString,
+            }, readRelation, executionDataflowBlockOptions);
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServerSinkOptions.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServerSinkOptions.cs
@@ -1,0 +1,31 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Connector.SqlServer
+{
+    public class SqlServerSinkOptions
+    {
+        public required Func<string> ConnectionStringFunc { get; set; }
+
+        /// <summary>
+        /// Set custom primary keys for the table.
+        /// If not set, the primary keys are collected from the database.
+        /// </summary>
+        public List<string>? CustomPrimaryKeys { get; set; }
+    }
+}

--- a/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
@@ -221,7 +221,7 @@ namespace FlowtideDotNet.SqlServer.Tests.Acceptance
             {
                 return Task.CompletedTask;
             }, nodeMetrics, stateClient, new NullLoggerFactory());
-            var sink = new SqlServerSink(() => sqlServerFixture.ConnectionString, writeRel, new System.Threading.Tasks.Dataflow.ExecutionDataflowBlockOptions());
+            var sink = new SqlServerSink(new Connector.SqlServer.SqlServerSinkOptions() { ConnectionStringFunc = () => sqlServerFixture.ConnectionString }, writeRel, new System.Threading.Tasks.Dataflow.ExecutionDataflowBlockOptions());
 
             sink.Setup("mergejoinstream", "op");
             sink.CreateBlock();

--- a/tests/FlowtideDotNet.SqlServer.Tests/SinkTests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/SinkTests.cs
@@ -23,7 +23,7 @@ namespace FlowtideDotNet.SqlServer.Tests
         [Fact]
         public void TempTableIsTemporary()
         {
-            var sink = new SqlServerSink(() => "", new Substrait.Relations.WriteRelation()
+            var sink = new SqlServerSink(new Connector.SqlServer.SqlServerSinkOptions() { ConnectionStringFunc = () => "" }, new Substrait.Relations.WriteRelation()
             {
                 Input = new ReadRelation()
                 {

--- a/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerTestStream.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerTestStream.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.AcceptanceTests.Internal;
+using FlowtideDotNet.Connector.SqlServer;
 using FlowtideDotNet.Core.Engine;
 using FlowtideDotNet.Substrait.Sql;
 using System;
@@ -24,10 +25,12 @@ namespace FlowtideDotNet.SqlServer.Tests.e2e
     internal class SqlServerTestStream : FlowtideTestStream
     {
         private readonly string connectionString;
+        private readonly List<string>? customPrimaryKeys;
 
-        public SqlServerTestStream(string testName, string connectionString) : base(testName)
+        public SqlServerTestStream(string testName, string connectionString, List<string>? customPrimaryKeys = null) : base(testName)
         {
             this.connectionString = connectionString;
+            this.customPrimaryKeys = customPrimaryKeys;
         }
 
         protected override void AddReadResolvers(ReadWriteFactory factory)
@@ -37,7 +40,11 @@ namespace FlowtideDotNet.SqlServer.Tests.e2e
 
         protected override void AddWriteResolvers(ReadWriteFactory factory)
         {
-            factory.AddSqlServerSink("*", () => connectionString);
+            factory.AddSqlServerSink("*", new SqlServerSinkOptions()
+            {
+                ConnectionStringFunc = () => connectionString,
+                CustomPrimaryKeys = customPrimaryKeys
+            });
         }
     }
 }


### PR DESCRIPTION
This change allows a user to enter custom primary keys, this is useful if the table is missing a primary key or you want to use another primary key.