### PR TITLE
Fix bug where worker should use run instead of start

### DIFF
--- a/src/FlowtideDotNet.DependencyInjection/Internal/StreamWorkerService.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Internal/StreamWorkerService.cs
@@ -40,7 +40,7 @@ namespace FlowtideDotNet.DependencyInjection.Internal
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             var stream = serviceProvider.GetRequiredKeyedService<Base.Engine.DataflowStream>(name);
-            await stream.StartAsync();
+            await stream.RunAsync();
         }
     }
 }


### PR DESCRIPTION
Run actually runs the scheduler, while start only starts the stream but the scheduler implementation needs to be implemented elsewhere.