### PR TITLE
Improve comparison performance

### DIFF
--- a/src/FlowtideDotNet.Core/CompactRowData.cs
+++ b/src/FlowtideDotNet.Core/CompactRowData.cs
@@ -26,7 +26,7 @@ namespace FlowtideDotNet.Core
             _vector = vector;
         }
 
-        public CompactRowData(Memory<byte> memory)
+        public CompactRowData(byte[] memory)
         {
             _memory = memory;
             _vector = FlxValue.FromMemory(memory).AsVector;

--- a/src/FlowtideDotNet.Core/Compute/FlxValueComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/FlxValueComparer.cs
@@ -48,44 +48,47 @@ namespace FlowtideDotNet.Core.Compute
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int CompareLongSameWidth(in FlxValue a, in FlxValue b, in byte width) 
         {
-            if (width == 1)
+            if (width >= 4)
             {
-                return a.Buffer[a._offset] - b.Buffer[b._offset];
+                if (width == 4)
+                {
+                       return BitConverter.ToInt32(a._buffer, a._offset) - BitConverter.ToInt32(b._buffer, b._offset);
+                }
+                else
+                {
+                    return BitConverter.ToInt64(a.Buffer.Slice(a._offset, 8)).CompareTo(BitConverter.ToInt64(b.Buffer.Slice(b._offset, 8)));
+                }
             }
-
-            if (width == 2)
+            else
             {
+                if (width == 1)
+                {
+                    return a.Buffer[a._offset] - b.Buffer[b._offset];
+                }
                 return BitConverter.ToInt16(a.Buffer.Slice(a._offset, 2)) - BitConverter.ToInt16(b.Buffer.Slice(b._offset, 2));
             }
-
-            if (width == 4)
-            {
-                return BitConverter.ToInt32(a.Buffer.Slice(a._offset, 4)) - BitConverter.ToInt32(b.Buffer.Slice(b._offset, 4));
-            }
-
-            return BitConverter.ToInt64(a.Buffer.Slice(a._offset, 8)).CompareTo(BitConverter.ToInt64(b.Buffer.Slice(b._offset, 8)));
         }
 
         public static int CompareTo(in FlxValue a, in FlxValue b)
         {
-            var tComp = a.ValueType - b.ValueType;
+            var tComp = a._type - b._type;
             if (tComp == 0)
             {
                 // Same tpe
-                if (a.ValueType == FlexBuffers.Type.Null)
+                if (a._type == FlexBuffers.Type.Null)
                 {
                     return 0;
                 }
-                if (a.ValueType == FlexBuffers.Type.Bool)
+                if (a._type == FlexBuffers.Type.Bool)
                 {
                     return a.AsBool.CompareTo(b.AsBool);
                 }
                 // Check for string comparison
-                if (a.ValueType == FlexBuffers.Type.String)
+                if (a._type == FlexBuffers.Type.String)
                 {
                     return FlxString.Compare(a.AsFlxString, b.AsFlxString);
                 }
-                if (a.ValueType == FlexBuffers.Type.Int)
+                if (a._type == FlexBuffers.Type.Int)
                 {
                     if (a._parentWidth == b._parentWidth)
                     {
@@ -93,11 +96,11 @@ namespace FlowtideDotNet.Core.Compute
                     }
                     return a.AsLong.CompareTo(b.AsLong);
                 }
-                if (a.ValueType == FlexBuffers.Type.Key)
+                if (a._type == FlexBuffers.Type.Key)
                 {
                     return string.Compare(a.AsString, b.AsString);
                 }
-                if (a.ValueType == FlexBuffers.Type.Vector)
+                if (a._type == FlexBuffers.Type.Vector)
                 {
                     var avec = a.AsVector;
                     var bvec = b.AsVector;
@@ -121,13 +124,13 @@ namespace FlowtideDotNet.Core.Compute
                     }
                     return 0;
                 }
-                if (a.ValueType == FlexBuffers.Type.Blob)
+                if (a._type == FlexBuffers.Type.Blob)
                 {
                     var ablob = a.AsBlob;
                     var bblob = b.AsBlob;
                     return ablob.SequenceCompareTo(bblob);
                 }
-                if (a.ValueType == FlexBuffers.Type.Map)
+                if (a._type == FlexBuffers.Type.Map)
                 {
                     var amap = a.AsMap;
                     var bmap = b.AsMap;
@@ -162,11 +165,11 @@ namespace FlowtideDotNet.Core.Compute
                 }
                 throw new NotImplementedException();
             }
-            if (a.ValueType == FlexBuffers.Type.Decimal)
+            if (a._type == FlexBuffers.Type.Decimal)
             {
                 return CompareDecimal(a, b);
             }
-            if (b.ValueType == FlexBuffers.Type.Decimal)
+            if (b._type == FlexBuffers.Type.Decimal)
             {
                 return CompareDecimal(b, a) * -1;
             }

--- a/src/FlowtideDotNet.Core/Flexbuffer/FlexbufferMerger.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlexbufferMerger.cs
@@ -57,37 +57,37 @@ namespace FlowtideDotNet.Core.Flexbuffer
             var val = vv.AsLong;
             var vv2 = vec1[1];
             var vals = vv2.AsString;
-            vec1._buffer.Slice(0, vec1childrenstart).CopyTo(buffer);
+            vec1._buffer.AsSpan().Slice(0, vec1childrenstart).CopyTo(buffer);
 
             var vec2childrenstart = vec2._offset + vec2._byteWidth;
-            vec2._buffer.Slice(0, vec2childrenstart).CopyTo(buffer.AsMemory().Slice(vec1childrenstart));
+            vec2._buffer.AsSpan().Slice(0, vec2childrenstart).CopyTo(buffer.AsSpan().Slice(vec1childrenstart));
 
             //var vec1Table = vec1._buffer.Slice(vec1childrenstart, (vec1._offset + vec1._length * vec1._byteWidth + vec1.Length) - vec1childrenstart);
 
             for (int i = 0; i < vec1.Length; i++)
             {
-                var type = vec1._buffer.Span[vec1._offset + vec1._length * vec1._byteWidth + i];
+                var type = vec1._buffer[vec1._offset + vec1._length * vec1._byteWidth + i];
                 var t = (FlexBuffers.Type)(type >> 2);
                 var elemOffset = vec1._offset + (i * vec1._byteWidth);
                 switch (t)
                 {
                     case FlexBuffers.Type.String:
                     case FlexBuffers.Type.Vector:
-                        int indirectOffset = FlxValue.ComputeIndirectOffset(vec1._buffer.Span, elemOffset, vec1._byteWidth);
+                        int indirectOffset = FlxValue.ComputeIndirectOffset(vec1._buffer, elemOffset, vec1._byteWidth);
                         break;
                 }
             }
 
             for (int i = 0; i < vec2.Length; i++)
             {
-                var type = vec2._buffer.Span[vec2._offset + vec2._length * vec2._byteWidth + i];
+                var type = vec2._buffer[vec2._offset + vec2._length * vec2._byteWidth + i];
                 var t = (FlexBuffers.Type)(type >> 2);
                 var elemOffset = vec2._offset + (i * vec2._byteWidth);
                 switch (t)
                 {
                     case FlexBuffers.Type.String:
                     case FlexBuffers.Type.Vector:
-                        int indirectOffset = FlxValue.ComputeIndirectOffset(vec2._buffer.Span, elemOffset, vec2._byteWidth);
+                        int indirectOffset = FlxValue.ComputeIndirectOffset(vec2._buffer, elemOffset, vec2._byteWidth);
                         var newOffset = indirectOffset + vec1childrenstart;
                         break;
                 }

--- a/src/FlowtideDotNet.Core/Flexbuffer/FlxValue.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlxValue.cs
@@ -24,11 +24,11 @@ namespace FlexBuffers
     public struct FlxValue
     {
         public static readonly FlxValue Null = FlxValue.FromBytes(FlexBuffer.Null());
-        private readonly byte[] _buffer;
+        internal readonly byte[] _buffer;
         internal readonly int _offset;
         internal readonly byte _parentWidth;
         internal readonly byte _byteWidth;
-        private readonly Type _type;
+        internal readonly Type _type;
 
         internal FlxValue(byte[] buffer, int offset, byte parentWidth, byte packedType)
         {

--- a/src/FlowtideDotNet.Core/Flexbuffer/FlxValue.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlxValue.cs
@@ -24,13 +24,13 @@ namespace FlexBuffers
     public struct FlxValue
     {
         public static readonly FlxValue Null = FlxValue.FromBytes(FlexBuffer.Null());
-        private readonly Memory<byte> _buffer;
+        private readonly byte[] _buffer;
         internal readonly int _offset;
         internal readonly byte _parentWidth;
         internal readonly byte _byteWidth;
         private readonly Type _type;
 
-        internal FlxValue(Memory<byte> buffer, int offset, byte parentWidth, byte packedType)
+        internal FlxValue(byte[] buffer, int offset, byte parentWidth, byte packedType)
         {
             _buffer = buffer;
             _offset = offset;
@@ -39,7 +39,7 @@ namespace FlexBuffers
             _type = (Type) (packedType >> 2);
         }
         
-        internal FlxValue(Memory<byte> buffer, int offset, byte parentWidth, byte byteWidth, Type type)
+        internal FlxValue(byte[] buffer, int offset, byte parentWidth, byte byteWidth, Type type)
         {
             _buffer = buffer;
             _offset = offset;
@@ -61,13 +61,13 @@ namespace FlexBuffers
             return new FlxValue(bytes, offset, byteWidth, packedType);
         }
 
-        public static FlxValue FromMemory(Memory<byte> memory)
+        public static FlxValue FromMemory(byte[] memory)
         {
             if (memory.Length < 3)
             {
                 throw new InvalidOperationException($"Invalid buffer {memory}");
             }
-            var span = memory.Span;
+            var span = memory;
             var byteWidth = span[span.Length - 1];
             var packedType = span[span.Length - 2];
             var offset = span.Length - byteWidth - 2;
@@ -85,7 +85,7 @@ namespace FlexBuffers
 
         public FlxValueRef GetRef()
         {
-            return new FlxValueRef(_buffer.Span, _offset, _parentWidth, _byteWidth, _type);
+            return new FlxValueRef(_buffer, _offset, _parentWidth, _byteWidth, _type);
         }
 
         public void AddToHash(in XxHash32 xxHash)
@@ -96,7 +96,7 @@ namespace FlexBuffers
             }
             else if (_type == Type.Int)
             {
-                var span = _buffer.Span;
+                var span = _buffer;
                 var v = ReadLong(span, _offset, _parentWidth);
                 Span<byte> buffer = stackalloc byte[8];
                 BinaryPrimitives.WriteInt64LittleEndian(buffer, v);
@@ -104,7 +104,7 @@ namespace FlexBuffers
             }
             else if (_type == Type.Uint)
             {
-                var span = _buffer.Span;
+                var span = _buffer;
                 var v = ReadULong(span, _offset, _parentWidth);
                 Span<byte> buffer = stackalloc byte[8];
                 BinaryPrimitives.WriteUInt64LittleEndian(buffer, v);
@@ -112,7 +112,7 @@ namespace FlexBuffers
             }
             else if (_type == Type.Float)
             {
-                var span = _buffer.Span;
+                var span = _buffer;
                 var v = ReadDouble(span, _offset, _parentWidth);
                 Span<byte> buffer = stackalloc byte[8];
                 BinaryPrimitives.WriteDoubleLittleEndian(buffer, v);
@@ -160,7 +160,7 @@ namespace FlexBuffers
 
         private void HashString(in XxHash32 xxHash)
         {
-            var span = _buffer.Span;
+            Span<byte> span = _buffer;
             var indirectOffset = ComputeIndirectOffset(span, _offset, _parentWidth);
             var size = (int)ReadULong(span, indirectOffset - _byteWidth, _byteWidth);
             var sizeWidth = (int)_byteWidth;
@@ -203,7 +203,7 @@ namespace FlexBuffers
         {
             get
             {
-                var span = _buffer.Span;
+                var span = _buffer;
                 if (_type == Type.Int)
                 {
                     return ReadLong(span, _offset, _parentWidth);    
@@ -242,18 +242,18 @@ namespace FlexBuffers
             {
                 if (_type == Type.Uint)
                 {
-                    return ReadULong(_buffer.Span, _offset, _parentWidth);    
+                    return ReadULong(_buffer, _offset, _parentWidth);    
                 }
                 
                 if (_type == Type.IndirectUInt)
                 {
-                    var indirectOffset = ComputeIndirectOffset(_buffer.Span, _offset, _parentWidth);
-                    return ReadULong(_buffer.Span, indirectOffset, _byteWidth);
+                    var indirectOffset = ComputeIndirectOffset(_buffer, _offset, _parentWidth);
+                    return ReadULong(_buffer, indirectOffset, _byteWidth);
                 }
 
                 if (_type == Type.Int)
                 {
-                    var value = ReadLong(_buffer.Span, _offset, _parentWidth);
+                    var value = ReadLong(_buffer, _offset, _parentWidth);
                     if (value >= 0)
                     {
                         return (ulong) value;
@@ -262,8 +262,8 @@ namespace FlexBuffers
                 
                 if (_type == Type.IndirectInt)
                 {
-                    var indirectOffset = ComputeIndirectOffset(_buffer.Span, _offset, _parentWidth);
-                    var value = ReadLong(_buffer.Span, indirectOffset, _byteWidth);
+                    var indirectOffset = ComputeIndirectOffset(_buffer, _offset, _parentWidth);
+                    var value = ReadLong(_buffer, indirectOffset, _byteWidth);
                     if (value >= 0)
                     {
                         return (ulong) value;
@@ -277,7 +277,7 @@ namespace FlexBuffers
         {
             get
             {
-                var span = _buffer.Span;
+                var span = _buffer;
                 if (_type == Type.Float)
                 {
                     return ReadDouble(span, _offset, _parentWidth);    
@@ -315,15 +315,15 @@ namespace FlexBuffers
             {
                 if (_type == Type.Bool)
                 {
-                    return _buffer.Span[_offset] != 0;
+                    return _buffer[_offset] != 0;
                 }
                 if (_type == Type.Int)
                 {
-                    return ReadLong(_buffer.Span, _offset, _parentWidth) != 0;    
+                    return ReadLong(_buffer, _offset, _parentWidth) != 0;    
                 }
                 if (_type == Type.Uint)
                 {
-                    return ReadULong(_buffer.Span, _offset, _parentWidth) != 0;    
+                    return ReadULong(_buffer, _offset, _parentWidth) != 0;    
                 }
                 throw new InvalidOperationException($"Type {_type} is not convertible to bool");
             }
@@ -333,7 +333,7 @@ namespace FlexBuffers
         {
             get
             {
-                var span = _buffer.Span;
+                Span<byte> span = _buffer;
                 if (_type == Type.String)
                 {
                     var indirectOffset = ComputeIndirectOffset(span, _offset, _parentWidth);
@@ -364,7 +364,7 @@ namespace FlexBuffers
         {
             get
             {
-                var span = _buffer.Span;
+                Span<byte> span = _buffer;
                 if (_type == Type.String)
                 {
                     var indirectOffset = ComputeIndirectOffset(span, _offset, _parentWidth);
@@ -400,7 +400,7 @@ namespace FlexBuffers
             {
                 if (_type == Type.Decimal)
                 {
-                    var span = _buffer.Span;
+                    Span<byte> span = _buffer;
                     var indirectOffset = ComputeIndirectOffset(span, _offset, _parentWidth);
                     return new decimal(MemoryMarshal.Cast<byte, int>(span.Slice(indirectOffset, 16)));
                 }
@@ -420,7 +420,7 @@ namespace FlexBuffers
                 {
                     throw new InvalidOperationException($"Type {_type} is not a vector.");
                 }
-                var span = _buffer.Span;
+                var span = _buffer;
                 var indirectOffset = ComputeIndirectOffset(span, _offset, _parentWidth);
                 var size = TypesUtil.IsFixedTypedVector(_type) 
                     ? TypesUtil.FixedTypedVectorElementSize(_type) 
@@ -437,7 +437,7 @@ namespace FlexBuffers
                 {
                     throw new InvalidOperationException($"Type {_type} is not a map.");
                 }
-                var span = _buffer.Span;
+                Span<byte> span = _buffer;
                 var indirectOffset = ComputeIndirectOffset(span, _offset, _parentWidth);
                 var size = ReadULong(span, indirectOffset - _byteWidth, _byteWidth);
                 return new FlxMap(_buffer, indirectOffset, _byteWidth, (int)size);
@@ -452,7 +452,7 @@ namespace FlexBuffers
                 {
                     throw new InvalidOperationException($"Type {_type} is not a blob.");
                 }
-                var span = _buffer.Span;
+                Span<byte> span = _buffer;
                 var indirectOffset = ComputeIndirectOffset(span, _offset, _parentWidth);
                 var size = ReadULong(span, indirectOffset - _byteWidth, _byteWidth);
 
@@ -619,22 +619,22 @@ namespace FlexBuffers
             return offset - step;
         }
         
-        internal Span<byte> Buffer => _buffer.Span;
+        internal Span<byte> Buffer => _buffer;
         internal int Offset => _offset;
 
-        internal int IndirectOffset => ComputeIndirectOffset(_buffer.Span, _offset, _parentWidth);
+        internal int IndirectOffset => ComputeIndirectOffset(_buffer, _offset, _parentWidth);
 
     }
 
     public struct FlxVector: IEnumerable<FlxValue>
     {
-        internal readonly Memory<byte> _buffer;
+        internal readonly byte[] _buffer;
         internal readonly int _offset;
         internal readonly int _length;
         internal readonly byte _byteWidth;
         private readonly Type _type;
 
-        internal FlxVector(Memory<byte> buffer, int offset, byte byteWidth, Type type, int length)
+        internal FlxVector(byte[] buffer, int offset, byte byteWidth, Type type, int length)
         {
             _buffer = buffer;
             _offset = offset;
@@ -652,15 +652,14 @@ namespace FlexBuffers
 
         public FlxValueRef GetRef(scoped in int index)
         {
-            var span = _buffer.Span;
-            return GetRefWithSpan(index, _buffer.Span);
+            return GetRefWithSpan(index, _buffer);
         }
 
         public Span<byte> Span
         {
             get
             {
-                return _buffer.Span;
+                return _buffer;
             }
         }
 
@@ -732,8 +731,7 @@ namespace FlexBuffers
         {
             get
             {
-                var span = _buffer.Span;
-                return GetWithSpan(index, span);
+                return GetWithSpan(index, _buffer);
             }
         }
 
@@ -799,12 +797,12 @@ namespace FlexBuffers
 
     public struct FlxMap: IEnumerable<KeyValuePair<string, FlxValue>>
     {
-        private readonly Memory<byte> _buffer;
+        private readonly byte[] _buffer;
         private readonly int _offset;
         private readonly int _length;
         private readonly byte _byteWidth;
 
-        internal FlxMap(Memory<byte> buffer, int offset, byte byteWidth, int length)
+        internal FlxMap(byte[] buffer, int offset, byte byteWidth, int length)
         {
             _buffer = buffer;
             _offset = offset;
@@ -818,7 +816,7 @@ namespace FlexBuffers
         {
             get
             {
-                var span = _buffer.Span;
+                var span = _buffer;
                 var keysOffset = _offset - _byteWidth * 3;
                 var indirectOffset = FlxValue.ComputeIndirectOffset(span, keysOffset, _byteWidth);
                 var bWidth = FlxValue.ReadULong(span, keysOffset + _byteWidth, _byteWidth);

--- a/src/FlowtideDotNet.Core/Flexbuffer/FlxValueRef.cs
+++ b/src/FlowtideDotNet.Core/Flexbuffer/FlxValueRef.cs
@@ -64,13 +64,13 @@ namespace FlowtideDotNet.Core.Flexbuffer
             return new FlxValueRef(span, offset, byteWidth, packedType);
         }
 
-        public static FlxValue FromMemory(Memory<byte> memory)
+        public static FlxValue FromMemory(byte[] memory)
         {
             if (memory.Length < 3)
             {
                 throw new InvalidOperationException($"Invalid buffer {memory}");
             }
-            var span = memory.Span;
+            var span = memory;
             var byteWidth = span[span.Length - 1];
             var packedType = span[span.Length - 2];
             var offset = span.Length - byteWidth - 2;

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinExpressionCompiler.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinExpressionCompiler.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlexBuffers;
 using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Core.Compute.Internal;
 using FlowtideDotNet.Core.Flexbuffer;
@@ -25,7 +26,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
     {
         internal static System.Linq.Expressions.MethodCallExpression CompareRef(System.Linq.Expressions.Expression a, System.Linq.Expressions.Expression b)
         {
-            MethodInfo? compareMethod = typeof(FlxValueRefComparer).GetMethod("CompareTo", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+            MethodInfo? compareMethod = typeof(FlxValueComparer).GetMethod("CompareTo", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
             Debug.Assert(compareMethod != null);
             return System.Linq.Expressions.Expression.Call(compareMethod, a, b);
         }
@@ -35,7 +36,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             if (fieldReference is DirectFieldReference directFieldReference &&
                     directFieldReference.ReferenceSegment is StructReferenceSegment referenceSegment)
             {
-                var method = typeof(JoinStreamEvent).GetMethod("GetColumnRef");
+                var method = typeof(JoinStreamEvent).GetMethod("GetColumn");
 
                 if (method == null)
                 {
@@ -55,7 +56,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         // Used in reflection
 #pragma warning disable IDE0051 // Remove unused private members
-        private static bool EqualImplementation(in FlxValueRef x, in FlxValueRef y)
+        private static bool EqualImplementation(in FlxValue x, in FlxValue y)
 #pragma warning restore IDE0051 // Remove unused private members
         {
             // If either is null, return null
@@ -63,7 +64,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             {
                 return false;
             }
-            else if (FlxValueRefComparer.CompareTo(x, y) == 0)
+            else if (FlxValueComparer.CompareTo(x, y) == 0)
             {
                 return true;
             }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizationOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizationOperator.cs
@@ -150,7 +150,7 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             Debug.Assert(_tree != null, nameof(_tree));
 
             bool isUpdate = false;
-            Memory<byte>? previousValue = null;
+            byte[]? previousValue = null;
 
             var ingressInput = IngressData.Create(b =>
             {
@@ -197,12 +197,12 @@ namespace FlowtideDotNet.Core.Operators.Normalization
 
             if (isUpdate)
             {
-                if (!previousValue.HasValue)
+                if (previousValue == null)
                 {
                     throw new InvalidOperationException("Previous value was null, should not happen");
                 }
                 output.Add(new RowEvent(1, 0, new CompactRowData(ingressInput.Memory)));
-                output.Add(new RowEvent(-1, 0, new CompactRowData(previousValue.Value)));
+                output.Add(new RowEvent(-1, 0, new CompactRowData(previousValue)));
             }
             else if (added)
             {

--- a/src/FlowtideDotNet.Core/Operators/Read/IngressData.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/IngressData.cs
@@ -21,16 +21,16 @@ namespace FlowtideDotNet.Core.Operators.Read
         private FlxVector _vector;
         internal bool IsDeleted { get; set; }
 
-        internal IngressData(Memory<byte> bytes, bool isDeleted)
+        internal IngressData(byte[] bytes, bool isDeleted)
         {
             Memory = bytes;
             _vector = FlxValue.FromMemory(bytes).AsVector;
             IsDeleted = isDeleted;
         }
 
-        public Span<byte> Span => Memory.Span;
+        public Span<byte> Span => Memory;
 
-        public Memory<byte> Memory { get; internal set; }
+        public byte[] Memory { get; internal set; }
 
         public FlxVector Vector => _vector;
 
@@ -40,12 +40,6 @@ namespace FlowtideDotNet.Core.Operators.Read
         {
             dest[0] = IsDeleted ? (byte)1 : (byte)0;
             Span.CopyTo(dest.Slice(1));
-        }
-
-        public static IngressData CreateFromWal(Memory<byte> bytes)
-        {
-            var isDeleted = bytes.Span[0];
-            return new IngressData(bytes.Slice(1), isDeleted == 1);
         }
 
         public static IngressData Create(Action<IFlexBufferVectorBuilder> vector)

--- a/src/FlowtideDotNet.Core/Properties/AssemblyInfo.cs
+++ b/src/FlowtideDotNet.Core/Properties/AssemblyInfo.cs
@@ -17,3 +17,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("FlowtideDotNet.Connector.SpiceDB")]
 [assembly: InternalsVisibleTo("FlowtideDotNet.Connector.Permify")]
 [assembly: InternalsVisibleTo("FlowtideDotNet.Connector.Sharepoint")]
+[assembly: InternalsVisibleTo("FlowtideDotNet.Benchmarks")]

--- a/tests/FlowtideDotNet.Benchmarks/CompareBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/CompareBenchmark.cs
@@ -1,0 +1,111 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using BenchmarkDotNet.Attributes;
+using FlowtideDotNet.Core;
+using FlowtideDotNet.Core.Compute;
+using FlowtideDotNet.Core.Operators.Join;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Benchmarks
+{
+    public class CompareBenchmark
+    {
+
+        private class Comparer : IComparer<JoinStreamEvent>
+        {
+            public int Compare(JoinStreamEvent x, JoinStreamEvent y)
+            {
+                var c1 = x.GetColumn(0);
+                var c2 = y.GetColumn(0);
+
+                return FlxValueComparer.CompareTo(c1, c2);
+            }
+        }
+
+        private class RefStructComparer : IComparer<JoinStreamEvent>
+        {
+            public int Compare(JoinStreamEvent x, JoinStreamEvent y)
+            {
+                var c1 = x.GetColumnRef(0);
+                var c2 = y.GetColumnRef(0);
+
+                return FlxValueRefComparer.CompareTo(c1, c2);
+            }
+        }
+
+        private List<JoinStreamEvent> compactData = new List<JoinStreamEvent>();
+        private List<JoinStreamEvent> arrayData = new List<JoinStreamEvent>();
+
+
+        [IterationSetup()]
+        public void IterationSetup()
+        {
+            Random r = new Random(123);
+            compactData.Clear();
+            arrayData.Clear();
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                var e = RowEvent.Create(1, 0, b =>
+                {
+                    b.Add(r.Next());
+                });
+                compactData.Add(new JoinStreamEvent(0, 0, e.RowData));
+                arrayData.Add(new JoinStreamEvent(0, 0, ArrayRowData.Create(e.RowData, default)));
+            }
+        }
+
+        [Benchmark]
+        public void CompareLongCompactRowData()
+        {
+            var comparer = new Comparer();
+            for (int i = 0; i < compactData.Count; i++)
+            {
+                comparer.Compare(compactData[0], compactData[i]);
+            }
+        }
+
+        [Benchmark]
+        public void CompareLongCompactRowDataRefStruct()
+        {
+            var comparer = new RefStructComparer();
+            for (int i = 0; i < compactData.Count; i++)
+            {
+                comparer.Compare(compactData[0], compactData[i]);
+            }
+        }
+
+        [Benchmark]
+        public void CompareLongArrayRowData()
+        {
+            var comparer = new Comparer();
+            for (int i = 0; i < arrayData.Count; i++)
+            {
+                comparer.Compare(arrayData[0], arrayData[i]);
+            }
+        }
+
+        [Benchmark]
+        public void CompareLongArrayRowDataRefStruct()
+        {
+            var comparer = new RefStructComparer();
+            for (int i = 0; i < arrayData.Count; i++)
+            {
+                comparer.Compare(arrayData[0], arrayData[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change tries to give better performance to comparisons.

Here are the benchmarks before and after the change:

```
Before:

| Method                     | Mean     | Error    | StdDev   | Processed Events / s |
|--------------------------- |---------:|---------:|---------:|---------------------:|
| InnerJoin                  | 960.4 ms | 17.93 ms | 11.86 ms |               529634 |
| LeftJoin                   | 969.5 ms | 17.80 ms |  2.75 ms |               773708 |
| ProjectionAndNormalization | 202.1 ms | 12.52 ms |  8.28 ms |               989398 |
| SumAggregation             | 208.0 ms | 11.78 ms |  7.79 ms |               961596 |

After:

| Method                     | Mean     | Error    | StdDev   | Processed Events / s |
|--------------------------- |---------:|---------:|---------:|---------------------:|
| InnerJoin                  | 854.2 ms | 10.15 ms |  1.57 ms |               594604 |
| LeftJoin                   | 884.2 ms | 50.27 ms | 33.25 ms |               850477 |
| ProjectionAndNormalization | 189.3 ms |  8.88 ms |  5.88 ms |              1056273 |
| SumAggregation             | 199.9 ms |  8.92 ms |  5.90 ms |              1000366 |
```