### PR TITLE
Update security policy for 0.10.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ These are the versions that will currently be updated with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.9.x   | :white_check_mark: |
+| 0.10.x  | :white_check_mark: |
+| 0.9.x   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Mark 0.9.x to no longer be supported for security updates. Mark 0.10.x as the new version with security support