### PR TITLE
Add support for map key reference in query

### DIFF
--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -56,12 +56,12 @@ namespace FlowtideDotNet.Core.Compute.Internal
 
             var expr = referenceSegment switch
             {
-                StructReferenceSegment structReferenceSegment => 
+                StructReferenceSegment { Field: >= 0 } structReferenceSegment => 
                     System.Linq.Expressions.Expression.Call(
                         expression, 
                         expression.Type.GetMethod(nameof(FlxValue.GetVectorValue)) ?? throw new MissingMethodException(nameof(FlxValue)), 
                         System.Linq.Expressions.Expression.Constant(structReferenceSegment.Field)),
-                MapKeyReferenceSegment mapKeyReferenceSegment => 
+                MapKeyReferenceSegment { Key: not null } mapKeyReferenceSegment => 
                     System.Linq.Expressions.Expression.Call(
                         expression, 
                         expression.Type.GetMethod(nameof(FlxValue.GetMapValue)) ?? throw new MissingMethodException(nameof(FlxValue)), 

--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -50,7 +50,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
             System.Linq.Expressions.Expression? expr = null;
             if (referenceSegment is StructReferenceSegment structReferenceSegment)
             {
-                var method = expression.Type.GetMethod("GetVectorValue");
+                var method = expression.Type.GetMethod(nameof(FlxValue.GetVectorValue));
                 Debug.Assert(method != null);
                 expr = System.Linq.Expressions.Expression.Call(expression, method, System.Linq.Expressions.Expression.Constant(structReferenceSegment.Field));
             }

--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -66,7 +66,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
                         expression, 
                         expression.Type.GetMethod(nameof(FlxValue.GetMapValue)) ?? throw new MissingMethodException(nameof(FlxValue)), 
                         System.Linq.Expressions.Expression.Constant(mapKeyReferenceSegment.Key)),
-                _ => throw new NotImplementedException("The ${nameof(referenceSegment)} must be a {nameof(StructReferenceSegment)} with a positive {nameof(StructReferenceSegment.Field}" or a ${nameof(MapKeyReferenceSegment)} with a non-null ${nameof(MapKeyReferenceSegment.Key)}"),
+                _ => throw new NotImplementedException("The ${nameof(referenceSegment)} must be a {nameof(StructReferenceSegment)} with a positive {nameof(StructReferenceSegment.Field)}" or a ${nameof(MapKeyReferenceSegment)} with a non-null ${nameof(MapKeyReferenceSegment.Key)}"),
             };
 
             if (referenceSegment.Child != null)

--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -56,7 +56,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
             }
             else if (referenceSegment is MapKeyReferenceSegment mapKeyReferenceSegment)
             {
-                var method = expression.Type.GetMethod("GetMapValue");
+                var method = expression.Type.GetMethod(nameof(FlxValue.GetMapValue));
                 Debug.Assert(method != null);
                 expr = System.Linq.Expressions.Expression.Call(expression, method, System.Linq.Expressions.Expression.Constant(mapKeyReferenceSegment.Key));
             }

--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -91,6 +91,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
                     }
                 }
                 var method = inputType.GetMethod("GetColumn");
+                Debug.Assert(method != null);
                 System.Linq.Expressions.Expression expr = System.Linq.Expressions.Expression.Call(state.Parameters[parameterIndex], method, System.Linq.Expressions.Expression.Constant(structReferenceSegment.Field - relativeIndex));
                 if (structReferenceSegment.Child != null)
                 {

--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -54,7 +54,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
                 Debug.Assert(method != null);
                 expr = System.Linq.Expressions.Expression.Call(expression, method, System.Linq.Expressions.Expression.Constant(structReferenceSegment.Field));
             }
-            if (referenceSegment is MapKeyReferenceSegment mapKeyReferenceSegment)
+            else if (referenceSegment is MapKeyReferenceSegment mapKeyReferenceSegment)
             {
                 var method = expression.Type.GetMethod("GetMapValue");
                 Debug.Assert(method != null);

--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -90,7 +90,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
                         parameterIndex = i;
                     }
                 }
-                var method = inputType.GetMethod("GetColumn");
+                var method = inputType.GetMethod(nameof(FlxValue.GetColumn));
                 Debug.Assert(method != null);
                 System.Linq.Expressions.Expression expr = System.Linq.Expressions.Expression.Call(state.Parameters[parameterIndex], method, System.Linq.Expressions.Expression.Constant(structReferenceSegment.Field - relativeIndex));
                 if (structReferenceSegment.Child != null)

--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -66,7 +66,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
                         expression, 
                         expression.Type.GetMethod(nameof(FlxValue.GetMapValue)) ?? throw new MissingMethodException(nameof(FlxValue)), 
                         System.Linq.Expressions.Expression.Constant(mapKeyReferenceSegment.Key)),
-                _ => throw new NotImplementedException(),
+                _ => throw new NotImplementedException("The ${nameof(referenceSegment)} must be a {nameof(StructReferenceSegment)} with a positive {nameof(StructReferenceSegment.Field}" or a ${nameof(MapKeyReferenceSegment)} with a non-null ${nameof(MapKeyReferenceSegment.Key)}"),
             };
 
             if (referenceSegment.Child != null)

--- a/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/FlowtideExpressionVisitor.cs
@@ -66,7 +66,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
                         expression, 
                         expression.Type.GetMethod(nameof(FlxValue.GetMapValue)) ?? throw new MissingMethodException(nameof(FlxValue)), 
                         System.Linq.Expressions.Expression.Constant(mapKeyReferenceSegment.Key)),
-                _ => throw new NotImplementedException("The ${nameof(referenceSegment)} must be a {nameof(StructReferenceSegment)} with a positive {nameof(StructReferenceSegment.Field)}" or a ${nameof(MapKeyReferenceSegment)} with a non-null ${nameof(MapKeyReferenceSegment.Key)}"),
+                _ => throw new NotImplementedException($"The {nameof(referenceSegment)} must be a {nameof(StructReferenceSegment)} with a positive {nameof(StructReferenceSegment.Field)} or a {nameof(MapKeyReferenceSegment)} with a non-null {nameof(MapKeyReferenceSegment.Key)}"),
             };
 
             if (referenceSegment.Child != null)

--- a/src/FlowtideDotNet.Core/Flexbuffer/FlxValue.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlxValue.cs
@@ -23,6 +23,7 @@ namespace FlexBuffers
 {
     public struct FlxValue
     {
+        public static readonly FlxValue Null = FlxValue.FromBytes(FlexBuffer.Null());
         private readonly Memory<byte> _buffer;
         internal readonly int _offset;
         internal readonly byte _parentWidth;
@@ -171,6 +172,32 @@ namespace FlexBuffers
             xxHash.Append(span.Slice(indirectOffset, size));
         }
 
+        public FlxValue GetMapValue(in string key)
+        {
+            if (this.ValueType == Type.Map)
+            {
+                var map = AsMap;
+                var index = map.KeyIndex(key);
+                if (index >= 0)
+                {
+                    return map.ValueByIndex(index);
+                }
+            }
+            return Null;
+        }
+
+        public FlxValue GetVectorValue(in int index)
+        {
+            if (this.ValueType == Type.Vector)
+            {
+                var vec = AsVector;
+                if (index < vec.Length)
+                {
+                    return vec.Get(index);
+                }
+            }
+            return Null;
+        }
 
         public long AsLong
         {

--- a/src/FlowtideDotNet.Core/Flexbuffer/FlxValueRef.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlxValueRef.cs
@@ -77,6 +77,33 @@ namespace FlowtideDotNet.Core.Flexbuffer
             return new FlxValue(memory, offset, byteWidth, packedType);
         }
 
+        public FlxValueRef GetMapValue(in string key)
+        {
+            if (this.ValueType == Type.Map)
+            {
+                var map = AsMap;
+                var index = map.KeyIndex(key);
+                if (index >= 0)
+                {
+                    return map.ValueByIndex(index);
+                }
+            }
+            return FlxValue.Null.GetRef();
+        }
+
+        public FlxValueRef GetVectorValue(in int index)
+        {
+            if (this.ValueType == Type.Vector)
+            {
+                var vec = AsVector;
+                if (index < vec.Length)
+                {
+                    return vec.Get(index);
+                }
+            }
+            return FlxValue.Null.GetRef();
+        }
+
         public Type ValueType => _type;
         public int BufferOffset => _offset;
 
@@ -610,7 +637,7 @@ namespace FlowtideDotNet.Core.Flexbuffer
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public FlxValueRef Get(in int index)
+        public FlxValueRef Get(scoped in int index)
         {
             //Debug.Assert(index < 0 || index >= _length, $"Bad index {index}, should be 0...{_length}");
             if (index < 0 || index >= _length)
@@ -726,7 +753,7 @@ namespace FlowtideDotNet.Core.Flexbuffer
 
         public FlxVectorRef Values => new FlxVectorRef(_buffer, _offset, _byteWidth, Type.Vector, _length);
 
-        public FlxValueRef ValueByIndex(in int keyIndex)
+        public FlxValueRef ValueByIndex(scoped in int keyIndex)
         {
             if (keyIndex < 0 || keyIndex >= Length)
             {

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinExpressionCompiler.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinExpressionCompiler.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.Compute;
+using FlowtideDotNet.Core.Compute.Internal;
 using FlowtideDotNet.Core.Flexbuffer;
 using FlowtideDotNet.Substrait.Expressions;
 using FlowtideDotNet.Substrait.Relations;
@@ -41,7 +42,13 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     throw new InvalidOperationException("Method GetRef could not be found");
                 }
 
-                return System.Linq.Expressions.Expression.Call(parameter, method, System.Linq.Expressions.Expression.Constant(referenceSegment.Field - relativeIndex));
+                System.Linq.Expressions.Expression expr = System.Linq.Expressions.Expression.Call(parameter, method, System.Linq.Expressions.Expression.Constant(referenceSegment.Field - relativeIndex));
+
+                if (referenceSegment.Child != null)
+                {
+                    return FlowtideExpressionVisitor.VisitInnerReferenceSegment(referenceSegment.Child, expr);
+                }
+                return expr;
             }
             throw new NotSupportedException("Only direct field references are supported in merge join keys");
         }

--- a/src/FlowtideDotNet.Substrait/Expressions/MapKeyReferenceSegment.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/MapKeyReferenceSegment.cs
@@ -1,0 +1,25 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Substrait.Expressions
+{
+    public class MapKeyReferenceSegment : ReferenceSegment
+    {
+        public required string Key { get; set; }
+    }
+}

--- a/src/FlowtideDotNet.Substrait/Sql/SqlExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/SqlExpressionVisitor.cs
@@ -34,16 +34,13 @@ namespace FlowtideDotNet.Substrait.Sql
 
         public override ExpressionData Visit(SqlParser.Ast.Expression expression, EmitData state)
         {
-            if (state.TryGetEmitIndex(expression, out var index))
+            if (state.TryGetEmitIndex(expression, out var segment, out var name))
             {
                 var r = new DirectFieldReference()
                 {
-                    ReferenceSegment = new StructReferenceSegment()
-                    {
-                        Field = index
-                    }
+                    ReferenceSegment = segment
                 };
-                return new ExpressionData(r, state.GetName(index));
+                return new ExpressionData(r, name);
             }
             return base.Visit(expression, state);
         }
@@ -339,16 +336,13 @@ namespace FlowtideDotNet.Substrait.Sql
         {
             var removedQuotaIdentifier = new SqlParser.Ast.Expression.CompoundIdentifier(new Sequence<Ident>(compoundIdentifier.Idents.Select(x => new Ident(x.Value))));
             // First try and get the index directly based on the expression
-            if (state.TryGetEmitIndex(removedQuotaIdentifier, out var index))
+            if (state.TryGetEmitIndex(removedQuotaIdentifier, out var segment, out var name))
             {
                 var r = new DirectFieldReference()
                 {
-                    ReferenceSegment = new StructReferenceSegment()
-                    {
-                        Field = index
-                    }
+                    ReferenceSegment = segment
                 };
-                return new ExpressionData(r, state.GetName(index));
+                return new ExpressionData(r, name);
             }
 
             // Otherwise try and find a a part of it.

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -387,5 +387,23 @@ namespace FlowtideDotNet.AcceptanceTests
                     companyName = default(string)
                 });
         }
+
+        [Fact]
+        public async Task JoinWithSubProperty()
+        {
+            GenerateData();
+            await StartStream(@"
+                CREATE VIEW test AS
+                SELECT map('userkey', userkey) AS user 
+                FROM orders;
+
+                INSERT INTO output 
+                SELECT
+                    t.user.userkey
+                FROM test t
+                INNER JOIN users u ON t.user.userkey = u.userkey");
+            await WaitForUpdate();
+            AssertCurrentDataEqual(Orders.Select(x => new { x.UserKey }));
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/SelectTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/SelectTests.cs
@@ -98,5 +98,23 @@ namespace FlowtideDotNet.AcceptanceTests
             await WaitForUpdate();
             AssertCurrentDataEqual(Orders.Select(x => new { x.UserKey }));
         }
+
+        [Fact]
+        public async Task SelectSubPropertyDifferentCase()
+        {
+            GenerateData();
+            await StartStream(@"
+                CREATE VIEW test AS
+                SELECT map('userkey', userkey) AS user 
+                FROM orders;
+
+                INSERT INTO output 
+                SELECT
+                    user.userKey
+                FROM test");
+            await WaitForUpdate();
+            // Expect an array where all columns are null since the field was not found in the map
+            AssertCurrentDataEqual(Orders.Select(x => new { UserKey = default(int?) }));
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/SelectTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/SelectTests.cs
@@ -81,5 +81,22 @@ namespace FlowtideDotNet.AcceptanceTests
             await WaitForUpdate();
             AssertCurrentDataEqual(Orders.Select(x => new { x.UserKey }).Distinct());
         }
+
+        [Fact]
+        public async Task SelectSubProperty()
+        {
+            GenerateData();
+            await StartStream(@"
+                CREATE VIEW test AS
+                SELECT map('userkey', userkey) AS user 
+                FROM orders;
+
+                INSERT INTO output 
+                SELECT
+                    user.userkey
+                FROM test");
+            await WaitForUpdate();
+            AssertCurrentDataEqual(Orders.Select(x => new { x.UserKey }));
+        }
     }
 }


### PR DESCRIPTION
This change allows a user to access map properties by using ".{propertyName}" after a field in SQL.