### PR TITLE
Fix edge case bug in merge join operator

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnComparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnComparer.cs
@@ -24,6 +24,8 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
         private DataValueContainer dataValueContainer;
         private readonly int columnCount;
 
+        public bool SeekNextPageForValue => false;
+
         public ColumnComparer(int columnCount)
         {
             dataValueContainer = new DataValueContainer();

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
@@ -42,6 +42,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 }
             }
         }
+
+        public bool SeekNextPageForValue => false;
+
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
         {
             throw new NotImplementedException();

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
@@ -32,6 +32,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         public int end;
         public bool noMatch = false;
 
+        public bool SeekNextPageForValue => true;
+
         public MergeJoinSearchComparer(List<KeyValuePair<int, ReferenceSegment?>> selfColumns, List<KeyValuePair<int, ReferenceSegment?>> referenceColumns)
         {
             dataValueContainer = new DataValueContainer();

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeTreeComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeTreeComparer.cs
@@ -27,6 +27,8 @@ namespace FlowtideDotNet.Core.Operators.Normalization
         private DataValueContainer dataValueContainer;
         private readonly List<int> _keyColumns;
 
+        public bool SeekNextPageForValue => false;
+
         public NormalizeTreeComparer(List<int> keyColumns)
         {
             dataValueContainer = new DataValueContainer();

--- a/src/FlowtideDotNet.Storage/Tree/BPlusTreeListComparer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/BPlusTreeListComparer.cs
@@ -26,6 +26,9 @@ namespace FlowtideDotNet.Storage.Tree
         {
             this.comparer = comparer;
         }
+
+        public bool SeekNextPageForValue => false;
+
         public int CompareTo(in K x, in K y)
         {
             return comparer.Compare(x, y);

--- a/src/FlowtideDotNet.Storage/Tree/IBplusTreeComparer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBplusTreeComparer.cs
@@ -46,5 +46,11 @@ namespace FlowtideDotNet.Storage.Tree
         /// <param name="index"></param>
         /// <returns></returns>
         int CompareTo(in K key, in TKeyContainer keyContainer, in int index);
+
+        /// <summary>
+        /// Set to true if seek in iterator should check the next page for the value if it is not found in the current page
+        /// and the key to search was the largest in the page.
+        /// </summary>
+        bool SeekNextPageForValue { get; }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -540,5 +540,49 @@ namespace FlowtideDotNet.AcceptanceTests
 
             AssertCurrentDataEqual(expectedList);
         }
+
+        [Fact]
+        public async Task TestJoinUpdateValueOnPageBorder()
+        {
+            GenerateCompanies(10);
+            GenerateUsers(1000);
+
+            await StartStream(@"
+                INSERT INTO output 
+                SELECT 
+                    u.userkey, u.firstName, o.orderkey
+                FROM users u
+                LEFT JOIN orders o
+                ON u.userkey = o.userkey
+                ", pageSize: 512);
+
+            await WaitForUpdate();
+
+            var firstUser = Users[0];
+            // Get the user that will be placed at the right side border of a page.
+            var keyToFind = firstUser.UserKey + 511;
+            var userObj = Users.First(x => x.UserKey == keyToFind);
+
+            // Force so the update of a new object is added after the current object.
+            userObj.FirstName = "Zzzzz";
+            AddOrUpdateUser(userObj);
+
+            await WaitForUpdate();
+
+            GenerateOrders(1000);
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(
+                from user in Users
+                join order in Orders on user.UserKey equals order.UserKey into gj
+                from suborder in gj.DefaultIfEmpty()
+                select new
+                {
+                    user.UserKey,
+                    user.FirstName,
+                    suborder?.OrderKey
+                });
+        }
     }
 }


### PR DESCRIPTION
An update to a row on the right side edge of a page with a larger value in the other columns would add it to the next page. Then the delete of the old value would mean that the key points to a page where the key does not exist. This change allows the iterator to check the next page for the key. This is only useful really when searching for a single column while insertion is done based on multiple columns.