### PR TITLE
Add column aggregate operator

### DIFF
--- a/samples/MonitoringAzureMonitor/DummyReadOperator.cs
+++ b/samples/MonitoringAzureMonitor/DummyReadOperator.cs
@@ -83,7 +83,7 @@ namespace MonitoringAzureMonitor
                         }
                     }));
                 }
-                await output.SendAsync(new StreamEventBatch(o));
+                await output.SendAsync(new StreamEventBatch(o, 16));
                 output.ExitCheckpointLock();
                 ScheduleCheckpoint(TimeSpan.FromSeconds(1));
             }

--- a/samples/MonitoringPrometheus/DummyReadOperator.cs
+++ b/samples/MonitoringPrometheus/DummyReadOperator.cs
@@ -71,7 +71,7 @@ namespace MonitoringPrometheus
                     }
                 }));
             }
-            await output.SendAsync(new StreamEventBatch(o));
+            await output.SendAsync(new StreamEventBatch(o, 16));
             await output.SendWatermark(new FlowtideDotNet.Base.Watermark("dummy", _watermarkCounter++));
             output.ExitCheckpointLock();
             ScheduleCheckpoint(TimeSpan.FromSeconds(1));
@@ -109,7 +109,7 @@ namespace MonitoringPrometheus
                         }
                     }));
                 }
-                await output.SendAsync(new StreamEventBatch(o));
+                await output.SendAsync(new StreamEventBatch(o, 16));
                 await output.SendWatermark(new FlowtideDotNet.Base.Watermark("dummy", _watermarkCounter++));
                 output.ExitCheckpointLock();
                 ScheduleCheckpoint(TimeSpan.FromSeconds(1));

--- a/src/FlowtideDotNet.Base/Engine/IStreamNotificationReciever.cs
+++ b/src/FlowtideDotNet.Base/Engine/IStreamNotificationReciever.cs
@@ -17,5 +17,7 @@ namespace FlowtideDotNet.Base.Engine
     public interface IStreamNotificationReciever
     {
         void OnStreamStateChange(StreamStateValue newState);
+
+        void OnCheckpointComplete();
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
@@ -75,6 +75,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 await run._context._stateManager.CheckpointAsync(false);
                 _context._logger.StateManagerCheckpointDone(_context.streamName);
 
+                if (_context._notificationReciever != null)
+                {
+                    _context._notificationReciever.OnCheckpointComplete();
+                }
+
                 await run._context.stateHandler.WriteLatestState(run._context.streamName, run._context._lastState);
 
                 await _context.ForEachIngressBlockAsync((key, block) =>
@@ -125,7 +130,6 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         private void CheckpointCompleted()
         {
             Debug.Assert(_context != null, nameof(_context));
-
             lock (_context._checkpointLock)
             {
                 _context._initialCheckpointTaken = true;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -45,7 +45,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         internal readonly Dictionary<string, IStreamVertex> _blockLookup;
         internal readonly IStateHandler stateHandler;
         internal readonly StreamMetrics _streamMetrics;
-        private readonly IStreamNotificationReciever? _notificationReciever;
+        internal readonly IStreamNotificationReciever? _notificationReciever;
         internal readonly ILoggerFactory loggerFactory;
         internal readonly object _checkpointLock;
         internal readonly Dictionary<string, List<OperatorTrigger>> _triggers;

--- a/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaDataSource.cs
+++ b/src/FlowtideDotNet.Connector.Kafka/Internal/KafkaDataSource.cs
@@ -159,7 +159,7 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
                     waitTimeMs = 1;
                     if (rows.Count > 100)
                     {
-                        await output.SendAsync(new StreamEventBatch(rows));
+                        await output.SendAsync(new StreamEventBatch(rows, readRelation.OutputLength));
                         rows = new List<RowEvent>();
                         await SendWatermark(output);
                         _eventsProcessed.Add(rows.Count);
@@ -169,7 +169,7 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
                 {
                     if (rows.Count > 0)
                     {
-                        await output.SendAsync(new StreamEventBatch(rows));
+                        await output.SendAsync(new StreamEventBatch(rows, readRelation.OutputLength));
                         rows = new List<RowEvent>();
                         await SendWatermark(output);
                         _eventsProcessed.Add(rows.Count);
@@ -228,7 +228,7 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
                 
                 if (result == null || rows.Count >= 100)
                 {
-                    await output.SendAsync(new StreamEventBatch(rows));
+                    await output.SendAsync(new StreamEventBatch(rows, readRelation.OutputLength));
                     rows = new List<RowEvent>();
                     _eventsProcessed.Add(rows.Count);
                     // Check offsets
@@ -257,7 +257,7 @@ namespace FlowtideDotNet.Connector.Kafka.Internal
 
             if (rows.Count > 0)
             {
-                await output.SendAsync(new StreamEventBatch(rows));
+                await output.SendAsync(new StreamEventBatch(rows, readRelation.OutputLength));
                 _eventsProcessed.Add(rows.Count);
             }
 

--- a/src/FlowtideDotNet.Connector.OpenFGA/Internal/FlowtideOpenFGASource.cs
+++ b/src/FlowtideDotNet.Connector.OpenFGA/Internal/FlowtideOpenFGASource.cs
@@ -32,6 +32,7 @@ namespace FlowtideDotNet.Connector.OpenFGA.Internal
     internal class FlowtideOpenFgaSource : ReadBaseOperator<FlowtideOpenFgaSourceState>
     {
         private readonly OpenFgaSourceOptions m_options;
+        private readonly ReadRelation m_readRelation;
         private OpenFgaClient? m_client;
         private FlowtideOpenFgaSourceState? m_state;
 
@@ -60,6 +61,7 @@ namespace FlowtideDotNet.Connector.OpenFGA.Internal
             }
 
             this.m_options = openFgaOptions;
+            this.m_readRelation = readRelation;
         }
 
         public override string DisplayName => m_displayName;
@@ -157,7 +159,7 @@ namespace FlowtideDotNet.Connector.OpenFGA.Internal
                         m_state.LastTimestamp = timestamp;
                     }
                 }
-                await output.SendAsync(new StreamEventBatch(outputData));
+                await output.SendAsync(new StreamEventBatch(outputData, m_readRelation.OutputLength));
                 m_state.ContinuationToken = changes.ContinuationToken;
 
                 changes = await m_client.ReadChanges(request, options: new OpenFga.Sdk.Client.Model.ClientReadChangesOptions()

--- a/src/FlowtideDotNet.Connector.Permify/Internal/PermifyRelationSource.cs
+++ b/src/FlowtideDotNet.Connector.Permify/Internal/PermifyRelationSource.cs
@@ -159,7 +159,7 @@ namespace FlowtideDotNet.Connector.Permify.Internal
                         _state.WatchSnapToken = _watchStream.ResponseStream.Current.Changes.SnapToken;
                         if (outData.Count > 0)
                         {
-                            await output.SendAsync(new StreamEventBatch(outData));
+                            await output.SendAsync(new StreamEventBatch(outData, _readRelation.OutputLength));
                             await output.SendWatermark(GetWatermark(_state.WatchSnapToken));
                             ScheduleCheckpoint(TimeSpan.FromMilliseconds(1));
                         }
@@ -229,7 +229,7 @@ namespace FlowtideDotNet.Connector.Permify.Internal
                         var rowEvent = _rowEncoder.Encode(tuple, 1);
                         outData.Add(rowEvent);
                     }
-                    await output.SendAsync(new StreamEventBatch(outData));
+                    await output.SendAsync(new StreamEventBatch(outData, _readRelation.OutputLength));
 
                     if (string.IsNullOrEmpty(readResponse.ContinuousToken))
                     {

--- a/src/FlowtideDotNet.Connector.Sharepoint/Internal/SharepointSource.cs
+++ b/src/FlowtideDotNet.Connector.Sharepoint/Internal/SharepointSource.cs
@@ -173,7 +173,7 @@ namespace FlowtideDotNet.Connector.Sharepoint.Internal
                     outputData.Add(new RowEvent(weight, 0, new ArrayRowData(data)));
                 }
                 _state.ODataNextUrl = page.OdataDeltaLink;
-                await output.SendAsync(new StreamEventBatch(outputData));
+                await output.SendAsync(new StreamEventBatch(outputData, readRelation.OutputLength));
             }
             return calledDecodersNewBatch;
         }

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerDataSource.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerDataSource.cs
@@ -166,7 +166,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
                 _eventsCounter.Add(result.Count);
                 _eventsProcessed.Add(result.Count);
                 Logger.ChangesFoundInTable(result.Count, _tableName, StreamName, Name);
-                await output.SendAsync(new StreamEventBatch(result));
+                await output.SendAsync(new StreamEventBatch(result, readRelation.OutputLength));
                 await output.SendWatermark(new FlowtideDotNet.Base.Watermark(_tableName, _state.ChangeTrackingVersion));
                 this.ScheduleCheckpoint(TimeSpan.FromSeconds(1));
             }
@@ -301,7 +301,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
                             {
                                 _eventsCounter.Add(outdata.Count);
                                 _eventsProcessed.Add(outdata.Count);
-                                await output.SendAsync(new StreamEventBatch(outdata));
+                                await output.SendAsync(new StreamEventBatch(outdata, readRelation.OutputLength));
                                 outdata = new List<RowEvent>();
                             }
                         }
@@ -309,7 +309,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
                         {
                             _eventsCounter.Add(outdata.Count);
                             _eventsProcessed.Add(outdata.Count);
-                            await output.SendAsync(new StreamEventBatch(outdata));
+                            await output.SendAsync(new StreamEventBatch(outdata, readRelation.OutputLength));
                         }
                         retryCount = 0;
                         SetHealth(true);

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -460,7 +460,7 @@ namespace FlowtideDotNet.Core.ColumnStore
             }
         }
 
-        public (int, int) SearchBoundries<T>(in T value, in int start, in int end, in ReferenceSegment? child)
+        public (int, int) SearchBoundries<T>(in T value, in int start, in int end, in ReferenceSegment? child, bool desc = false)
             where T : IDataValue
         {
             if (_type == value.Type)
@@ -476,13 +476,21 @@ namespace FlowtideDotNet.Core.ColumnStore
                 // TODO: Check if there is any null values, if so null bitmap must be passed in.
                 if (_nullCounter > 0)
                 {
-                    return BoundarySearch.SearchBoundriesForDataColumn(in _dataColumn!, in value, in start, end, child, _validityList);
+                    if (!desc)
+                    {
+                        return BoundarySearch.SearchBoundriesForDataColumn(in _dataColumn!, in value, in start, end, child, _validityList);
+                    }
+                    else
+                    {
+                        return BoundarySearch.SearchBoundriesForDataColumnDesc(in _dataColumn!, in value, in start, end, child, _validityList);
+                    }
+                    
                 }
-                return _dataColumn!.SearchBoundries(in value, in start, in end, child);
+                return _dataColumn!.SearchBoundries(in value, in start, in end, child, desc);
             }
             else if (_type == ArrowTypeId.Union)
             {
-                return _dataColumn!.SearchBoundries(in value, in start, in end, child);
+                return _dataColumn!.SearchBoundries(in value, in start, in end, child, desc);
             }
             else if (_type == ArrowTypeId.Null)
             {
@@ -496,11 +504,18 @@ namespace FlowtideDotNet.Core.ColumnStore
                 {
                     return BoundarySearch.SearchBoundriesForDataColumn(in _dataColumn!, in value, in start, end, child, _validityList);
                 }
-                return _dataColumn!.SearchBoundries(in value, in start, in end, child);
+                return _dataColumn!.SearchBoundries(in value, in start, in end, child, desc);
             }
             else if (_nullCounter > 0 && value.Type == ArrowTypeId.Null)
             {
-                return BoundarySearch.SearchBoundriesForDataColumn(in _dataColumn!, in value, in start, end, child, _validityList);
+                if (!desc)
+                {
+                    return BoundarySearch.SearchBoundriesForDataColumn(in _dataColumn!, in value, in start, end, child, _validityList);
+                }
+                else
+                {
+                    return BoundarySearch.SearchBoundriesForDataColumnDesc(in _dataColumn!, in value, in start, end, child, _validityList);
+                }
             }
             else
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnReference.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnReference.cs
@@ -1,0 +1,32 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.ColumnStore
+{
+    public struct ColumnReference
+    {
+        public IColumn column;
+        public int index;
+
+        public ColumnReference(IColumn column, int index)
+        {
+            this.column = column;
+            this.index = index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -125,7 +125,7 @@ namespace FlowtideDotNet.Core.ColumnStore
             innerColumn.Return();
         }
 
-        public (int, int) SearchBoundries<T>(in T value, in int start, in int end, in ReferenceSegment? child) where T : IDataValue
+        public (int, int) SearchBoundries<T>(in T value, in int start, in int end, in ReferenceSegment? child, bool desc = false) where T : IDataValue
         {
             throw new NotSupportedException("Column with offset does not SearchBoundries.");
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/Comparers/BoolComparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Comparers/BoolComparer.cs
@@ -27,4 +27,14 @@ namespace FlowtideDotNet.Core.ColumnStore.Comparers
             return x.CompareTo(y);
         }
     }
+
+    internal class BoolComparerDesc : IColumnComparer<bool>
+    {
+        internal static readonly BoolComparerDesc Instance = new BoolComparerDesc();
+
+        public int Compare(in bool x, in bool y)
+        {
+            return y.CompareTo(x);
+        }
+    }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Comparers/DecimalComparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Comparers/DecimalComparer.cs
@@ -26,4 +26,13 @@ namespace FlowtideDotNet.Core.ColumnStore.Comparers
             return x.CompareTo(y);
         }
     }
+
+    internal class DecimalComparerDesc : IColumnComparer<decimal>
+    {
+        internal static readonly DecimalComparerDesc Instance = new DecimalComparerDesc();
+        public int Compare(in decimal x, in decimal y)
+        {
+            return y.CompareTo(x);
+        }
+    }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Comparers/DoubleComparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Comparers/DoubleComparer.cs
@@ -27,4 +27,14 @@ namespace FlowtideDotNet.Core.ColumnStore.Comparers
             return x.CompareTo(y);
         }
     }
+
+    internal class DoubleComparerDesc : IColumnComparer<double>
+    {
+        internal static readonly DoubleComparerDesc Instance = new DoubleComparerDesc();
+
+        public int Compare(in double x, in double y)
+        {
+            return y.CompareTo(x);
+        }
+    }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Comparers/Int64Comparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Comparers/Int64Comparer.cs
@@ -27,4 +27,14 @@ namespace FlowtideDotNet.Core.ColumnStore.Comparers
             return x.CompareTo(y);
         }
     }
+
+    internal class Int64ComparerDesc : IColumnComparer<long>
+    {
+        internal static readonly Int64ComparerDesc Instance = new Int64ComparerDesc();
+
+        public int Compare(in long x, in long y)
+        {
+            return y.CompareTo(x);
+        }
+    }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Comparers/SpanByteComparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Comparers/SpanByteComparer.cs
@@ -27,4 +27,13 @@ namespace FlowtideDotNet.Core.ColumnStore.Comparers
             return x.SequenceCompareTo(y);
         }
     }
+
+    internal class SpanByteComparerDesc : ISpanByteComparer
+    {
+        public static readonly SpanByteComparerDesc Instance = new SpanByteComparerDesc();
+        public int Compare(in ReadOnlySpan<byte> x, in ReadOnlySpan<byte> y)
+        {
+            return y.SequenceCompareTo(x);
+        }
+    }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -114,8 +114,12 @@ namespace FlowtideDotNet.Core.ColumnStore
             _data.RemoveAt(index);
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child) where T : IDataValue
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc) where T : IDataValue
         {
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundries(_data, dataValue.AsBinary, start, end, SpanByteComparerDesc.Instance);
+            }
             return BoundarySearch.SearchBoundries(_data, dataValue.AsBinary, start, end, SpanByteComparer.Instance);
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -156,5 +156,20 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return ArrowTypeId.Binary;
         }
+
+        public void Clear()
+        {
+            _data.Clear();
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            throw new NotImplementedException();
+        }
+
+        public int EndNewList()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -194,5 +194,20 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return ArrowTypeId.Boolean;
         }
+
+        public void Clear()
+        {
+            _data.Clear();
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            throw new NotImplementedException();
+        }
+
+        public int EndNewList()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -108,10 +108,14 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataValueContainer._boolValue = new BoolValue(_data.Get(index));
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child)
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc)
             where T : IDataValue
         {
             var val = dataValue.AsBool;
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundries<bool>(_data, val, start, end, BoolComparerDesc.Instance);
+            }
             return BoundarySearch.SearchBoundries<bool>(_data, val, start, end, BoolComparer.Instance);
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -103,9 +103,13 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataValueContainer._decimalValue = new DecimalValue(_values[index]);
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child) 
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc) 
             where T : IDataValue
         {
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundries(_values, dataValue.AsDecimal, start, end, DecimalComparerDesc.Instance);
+            }
             return BoundarySearch.SearchBoundries(_values, dataValue.AsDecimal, start, end, DecimalComparer.Instance);
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -166,5 +166,20 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return ArrowTypeId.Decimal128;
         }
+
+        public void Clear()
+        {
+            _values.Clear();
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            throw new NotImplementedException();
+        }
+
+        public int EndNewList()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -168,5 +168,20 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return ArrowTypeId.Double;
         }
+
+        public void Clear()
+        {
+            _data.Clear();
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            throw new NotImplementedException();
+        }
+
+        public int EndNewList()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -102,10 +102,14 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataValueContainer._doubleValue = new DoubleValue(_data[index]);
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child) 
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc) 
             where T : IDataValue
         {
             var val = dataValue.AsDouble;
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundries<double>(_data, val, start, end, DoubleComparerDesc.Instance);
+            }
             return BoundarySearch.SearchBoundries<double>(_data, val, start, end, DoubleComparer.Instance);
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
@@ -54,5 +54,11 @@ namespace FlowtideDotNet.Core.ColumnStore
         (IArrowArray, IArrowType) ToArrowArray(ArrowBuffer nullBuffer, int nullCount);
 
         ArrowTypeId GetTypeAt(in int index, in ReferenceSegment? child);
+
+        void Clear();
+
+        void AddToNewList<T>(in T value) where T : IDataValue;
+
+        int EndNewList();
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
@@ -43,7 +43,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         int Update<T>(in int index, in T value)
             where T: IDataValue;
 
-        (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child)
+        (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc)
             where T : IDataValue;
 
         void RemoveAt(in int index);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -205,5 +205,21 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return ArrowTypeId.Int64;
         }
+
+        public void Clear()
+        {
+            Debug.Assert(_data != null);
+            _data.Clear();
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            throw new NotImplementedException();
+        }
+
+        public int EndNewList()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -124,11 +124,15 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataValueContainer._int64Value = new Int64Value(_data.GetRef(index));
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child)
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc)
             where T: IDataValue
         {
             Debug.Assert(_data != null);
             var val = dataValue.AsLong;
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundries(_data, val, start, end, Int64ComparerDesc.Instance);
+            }
             return BoundarySearch.SearchBoundries(_data, val, start, end, Int64Comparer.Instance);
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -20,6 +20,7 @@ using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Substrait.Expressions;
 using System;
 using System.Buffers;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -29,7 +30,7 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.ColumnStore
 {
-    internal class Int64Column : IDataColumn
+    internal class Int64Column : IDataColumn, IEnumerable<long>
     {
         //private List<long> _data;
         private NativeLongList? _data;
@@ -224,6 +225,26 @@ namespace FlowtideDotNet.Core.ColumnStore
         public int EndNewList()
         {
             throw new NotImplementedException();
+        }
+
+        private IEnumerable<long> GetEnumerable()
+        {
+            Debug.Assert(_data != null);
+
+            for (int i = 0; i < _data.Count; i++)
+            {
+                yield return _data.Get(i);
+            }
+        }
+
+        public IEnumerator<long> GetEnumerator()
+        {
+            return GetEnumerable().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerable().GetEnumerator();
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
@@ -101,6 +101,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                 }
                 return -1;
             }
+            else if (value.Type == ArrowTypeId.Null)
+            {
+                return 1;
+            }
             var otherList = value.AsList;
             
             var startOffset = _offsets.Get(index);
@@ -135,9 +139,13 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataValueContainer._type = ArrowTypeId.List;
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child) 
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc) 
             where T : IDataValue
         {
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundriesForDataColumnDesc(this, in dataValue, start, end, child, default);
+            }
             return BoundarySearch.SearchBoundriesForDataColumn(this, in dataValue, start, end, child, default);
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
@@ -23,6 +23,7 @@ using FlowtideDotNet.Substrait.Expressions;
 using System.Buffers;
 using FlowtideDotNet.Core.ColumnStore.Serialization;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using static Substrait.Protobuf.Expression.Types.Literal.Types;
 
 namespace FlowtideDotNet.Core.ColumnStore
 {
@@ -261,6 +262,35 @@ namespace FlowtideDotNet.Core.ColumnStore
         public ArrowTypeId GetTypeAt(in int index, in ReferenceSegment? child)
         {
             return ArrowTypeId.List;
+        }
+
+        public void Clear()
+        {
+            _offsets.Clear();
+            _offsets.Add(0);
+            _internalColumn.Clear();
+        }
+
+        /// <summary>
+        /// Allows adding values to a new list directly without creating a list value type.
+        /// This allows for more efficient list creation.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            _internalColumn.Add(value);
+        }
+
+        /// <summary>
+        /// Signals an end to a list created with AddToNewList.
+        /// </summary>
+        /// <returns></returns>
+        public int EndNewList()
+        {
+            var currentOffset = _offsets.Count - 1;
+            _offsets.Add(_internalColumn.Count);
+            return currentOffset;
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -199,6 +199,35 @@ namespace FlowtideDotNet.Core.ColumnStore
                     }
                     return 0;
                 }
+                else if (map is MapValue mapValue)
+                {
+                    var length = endOffset - startOffset;
+                    var otherLength = mapValue.GetLength();
+
+                    if (length != otherLength)
+                    {
+                        return length - otherLength;
+                    }
+
+                    var dataValueContainer = new DataValueContainer();
+                    for (int i = 0; i < length; i++)
+                    {
+                        mapValue.GetKeyAt(i, dataValueContainer);   
+                        var keyCompareVal = _keyColumn.CompareTo(startOffset + i, dataValueContainer, default);
+                        if (keyCompareVal != 0)
+                        {
+                            return keyCompareVal;
+                        }
+                        //var valueVal = _valueColumn.GetValueAt(startOffset + i, default);
+                        mapValue.GetValueAt(i, dataValueContainer);
+                        var valueCompareVal = _valueColumn.CompareTo(startOffset + i, dataValueContainer, default);
+                        if (valueCompareVal != 0)
+                        {
+                            return valueCompareVal;
+                        }
+                    }
+                    return 0;
+                }
                 else
                 {
                     throw new NotImplementedException();
@@ -379,6 +408,24 @@ namespace FlowtideDotNet.Core.ColumnStore
         public ArrowTypeId GetTypeAt(in int index, in ReferenceSegment? child)
         {
             return ArrowTypeId.Map;
+        }
+
+        public void Clear()
+        {
+            _offsets.Clear();
+            _offsets.Add(0);
+            _keyColumn.Clear();
+            _valueColumn.Clear();
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            throw new NotImplementedException();
+        }
+
+        public int EndNewList()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -146,6 +146,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                 }
                 return -1;
             }
+            else if (value.Type == ArrowTypeId.Null)
+            {
+                return 1;
+            }
             if (child != null)
             {
                 if (child is MapKeyReferenceSegment mapKeyReferenceSegment)
@@ -320,10 +324,14 @@ namespace FlowtideDotNet.Core.ColumnStore
             return index;
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child) 
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc) 
             where T : IDataValue
         {
-            return BoundarySearch.SearchBoundriesForMapColumn(this, dataValue, start, end, child, default);
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundriesForDataColumnDesc(this, dataValue, start, end, child, default);
+            }
+            return BoundarySearch.SearchBoundriesForDataColumn(this, dataValue, start, end, child, default);
         }
 
         public void RemoveAt(in int index)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
@@ -46,7 +46,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
         public int CompareTo<T>(in int index, in T value, in ReferenceSegment? child, in BitmapList? validityList) where T : IDataValue
         {
-            throw new NotImplementedException();
+            return 0;
         }
 
         public int CompareTo(in IDataColumn otherColumn, in int thisIndex, in int otherIndex)
@@ -74,7 +74,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             _count--;
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child) where T : IDataValue
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc) where T : IDataValue
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
@@ -98,5 +98,20 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
             return ArrowTypeId.Null;
         }
+
+        public void Clear()
+        {
+            _count = 0;
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            throw new NotImplementedException();
+        }
+
+        public int EndNewList()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -29,7 +29,6 @@ namespace FlowtideDotNet.Core.ColumnStore
 {
     public class StringColumn : IDataColumn, IEnumerable<string>
     {
-        private static SpanByteComparer s_spanByteComparer = new SpanByteComparer();
         private BinaryList _binaryList;
         private bool disposedValue;
 
@@ -74,14 +73,14 @@ namespace FlowtideDotNet.Core.ColumnStore
             {
                 return 1;
             }
-            return s_spanByteComparer.Compare(_binaryList.Get(index), value.AsString.Span);
+            return SpanByteComparer.Instance.Compare(_binaryList.Get(index), value.AsString.Span);
         }
 
         public int CompareTo(in IDataColumn otherColumn, in int thisIndex, in int otherIndex)
         {
             if (otherColumn is StringColumn stringColumn)
             {
-                return s_spanByteComparer.Compare(_binaryList.Get(thisIndex), stringColumn._binaryList.Get(otherIndex));
+                return SpanByteComparer.Instance.Compare(_binaryList.Get(thisIndex), stringColumn._binaryList.Get(otherIndex));
             }
             throw new NotImplementedException();
         }
@@ -117,9 +116,17 @@ namespace FlowtideDotNet.Core.ColumnStore
             _binaryList.RemoveAt(index);
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child) where T : IDataValue
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc) where T : IDataValue
         {
-            return BoundarySearch.SearchBoundries(_binaryList, dataValue.AsString.Span, start, end, s_spanByteComparer);
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundries(_binaryList, dataValue.AsString.Span, start, end, SpanByteComparerDesc.Instance);
+            }
+            else
+            {
+                return BoundarySearch.SearchBoundries(_binaryList, dataValue.AsString.Span, start, end, SpanByteComparer.Instance);
+            }
+            
         }
 
         public (IArrowArray, IArrowType) ToArrowArray(ArrowBuffer nullBuffer, int nullCount)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -176,5 +176,20 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return ArrowTypeId.String;
         }
+
+        public void Clear()
+        {
+            _binaryList.Clear();
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            throw new NotImplementedException();
+        }
+
+        public int EndNewList()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -162,8 +162,8 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
         public int CompareTo<T>(in int index, in T value, in ReferenceSegment? child, in BitmapList? validityList) where T : IDataValue
         {
-            var type = _typeList[index];
-
+            var typeIndex = _typeList[index];
+            var type = (sbyte)_valueColumns[typeIndex].Type;
             if (type == (sbyte)value.Type)
             {
                 var valueColumnIndex = _typeIds[(byte)type];
@@ -226,9 +226,13 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             valueColumn.GetValueAt(_offsets.Get(index), dataValueContainer, child);
         }
 
-        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child) where T : IDataValue
+        public (int, int) SearchBoundries<T>(in T dataValue, in int start, in int end, in ReferenceSegment? child, bool desc) where T : IDataValue
         {
-            return BoundarySearch.SearchBoundriesForColumn(this, in dataValue, in start, in end);
+            if (desc)
+            {
+                return BoundarySearch.SearchBoundriesForDataColumnDesc(this, in dataValue, in start, in end, child, default);
+            }
+            return BoundarySearch.SearchBoundriesForDataColumn(this, in dataValue, in start, in end, child, default);
         }
 
         public int Update<T>(in int index, in T value) where T : IDataValue

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -330,5 +330,36 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             }
             return _valueColumns[valueColumnIndex].GetTypeAt(_offsets.Get(index), child);
         }
+
+        public void Clear()
+        {
+            _typeList.Clear();
+            _offsets.Clear();
+            for (int i = 0; i < _valueColumns.Count; i++)
+            {
+                _valueColumns[i].Clear();
+            }
+        }
+
+        public void AddToNewList<T>(in T value) where T : IDataValue
+        {
+            CheckArrayExist(ArrowTypeId.List);
+
+            var typeByte = (byte)ArrowTypeId.List;
+            var arrayIndex = _typeIds[typeByte];
+            _valueColumns[arrayIndex].AddToNewList(in value);
+        }
+
+        public int EndNewList()
+        {
+            CheckArrayExist(ArrowTypeId.List);
+            var typeByte = (byte)ArrowTypeId.List;
+            var arrayIndex = _typeIds[typeByte];
+            var offset = _valueColumns[arrayIndex].EndNewList();
+            int index = _typeList.Count;
+            _typeList.InsertAt(index, arrayIndex);
+            _offsets.InsertAt(index, offset);
+            return index;
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
@@ -51,7 +51,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         int CompareTo(in IColumn otherColumn, in int thisIndex, in int otherIndex);
 
-        (int, int) SearchBoundries<T>(in T value, in int start, in int end, in ReferenceSegment? child)
+        (int, int) SearchBoundries<T>(in T value, in int start, in int end, in ReferenceSegment? child, bool desc = false)
             where T : IDataValue;
 
         (IArrowArray, IArrowType) ToArrowArray();

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnRowReference.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnRowReference.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
 {
-    internal struct ColumnRowReference
+    public struct ColumnRowReference
     {
         public int RowIndex;
         public EventBatchData referenceBatch;

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
@@ -293,5 +293,12 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
+
+        public void Clear()
+        {
+            _offsets.Clear();
+            _offsets.Add(0);
+            _length = 0;
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
@@ -400,5 +400,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
+
+        public void Clear()
+        {
+            _length = 0;
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
@@ -202,5 +202,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
+
+        public void Clear()
+        {
+            _length = 0;
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/NativeLongList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/NativeLongList.cs
@@ -294,5 +294,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
+
+        public void Clear()
+        {
+            _length = 0;
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/PrimitiveList.cs
@@ -216,5 +216,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                 Dispose();
             }
         }
+
+        public void Clear()
+        {
+            _length = 0;
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ColumnAggregateFunctionDefinition.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ColumnAggregateFunctionDefinition.cs
@@ -1,0 +1,143 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlexBuffers;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Substrait.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using static FlowtideDotNet.Core.Compute.IFunctionsRegister;
+
+namespace FlowtideDotNet.Core.Compute.Columnar
+{
+    internal abstract class ColumnAggregateFunctionDefinition 
+    {
+        public abstract Task<IColumnAggregateContainer> CreateContainer(
+            int groupingLength,
+            IStateManagerClient stateManagerClient,
+            AggregateFunction aggregateFunction,
+            ColumnParameterInfo parametersInfo,
+            ColumnarExpressionVisitor visitor,
+            ParameterExpression eventBatchParameter,
+            ParameterExpression indexParameter,
+            ParameterExpression stateParameter,
+            ParameterExpression weightParameter,
+            ParameterExpression groupingKeyParameter);
+    }
+
+    internal abstract class StatefulColumnAggregateContainer : IColumnAggregateContainer
+    {
+        public abstract Task Commit();
+        public abstract ValueTask Compute(ColumnRowReference key, EventBatchData rowBatch, int rowIndex, ColumnReference state, long weight);
+        public abstract void Disponse();
+        public abstract ValueTask GetValue(ColumnRowReference key, ColumnReference state, Column outputColumn);
+    }
+
+    internal class StatefulColumnAggregateContainer<T> : StatefulColumnAggregateContainer
+    {
+        private readonly Action<T> disposeFunction;
+        private readonly Func<T, Task> commitFunction;
+        private readonly ColumnAggregateStateToValueFunction<T> stateToValueFunc;
+
+        public StatefulColumnAggregateContainer(
+            T singleton,
+            Func<EventBatchData, int, ColumnReference, long, T, ColumnRowReference, ValueTask> mapFunction,
+            Action<T> disposeFunction,
+            Func<T, Task> commitFunction,
+            ColumnAggregateStateToValueFunction<T> stateToValueFunc)
+        {
+            Singleton = singleton;
+            MapFunction = mapFunction;
+            this.disposeFunction = disposeFunction;
+            this.commitFunction = commitFunction;
+            this.stateToValueFunc = stateToValueFunc;
+        }
+
+        public T Singleton { get; }
+        public Func<EventBatchData, int, ColumnReference, long, T, ColumnRowReference, ValueTask> MapFunction { get; }
+
+        public override Task Commit()
+        {
+            return commitFunction(Singleton);
+        }
+
+        public override ValueTask Compute(ColumnRowReference key, EventBatchData rowBatch, int rowIndex, ColumnReference state, long weight)
+        {
+            return MapFunction(rowBatch, rowIndex, state, weight, Singleton, key);
+        }
+
+        public override void Disponse()
+        {
+            disposeFunction(Singleton);
+        }
+
+        public override ValueTask GetValue(ColumnRowReference key, ColumnReference state, Column outputColumn)
+        {
+            return stateToValueFunc(state, key, Singleton, outputColumn);
+        }
+    }
+
+    internal class StatefulColumnAggregateFunctionDefinition<T> : ColumnAggregateFunctionDefinition
+    {
+        public StatefulColumnAggregateFunctionDefinition(
+            AggregateInitializeFunction<T> initializeFunction,
+            Action<T> disposeFunction,
+            Func<T, Task> commitFunction,
+            ColumnAggregateMapFunction mapFunc,
+            ColumnAggregateStateToValueFunction<T> stateToValueFunc)
+        {
+            InitializeFunction = initializeFunction;
+            DisposeFunction = disposeFunction;
+            CommitFunction = commitFunction;
+            MapFunc = mapFunc;
+            StateToValueFunc = stateToValueFunc;
+        }
+
+        public AggregateInitializeFunction<T> InitializeFunction { get; }
+
+        public Action<T> DisposeFunction { get; }
+        public Func<T, Task> CommitFunction { get; }
+        public ColumnAggregateMapFunction MapFunc { get; }
+
+        public ColumnAggregateStateToValueFunction<T> StateToValueFunc { get; }
+
+        public override async Task<IColumnAggregateContainer> CreateContainer(
+            int groupingLength,
+            IStateManagerClient stateManagerClient,
+            AggregateFunction aggregateFunction,
+            ColumnParameterInfo parametersInfo,
+            ColumnarExpressionVisitor visitor,
+            ParameterExpression eventBatchParameter,
+            ParameterExpression indexParameter,
+            ParameterExpression stateParameter,
+            ParameterExpression weightParameter,
+            ParameterExpression groupingKeyParameter)
+        {
+            var singleton = await InitializeFunction(groupingLength, stateManagerClient);
+
+            var singletonParameter = System.Linq.Expressions.Expression.Parameter(typeof(T));
+            var mapResult = MapFunc(aggregateFunction, parametersInfo, visitor, stateParameter, weightParameter, singletonParameter, groupingKeyParameter);
+            var lambda = System.Linq.Expressions.Expression.Lambda<Func<EventBatchData, int, ColumnReference, long, T, ColumnRowReference, ValueTask>>(mapResult, eventBatchParameter, indexParameter, stateParameter, weightParameter, singletonParameter, groupingKeyParameter);
+            var compiled = lambda.Compile();
+
+            var container = new StatefulColumnAggregateContainer<T>(singleton, compiled, DisposeFunction, CommitFunction, StateToValueFunc);
+            return container;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ColumnStreamingAggregateContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ColumnStreamingAggregateContainer.cs
@@ -1,0 +1,104 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.ColumnStore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static FlowtideDotNet.Core.Compute.IFunctionsRegister;
+using FlexBuffers;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Substrait.Expressions;
+using System.Linq.Expressions;
+
+namespace FlowtideDotNet.Core.Compute.Columnar
+{
+    internal class ColumnStreamingAggregateContainer : IColumnAggregateContainer
+    {
+        private readonly Action<EventBatchData, int, ColumnReference, long> mapFunction;
+        private readonly Action<ColumnReference, Column> stateToValueFunc;
+
+        public ColumnStreamingAggregateContainer(
+            Action<EventBatchData, int, ColumnReference, long> mapFunction,
+            Action<ColumnReference, ColumnStore.Column> stateToValueFunc
+            )
+        {
+            this.mapFunction = mapFunction;
+            this.stateToValueFunc = stateToValueFunc;
+        }
+        public Task Commit()
+        {
+            return Task.CompletedTask;
+        }
+
+        public ValueTask Compute(ColumnRowReference key, EventBatchData rowBatch, int rowIndex, ColumnReference state, long weight)
+        {
+            mapFunction(rowBatch, rowIndex, state, weight);
+            return ValueTask.CompletedTask;
+        }
+
+        public void Disponse()
+        {
+        }
+
+        public ValueTask GetValue(ColumnRowReference key, ColumnReference state, Column outputColumn)
+        {
+            stateToValueFunc(state, outputColumn);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    internal class ColumnStreamingAggregateFunctionDefinition : ColumnAggregateFunctionDefinition
+    {
+        public ColumnStreamingAggregateFunctionDefinition(
+            string uri,
+            string name,
+            Func<AggregateFunction, ColumnParameterInfo, ColumnarExpressionVisitor, ParameterExpression, ParameterExpression, System.Linq.Expressions.Expression> updateStateFunc,
+            Action<ColumnReference, ColumnStore.Column> stateToValueFunc)
+        {
+            Uri = uri;
+            Name = name;
+            UpdateStateFunc = updateStateFunc;
+            StateToValueFunc = stateToValueFunc;
+        }
+
+        public string Uri { get; }
+
+        public string Name { get; }
+
+        public Action<ColumnReference, ColumnStore.Column> StateToValueFunc { get; }
+
+        public Func<AggregateFunction, ColumnParameterInfo, ColumnarExpressionVisitor, ParameterExpression, ParameterExpression, System.Linq.Expressions.Expression> UpdateStateFunc { get; }
+
+        public override Task<IColumnAggregateContainer> CreateContainer(
+            int groupingLength, 
+            IStateManagerClient stateManagerClient, 
+            AggregateFunction aggregateFunction, 
+            ColumnParameterInfo parametersInfo, 
+            ColumnarExpressionVisitor visitor, 
+            ParameterExpression eventBatchParameter, 
+            ParameterExpression indexParameter, 
+            ParameterExpression stateParameter, 
+            ParameterExpression weightParameter, 
+            ParameterExpression groupingKeyParameter)
+        {
+            var mapFunc = UpdateStateFunc(aggregateFunction, parametersInfo, visitor, stateParameter, weightParameter);
+            var lambda = System.Linq.Expressions.Expression.Lambda<Action<EventBatchData, int, ColumnReference, long>>(mapFunc, eventBatchParameter, indexParameter, stateParameter, weightParameter);
+            var compiled = lambda.Compile();
+            return Task.FromResult<IColumnAggregateContainer>(new ColumnStreamingAggregateContainer(compiled, StateToValueFunc));
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ColumnarExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ColumnarExpressionVisitor.cs
@@ -30,7 +30,7 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.Compute.Columnar
 {
-    internal class ColumnarExpressionVisitor : ExpressionVisitor<System.Linq.Expressions.Expression, ColumnParameterInfo>
+    public class ColumnarExpressionVisitor : ExpressionVisitor<System.Linq.Expressions.Expression, ColumnParameterInfo>
     {
         private readonly IFunctionsRegister functionsRegister;
 

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BuiltInStringFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BuiltInStringFunctions.cs
@@ -1,0 +1,29 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.StringAgg;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions
+{
+    internal static class BuiltInStringFunctions
+    {
+        public static void RegisterFunctions(IFunctionsRegister functionsRegister)
+        {
+            ColumnStringAggAggregation.Register(functionsRegister);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ColumnListAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ColumnListAggAggregation.cs
@@ -1,0 +1,223 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlexBuffers;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.ListAgg;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Core.Compute.Internal.StatefulAggregations;
+using FlowtideDotNet.Core.Storage;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.FunctionExtensions;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
+{
+    internal class ColumnListAggAggregationSingleton
+    {
+        private readonly int keyLength;
+        public readonly DataValueContainer dataValueContainer;
+        public readonly IBPlusTreeIterator<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> iterator;
+
+        public ColumnListAggAggregationSingleton(IBPlusTree<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> tree, int keyLength)
+        {
+            Tree = tree;
+            this.keyLength = keyLength;
+            SearchComparer = new ListAggSearchComparer(keyLength);
+            dataValueContainer = new DataValueContainer();
+            iterator = tree.CreateIterator();
+        }
+        public int KeyLength => keyLength;
+        public ListAggSearchComparer SearchComparer { get; }
+        public IBPlusTree<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> Tree { get; }
+    }
+
+    internal class ColumnListAggAggregation
+    {
+        private static async Task<ColumnListAggAggregationSingleton> Initialize(int groupingLength, IStateManagerClient stateManagerClient)
+        {
+            List<int> insertPrimaryKeys = new List<int>();
+            for (int i = 0; i < groupingLength + 1; i++)
+            {
+                insertPrimaryKeys.Add(i);
+            }
+            List<int> searchPrimaryKeys = new List<int>();
+            for (int i = 0; i < groupingLength; i++)
+            {
+                searchPrimaryKeys.Add(i);
+            }
+            var tree = await stateManagerClient.GetOrCreateTree("listaggtree",
+                new FlowtideDotNet.Storage.Tree.BPlusTreeOptions<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>>()
+                {
+                    Comparer = new ListAggInsertComparer(groupingLength),
+                    KeySerializer = new ListAggKeyStorageSerializer(groupingLength),
+                    ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                });
+
+            return new ColumnListAggAggregationSingleton(tree, groupingLength);
+        }
+
+        private static System.Linq.Expressions.Expression ListAggMapFunction(
+           Substrait.Expressions.AggregateFunction function,
+           ColumnParameterInfo parametersInfo,
+           ColumnarExpressionVisitor visitor,
+           ParameterExpression stateParameter,
+           ParameterExpression weightParameter,
+           ParameterExpression singletonAccess,
+           ParameterExpression groupingKeyParameter)
+        {
+            if (function.Arguments.Count != 1)
+            {
+                throw new InvalidOperationException("List_agg must have one argument.");
+            }
+            var arg = visitor.Visit(function.Arguments[0], parametersInfo);
+            
+            var expr = GetListAggBody(arg.Type);
+            var body = expr.Body;
+            var replacer = new ParameterReplacerVisitor(expr.Parameters[0], arg!);
+            System.Linq.Expressions.Expression e = replacer.Visit(body);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[1], stateParameter);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[2], weightParameter);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[3], singletonAccess);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[4], groupingKeyParameter);
+            e = replacer.Visit(e);
+            return e;
+        }
+
+        //private static Expression<Func<IDataValue, ColumnReference, long, ColumnListAggAggregationSingleton, ColumnRowReference, ValueTask>> GetListAggBody()
+        //{
+        //    return (ev, state, weight, singleton, groupingKey) => DoListAgg(ev, state, weight, singleton, groupingKey);
+        //}
+
+        private static System.Linq.Expressions.LambdaExpression GetListAggBody(System.Type inputType)
+        {
+            var methodInfo = typeof(ColumnListAggAggregation).GetMethod(nameof(DoListAgg), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!.MakeGenericMethod(inputType);
+            
+            var ev = System.Linq.Expressions.Expression.Parameter(inputType, "ev");
+            var state = System.Linq.Expressions.Expression.Parameter(typeof(ColumnReference), "state");
+            var weight = System.Linq.Expressions.Expression.Parameter(typeof(long), "weight");
+            var singleton = System.Linq.Expressions.Expression.Parameter(typeof(ColumnListAggAggregationSingleton), "singleton");
+            var groupingKey = System.Linq.Expressions.Expression.Parameter(typeof(ColumnRowReference), "groupingKey");
+
+            var call = System.Linq.Expressions.Expression.Call(methodInfo, ev, state, weight, singleton, groupingKey);
+            return System.Linq.Expressions.Expression.Lambda(call, ev, state, weight, singleton, groupingKey);
+        }
+
+        private static async ValueTask DoListAgg<T>(T column, ColumnReference currentState, long weight, ColumnListAggAggregationSingleton singleton, ColumnRowReference groupingKey)
+            where T : IDataValue
+        {
+            if (column.IsNull)
+            {
+                return;
+            }
+
+            var columnRowRef = new ListAggColumnRowReference()
+            {
+                batch = groupingKey.referenceBatch,
+                index = groupingKey.RowIndex,
+                insertValue = column
+            };
+            await singleton.Tree.RMW(columnRowRef, (int)weight, (input, current, exists) =>
+            {
+                if (exists)
+                {
+                    current += input;
+
+                    if (current == 0)
+                    {
+                        return (0, GenericWriteOperation.Delete);
+                    }
+                    return (current, GenericWriteOperation.Upsert);
+                }
+                return (input, GenericWriteOperation.Upsert);
+            });
+
+            return;
+        }
+
+        private static async ValueTask ListAggGetValue(ColumnReference state, ColumnRowReference groupingKey, ColumnListAggAggregationSingleton singleton, ColumnStore.Column outputColumn)
+        {
+            var rowReference = new ListAggColumnRowReference()
+            {
+                batch = groupingKey.referenceBatch,
+                index = groupingKey.RowIndex
+            };
+
+            var iterator = singleton.iterator;
+            await iterator.Seek(rowReference, singleton.SearchComparer);
+
+            if (!singleton.SearchComparer.noMatch)
+            {
+                bool firstPage = true;
+                await foreach(var page in iterator)
+                {
+                    if (!firstPage)
+                    {
+                        var index = singleton.SearchComparer.FindIndex(in rowReference, page.Keys!);
+                        if (singleton.SearchComparer.noMatch)
+                        {
+                            break;
+                        }
+                    }
+                    firstPage = false;
+
+                    // Iterate over all the values
+                    for (int i = singleton.SearchComparer.start; i <= singleton.SearchComparer.end; i++)
+                    {
+                        page.Keys._data.GetColumn(singleton.KeyLength).GetValueAt(i, singleton.dataValueContainer, default);
+                        var weight = page.Values.Get(i);
+
+                        // Add an item for each weight
+                        for (int k = 0; k < weight; k++)
+                        {
+                            outputColumn.AddToNewList(singleton.dataValueContainer);
+                        }
+                    }
+                }
+            }
+
+            // End the list, if no values where added an empty list is created.
+            outputColumn.EndNewList();
+        }
+
+        private static async Task Commit(ColumnListAggAggregationSingleton singleton)
+        {
+            await singleton.Tree.Commit();
+        }
+
+        public static void Register(IFunctionsRegister functionsRegister)
+        {
+            functionsRegister.RegisterStatefulColumnAggregateFunction<ColumnListAggAggregationSingleton>(
+                FunctionsList.Uri,
+                FunctionsList.ListAgg,
+                Initialize,
+                (singleton) => { },
+                Commit,
+                ListAggMapFunction,
+                ListAggGetValue
+                );
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ColumnListAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ColumnListAggAggregation.cs
@@ -91,7 +91,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             }
             var arg = visitor.Visit(function.Arguments[0], parametersInfo);
             
-            var expr = GetListAggBody(arg.Type);
+            var expr = GetListAggBody(arg!.Type);
             var body = expr.Body;
             var replacer = new ParameterReplacerVisitor(expr.Parameters[0], arg!);
             System.Linq.Expressions.Expression e = replacer.Visit(body);
@@ -105,11 +105,6 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             e = replacer.Visit(e);
             return e;
         }
-
-        //private static Expression<Func<IDataValue, ColumnReference, long, ColumnListAggAggregationSingleton, ColumnRowReference, ValueTask>> GetListAggBody()
-        //{
-        //    return (ev, state, weight, singleton, groupingKey) => DoListAgg(ev, state, weight, singleton, groupingKey);
-        //}
 
         private static System.Linq.Expressions.LambdaExpression GetListAggBody(System.Type inputType)
         {
@@ -153,8 +148,6 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
                 }
                 return (input, GenericWriteOperation.Upsert);
             });
-
-            return;
         }
 
         private static async ValueTask ListAggGetValue(ColumnReference state, ColumnRowReference groupingKey, ColumnListAggAggregationSingleton singleton, ColumnStore.Column outputColumn)

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggColumnRowReference.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggColumnRowReference.cs
@@ -1,0 +1,34 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
+{
+    /// <summary>
+    /// Special column row reference that also contains a value that will be treated as the last column.
+    /// This is used so the value does not need to be copied into a column before insertion.
+    /// 
+    /// During insert, batch will be the length of grouping keys, but when fetching data it will be grouping keys + 1 to contain the values.
+    /// </summary>
+    internal struct ListAggColumnRowReference
+    {
+        public EventBatchData batch;
+        public int index;
+        public IDataValue insertValue;
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggInsertComparer.cs
@@ -1,0 +1,75 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Utils;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.ListAgg
+{
+    internal class ListAggInsertComparer : IBplusTreeComparer<ListAggColumnRowReference, ListAggKeyStorageContainer>
+    {
+        private DataValueContainer dataValueContainer;
+        private readonly int _groupingKeyLength;
+
+        public ListAggInsertComparer(int groupingKeyLength)
+        {
+            _groupingKeyLength = groupingKeyLength;
+            dataValueContainer = new DataValueContainer();
+        }
+
+        public bool SeekNextPageForValue => false;
+
+        public int CompareTo(in ListAggColumnRowReference x, in ListAggColumnRowReference y)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, in int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int FindIndex(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer)
+        {
+            int index = -1;
+            int start = 0;
+            int end = keyContainer.Count - 1;
+            for (int i = 0; i < _groupingKeyLength; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.batch.Columns[i].GetValueAt(key.index, dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
+
+                if (low < 0)
+                {
+                    return low;
+                }
+                else
+                {
+                    start = low;
+                    end = high;
+                }
+            }
+
+            (index, _) = keyContainer._data.Columns[_groupingKeyLength].SearchBoundries(key.insertValue, start, end, default);
+
+            return index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
@@ -1,0 +1,139 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.Memory;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Operators.Normalization;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
+{
+    internal class ListAggKeyStorageContainer : IKeyContainer<ListAggColumnRowReference>
+    {
+        private readonly int _groupingKeyLength;
+        internal EventBatchData _data;
+        private DataValueContainer _dataValueContainer;
+
+        public ListAggKeyStorageContainer(int groupingKeyLength)
+        {
+            this._groupingKeyLength = groupingKeyLength;
+            IColumn[] columns = new IColumn[groupingKeyLength + 1];
+            var memoryManager = GlobalMemoryManager.Instance;
+            for (int i = 0; i < (groupingKeyLength + 1); i++)
+            {
+                columns[i] = Column.Create(memoryManager);
+            }
+            _data = new EventBatchData(columns);
+            _dataValueContainer = new DataValueContainer();
+        }
+
+        public int Count => _data.Count;
+
+        public void Add(ListAggColumnRowReference key)
+        {
+            // Add is only run internally to copy values in the tree
+            for (int i = 0; i < (_groupingKeyLength + 1); i++)
+            {
+                key.batch.Columns[i].GetValueAt(key.index, _dataValueContainer, default);
+                _data.Columns[i].Add(_dataValueContainer);
+            }
+        }
+
+        public void AddRangeFrom(IKeyContainer<ListAggColumnRowReference> container, int start, int count)
+        {
+            if (container is ListAggKeyStorageContainer columnKeyStorageContainer)
+            {
+                for (int i = start; i < start + count; i++)
+                {
+                    Add(columnKeyStorageContainer.Get(i));
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int BinarySearch(ListAggColumnRowReference key, IComparer<ListAggColumnRowReference> comparer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            _data.Dispose();
+        }
+
+        public ListAggColumnRowReference Get(in int index)
+        {
+            return new ListAggColumnRowReference()
+            {
+                batch = _data,
+                index = index
+            };
+        }
+
+        public void Insert(int index, ListAggColumnRowReference key)
+        {
+            // Insert grouping keys
+            for (int i = 0; i < _groupingKeyLength; i++)
+            {
+                key.batch.Columns[i].GetValueAt(key.index, _dataValueContainer, default);
+                _data.Columns[i].InsertAt(index, _dataValueContainer);
+            }
+            // Insert the value in the last column
+            _data.Columns[_groupingKeyLength].InsertAt(index, key.insertValue);
+        }
+
+        public void Insert_Internal(int index, ListAggColumnRowReference key)
+        {
+            for (int i = 0; i < (_groupingKeyLength + 1); i++)
+            {
+                key.batch.Columns[i].GetValueAt(key.index, _dataValueContainer, default);
+                _data.Columns[i].InsertAt(index, _dataValueContainer);
+            }
+        }
+
+        public void RemoveAt(int index)
+        {
+            for (int i = 0; i < (_groupingKeyLength + 1); i++)
+            {
+                _data.Columns[i].RemoveAt(index);
+            }
+        }
+
+        public void RemoveRange(int start, int count)
+        {
+            var end = start + count;
+            for (int i = end - 1; i >= start; i--)
+            {
+                RemoveAt(i);
+            }
+        }
+
+        public void Update(int index, ListAggColumnRowReference key)
+        {
+            // Update is only run internally to copy values in the tree
+            for (int i = 0; i < (_groupingKeyLength + 1); i++)
+            {
+                key.batch.Columns[i].GetValueAt(key.index, _dataValueContainer, default);
+                _data.Columns[i].UpdateAt(index, _dataValueContainer);
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
@@ -42,8 +42,9 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             _dataValueContainer = new DataValueContainer();
         }
 
-        internal ListAggKeyStorageContainer(EventBatchData eventBatchData)
+        internal ListAggKeyStorageContainer(int groupingKeyLength, EventBatchData eventBatchData)
         {
+            _groupingKeyLength = groupingKeyLength;
             _data = eventBatchData;
             _dataValueContainer = new DataValueContainer();
         }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
@@ -42,6 +42,12 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             _dataValueContainer = new DataValueContainer();
         }
 
+        internal ListAggKeyStorageContainer(EventBatchData eventBatchData)
+        {
+            _data = eventBatchData;
+            _dataValueContainer = new DataValueContainer();
+        }
+
         public int Count => _data.Count;
 
         public void Add(ListAggColumnRowReference key)

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageSerializer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageSerializer.cs
@@ -1,0 +1,47 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Operators.Normalization;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
+{
+    internal class ListAggKeyStorageSerializer : IBPlusTreeKeySerializer<ListAggColumnRowReference, ListAggKeyStorageContainer>
+    {
+        private readonly int _groupingKeyLength;
+
+        public ListAggKeyStorageSerializer(int groupingKeyLength)
+        {
+            _groupingKeyLength = groupingKeyLength;
+        }
+        public ListAggKeyStorageContainer CreateEmpty()
+        {
+            return new ListAggKeyStorageContainer(_groupingKeyLength);
+        }
+
+        public ListAggKeyStorageContainer Deserialize(in BinaryReader reader)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Serialize(in BinaryWriter writer, in ListAggKeyStorageContainer values)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageSerializer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageSerializer.cs
@@ -44,7 +44,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
 
             var eventBatch = EventArrowSerializer.ArrowToBatch(recordBatch);
 
-            return new ListAggKeyStorageContainer(eventBatch);
+            return new ListAggKeyStorageContainer(_groupingKeyLength, eventBatch);
         }
 
         public void Serialize(in BinaryWriter writer, in ListAggKeyStorageContainer values)

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggSearchComparer.cs
@@ -1,0 +1,76 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
+{
+    internal class ListAggSearchComparer : IBplusTreeComparer<ListAggColumnRowReference, ListAggKeyStorageContainer>
+    {
+        private readonly int _groupingKeyLength;
+        private readonly DataValueContainer _dataValueContainer;
+        public int start;
+        public int end;
+        public bool noMatch = false;
+
+        public ListAggSearchComparer(int groupingKeyLength)
+        {
+            this._groupingKeyLength = groupingKeyLength;
+            _dataValueContainer = new DataValueContainer();
+        }
+
+        public bool SeekNextPageForValue => true;
+
+        public int CompareTo(in ListAggColumnRowReference x, in ListAggColumnRowReference y)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, in int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int FindIndex(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer)
+        {
+            int index = -1;
+            start = 0;
+            end = keyContainer.Count - 1;
+            noMatch = false;
+            for (int i = 0; i < _groupingKeyLength; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.batch.Columns[i].GetValueAt(key.index, _dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(_dataValueContainer, start, end, default);
+
+                if (low < 0)
+                {
+                    noMatch = true;
+                    return low;
+                }
+                else
+                {
+                    index = low;
+                    start = low;
+                    end = high;
+                }
+            }
+            return index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/ColumnMinMaxAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/ColumnMinMaxAggregation.cs
@@ -1,0 +1,204 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Substrait.FunctionExtensions;
+using System.Linq.Expressions;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax
+{
+    internal static class ColumnMinMaxAggregation
+    {
+        internal class MinMaxColumnAggregationSingleton
+        {
+            internal readonly IMinMaxSearchComparer searchComparer;
+            internal readonly IBPlusTreeIterator<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> iterator;
+            private readonly int keyLength;
+
+            public MinMaxColumnAggregationSingleton(
+                IBPlusTree<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> tree,
+                IMinMaxSearchComparer searchComparer,
+                IBPlusTreeIterator<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> iterator,
+                int keyLength)
+            {
+                Tree = tree;
+                this.searchComparer = searchComparer;
+                this.iterator = iterator;
+                this.keyLength = keyLength;
+            }
+
+            public int KeyLength => keyLength;
+            public IBPlusTree<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> Tree { get; }
+        }
+
+        public static void RegisterMin(IFunctionsRegister functionsRegister)
+        {
+            functionsRegister.RegisterStatefulColumnAggregateFunction<MinMaxColumnAggregationSingleton>(
+                FunctionsArithmetic.Uri,
+                FunctionsArithmetic.Min,
+                InitializeMin,
+                (singleton) => { },
+                Commit,
+                MinMaxMapFunction,
+                MinMaxGetValue
+                );
+        }
+
+        public static void RegisterMax(IFunctionsRegister functionsRegister)
+        {
+            functionsRegister.RegisterStatefulColumnAggregateFunction<MinMaxColumnAggregationSingleton>(
+                FunctionsArithmetic.Uri,
+                FunctionsArithmetic.Max,
+                InitializeMax,
+                (singleton) => { },
+                Commit,
+                MinMaxMapFunction,
+                MinMaxGetValue
+                );
+        }
+
+        private static System.Linq.Expressions.Expression MinMaxMapFunction(
+            Substrait.Expressions.AggregateFunction function,
+            ColumnParameterInfo parametersInfo,
+            ColumnarExpressionVisitor visitor,
+            ParameterExpression stateParameter,
+            ParameterExpression weightParameter,
+            ParameterExpression singletonAccess,
+            ParameterExpression groupingKeyParameter)
+        {
+            if (function.Arguments.Count != 1)
+            {
+                throw new InvalidOperationException("Min must have one argument.");
+            }
+            var arg = visitor.Visit(function.Arguments[0], parametersInfo);
+            var expr = GetMinMaxBody(arg!.Type);
+            var body = expr.Body;
+            var replacer = new ParameterReplacerVisitor(expr.Parameters[0], arg!);
+            System.Linq.Expressions.Expression e = replacer.Visit(body);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[1], stateParameter);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[2], weightParameter);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[3], singletonAccess);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[4], groupingKeyParameter);
+            e = replacer.Visit(e);
+            return e;
+        }
+
+        private static System.Linq.Expressions.LambdaExpression GetMinMaxBody(System.Type inputType)
+        {
+            var methodInfo = typeof(ColumnMinMaxAggregation).GetMethod(nameof(DoMinMax), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!.MakeGenericMethod(inputType);
+
+            var ev = System.Linq.Expressions.Expression.Parameter(inputType, "ev");
+            var state = System.Linq.Expressions.Expression.Parameter(typeof(ColumnReference), "state");
+            var weight = System.Linq.Expressions.Expression.Parameter(typeof(long), "weight");
+            var singleton = System.Linq.Expressions.Expression.Parameter(typeof(MinMaxColumnAggregationSingleton), "singleton");
+            var groupingKey = System.Linq.Expressions.Expression.Parameter(typeof(ColumnRowReference), "groupingKey");
+
+            var call = System.Linq.Expressions.Expression.Call(methodInfo, ev, state, weight, singleton, groupingKey);
+            return System.Linq.Expressions.Expression.Lambda(call, ev, state, weight, singleton, groupingKey);
+        }
+
+        private static async ValueTask DoMinMax<T>(T column, ColumnReference currentState, long weight, MinMaxColumnAggregationSingleton singleton, ColumnRowReference groupingKey)
+            where T : IDataValue
+        {
+            if (column.IsNull)
+            {
+                return;
+            }
+            var columnRowRef = new ListAggColumnRowReference()
+            {
+                batch = groupingKey.referenceBatch,
+                index = groupingKey.RowIndex,
+                insertValue = column
+            };
+            await singleton.Tree.RMW(columnRowRef, (int)weight, (input, current, exists) =>
+            {
+                if (exists)
+                {
+                    current += input;
+
+                    if (current == 0)
+                    {
+                        return (0, GenericWriteOperation.Delete);
+                    }
+                    return (current, GenericWriteOperation.Upsert);
+                }
+                return (input, GenericWriteOperation.Upsert);
+            });
+        }
+
+        private static async ValueTask MinMaxGetValue(ColumnReference state, ColumnRowReference groupingKey, MinMaxColumnAggregationSingleton singleton, Column outputColumn)
+        {
+            var rowReference = new ListAggColumnRowReference()
+            {
+                batch = groupingKey.referenceBatch,
+                index = groupingKey.RowIndex
+            };
+
+            var iterator = singleton.iterator;
+            await iterator.Seek(rowReference, singleton.searchComparer);
+
+            if (singleton.searchComparer.NoMatch)
+            {
+                outputColumn.Add(NullValue.Instance);
+                return;
+            }
+            var enumerator = iterator.GetAsyncEnumerator();
+            await enumerator.MoveNextAsync();
+            var page = enumerator.Current;
+
+            var value = page.Keys._data.Columns[singleton.KeyLength].GetValueAt(singleton.searchComparer.Start, default);
+            outputColumn.Add(value);
+        }
+
+        private static Task<MinMaxColumnAggregationSingleton> InitializeMin(int groupingLength, IStateManagerClient stateManagerClient)
+        {
+            return InitializeMinMax(groupingLength, stateManagerClient, new MinInsertComparer(groupingLength), new MinSearchComparer(groupingLength), "mintree");
+        }
+
+        private static Task<MinMaxColumnAggregationSingleton> InitializeMax(int groupingLength, IStateManagerClient stateManagerClient)
+        {
+            return InitializeMinMax(groupingLength, stateManagerClient, new MaxInsertComparer(groupingLength), new MaxSearchComparer(groupingLength), "maxtree");
+        }
+
+        private static async Task Commit(MinMaxColumnAggregationSingleton singleton)
+        {
+            await singleton.Tree.Commit();
+        }
+
+        private static async Task<MinMaxColumnAggregationSingleton> InitializeMinMax(
+            int groupingLength,
+            IStateManagerClient stateManagerClient,
+            IBplusTreeComparer<ListAggColumnRowReference, ListAggKeyStorageContainer> comparer,
+            IMinMaxSearchComparer searchComparer,
+            string treeName)
+        {
+            var tree = await stateManagerClient.GetOrCreateTree(treeName,
+                new FlowtideDotNet.Storage.Tree.BPlusTreeOptions<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>>()
+                {
+                    Comparer = comparer,
+                    KeySerializer = new ListAggKeyStorageSerializer(groupingLength),
+                    ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                });
+
+            return new MinMaxColumnAggregationSingleton(tree, searchComparer, tree.CreateIterator(), groupingLength);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/IMinMaxSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/IMinMaxSearchComparer.cs
@@ -1,0 +1,30 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax
+{
+    internal interface IMinMaxSearchComparer : IBplusTreeComparer<ListAggColumnRowReference, ListAggKeyStorageContainer>
+    {
+        public bool NoMatch { get; set; }
+
+        public int Start { get; set; }
+
+        public int End { get; set; }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MaxInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MaxInsertComparer.cs
@@ -1,0 +1,73 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax
+{
+    internal class MaxInsertComparer : IBplusTreeComparer<ListAggColumnRowReference, ListAggKeyStorageContainer>
+    {
+        private DataValueContainer dataValueContainer;
+        private readonly int _groupingKeyLength;
+
+        public MaxInsertComparer(int groupingKeyLength)
+        {
+            _groupingKeyLength = groupingKeyLength;
+            dataValueContainer = new DataValueContainer();
+        }
+
+        public bool SeekNextPageForValue => false;
+
+        public int CompareTo(in ListAggColumnRowReference x, in ListAggColumnRowReference y)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, in int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int FindIndex(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer)
+        {
+            int index = -1;
+            int start = 0;
+            int end = keyContainer.Count - 1;
+            for (int i = 0; i < _groupingKeyLength; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.batch.Columns[i].GetValueAt(key.index, dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default, true);
+
+                if (low < 0)
+                {
+                    return low;
+                }
+                else
+                {
+                    start = low;
+                    end = high;
+                }
+            }
+
+            (index, _) = keyContainer._data.Columns[_groupingKeyLength].SearchBoundries(key.insertValue, start, end, default, true);
+
+            return index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MaxSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MaxSearchComparer.cs
@@ -1,0 +1,76 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax
+{
+    internal class MaxSearchComparer : IMinMaxSearchComparer
+    {
+        private readonly int _groupingKeyLength;
+        private readonly DataValueContainer _dataValueContainer;
+
+        public MaxSearchComparer(int groupingKeyLength)
+        {
+            this._groupingKeyLength = groupingKeyLength;
+            _dataValueContainer = new DataValueContainer();
+        }
+
+        public bool SeekNextPageForValue => true;
+
+        public bool NoMatch { get; set; }
+        public int Start { get; set; }
+        public int End { get; set; }
+
+        public int CompareTo(in ListAggColumnRowReference x, in ListAggColumnRowReference y)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, in int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int FindIndex(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer)
+        {
+            int index = -1;
+            Start = 0;
+            End = keyContainer.Count - 1;
+            NoMatch = false;
+            for (int i = 0; i < _groupingKeyLength; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.batch.Columns[i].GetValueAt(key.index, _dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(_dataValueContainer, Start, End, default, true);
+
+                if (low < 0)
+                {
+                    NoMatch = true;
+                    return low;
+                }
+                else
+                {
+                    index = low;
+                    Start = low;
+                    End = high;
+                }
+            }
+            return index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinInsertComparer.cs
@@ -1,0 +1,73 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax
+{
+    internal class MinInsertComparer : IBplusTreeComparer<ListAggColumnRowReference, ListAggKeyStorageContainer>
+    {
+        private DataValueContainer dataValueContainer;
+        private readonly int _groupingKeyLength;
+
+        public MinInsertComparer(int groupingKeyLength)
+        {
+            _groupingKeyLength = groupingKeyLength;
+            dataValueContainer = new DataValueContainer();
+        }
+
+        public bool SeekNextPageForValue => false;
+
+        public int CompareTo(in ListAggColumnRowReference x, in ListAggColumnRowReference y)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, in int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int FindIndex(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer)
+        {
+            int index = -1;
+            int start = 0;
+            int end = keyContainer.Count - 1;
+            for (int i = 0; i < _groupingKeyLength; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.batch.Columns[i].GetValueAt(key.index, dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
+
+                if (low < 0)
+                {
+                    return low;
+                }
+                else
+                {
+                    start = low;
+                    end = high;
+                }
+            }
+
+            (index, _) = keyContainer._data.Columns[_groupingKeyLength].SearchBoundries(key.insertValue, start, end, default);
+
+            return index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinSearchComparer.cs
@@ -1,0 +1,77 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax
+{
+    internal class MinSearchComparer : IMinMaxSearchComparer
+    {
+        private readonly int _groupingKeyLength;
+        private readonly DataValueContainer _dataValueContainer;
+
+        public MinSearchComparer(int groupingKeyLength)
+        {
+            this._groupingKeyLength = groupingKeyLength;
+            _dataValueContainer = new DataValueContainer();
+        }
+
+        public bool SeekNextPageForValue => true;
+
+        public bool NoMatch { get; set; }
+        public int Start { get; set; }
+        public int End { get; set; }
+
+        public int CompareTo(in ListAggColumnRowReference x, in ListAggColumnRowReference y)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, in int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int FindIndex(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer)
+        {
+            int index = -1;
+            Start = 0;
+            End = keyContainer.Count - 1;
+            NoMatch = false;
+            for (int i = 0; i < _groupingKeyLength; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.batch.Columns[i].GetValueAt(key.index, _dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(_dataValueContainer, Start, End, default);
+
+                if (low < 0)
+                {
+                    NoMatch = true;
+                    return low;
+                }
+                else
+                {
+                    index = low;
+                    Start = low;
+                    End = high;
+                }
+            }
+            return index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/StringAgg/ColumnStringAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/StringAgg/ColumnStringAggAggregation.cs
@@ -1,0 +1,249 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlexBuffers;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.ListAgg;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Core.Compute.Internal.StatefulAggregations;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Substrait.FunctionExtensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using static SqlParser.Ast.Expression;
+using static SqlParser.Ast.Statement;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.StringAgg
+{
+    internal class ColumnStringAggAggregationSingleton
+    {
+        private readonly int keyLength;
+        public readonly DataValueContainer dataValueContainer;
+        public readonly IBPlusTreeIterator<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> iterator;
+
+        public ColumnStringAggAggregationSingleton(
+            IBPlusTree<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> tree, 
+            int keyLength)
+        {
+            Tree = tree;
+            this.keyLength = keyLength;
+            SearchComparer = new ListAggSearchComparer(keyLength);
+            dataValueContainer = new DataValueContainer();
+            iterator = tree.CreateIterator();
+        }
+        public int KeyLength => keyLength;
+        public ListAggSearchComparer SearchComparer { get; }
+        public string? Seperator { get; set; }
+        public IBPlusTree<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>> Tree { get; }
+    }
+
+    internal static class ColumnStringAggAggregation
+    {
+
+        private static async Task<ColumnStringAggAggregationSingleton> Initialize(int groupingLength, IStateManagerClient stateManagerClient)
+        {
+            List<int> insertPrimaryKeys = new List<int>();
+            for (int i = 0; i < groupingLength + 1; i++)
+            {
+                insertPrimaryKeys.Add(i);
+            }
+            List<int> searchPrimaryKeys = new List<int>();
+            for (int i = 0; i < groupingLength; i++)
+            {
+                searchPrimaryKeys.Add(i);
+            }
+            var tree = await stateManagerClient.GetOrCreateTree("stringaggtree",
+                new FlowtideDotNet.Storage.Tree.BPlusTreeOptions<ListAggColumnRowReference, int, ListAggKeyStorageContainer, ListValueContainer<int>>()
+                {
+                    Comparer = new ListAggInsertComparer(groupingLength),
+                    KeySerializer = new ListAggKeyStorageSerializer(groupingLength),
+                    ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                });
+
+            return new ColumnStringAggAggregationSingleton(tree, groupingLength);
+        }
+
+        private static System.Linq.Expressions.Expression StringAggMapFunction(
+           Substrait.Expressions.AggregateFunction function,
+           ColumnParameterInfo parametersInfo,
+           ColumnarExpressionVisitor visitor,
+           ParameterExpression stateParameter,
+           ParameterExpression weightParameter,
+           ParameterExpression singletonAccess,
+           ParameterExpression groupingKeyParameter)
+        {
+            if (function.Arguments.Count != 2)
+            {
+                throw new InvalidOperationException("String_agg must have two arguments.");
+            }
+            var arg = visitor.Visit(function.Arguments[0], parametersInfo);
+            var arg2 = visitor.Visit(function.Arguments[1], parametersInfo);
+
+            if (arg2 is not ConstantExpression constantExpression)
+            {
+                throw new InvalidOperationException("Seperator must be a constant string.");
+            }
+            if (constantExpression.Value is not StringValue stringVal)
+            {
+                throw new InvalidOperationException("Seperator must be a constant string.");
+            }
+            var seperator = stringVal.ToString();
+            var expr = GetStringAggBody(arg!.Type);
+            var body = expr.Body;
+            var replacer = new ParameterReplacerVisitor(expr.Parameters[0], arg!);
+            Expression e = replacer.Visit(body);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[1], System.Linq.Expressions.Expression.Constant(seperator));
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[2], stateParameter);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[3], weightParameter);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[4], singletonAccess);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[5], groupingKeyParameter);
+            e = replacer.Visit(e);
+            return e;
+        }
+
+        private static System.Linq.Expressions.LambdaExpression GetStringAggBody(System.Type inputType)
+        {
+            var methodInfo = typeof(ColumnStringAggAggregation).GetMethod(nameof(DoStringAgg), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!.MakeGenericMethod(inputType);
+
+            var ev = System.Linq.Expressions.Expression.Parameter(inputType, "ev");
+            var seperator = System.Linq.Expressions.Expression.Parameter(typeof(string), "seperator");
+            var state = System.Linq.Expressions.Expression.Parameter(typeof(ColumnReference), "state");
+            var weight = System.Linq.Expressions.Expression.Parameter(typeof(long), "weight");
+            var singleton = System.Linq.Expressions.Expression.Parameter(typeof(ColumnStringAggAggregationSingleton), "singleton");
+            var groupingKey = System.Linq.Expressions.Expression.Parameter(typeof(ColumnRowReference), "groupingKey");
+
+            var call = System.Linq.Expressions.Expression.Call(methodInfo, ev, seperator, state, weight, singleton, groupingKey);
+            return System.Linq.Expressions.Expression.Lambda(call, ev, seperator, state, weight, singleton, groupingKey);
+        }
+
+        private static async ValueTask DoStringAgg<T>(T column, string seperator, ColumnReference currentState, long weight, ColumnStringAggAggregationSingleton singleton, ColumnRowReference groupingKey)
+            where T : IDataValue
+        {
+            if (column.IsNull)
+            {
+                return;
+            }
+            if (column.Type != ArrowTypeId.String)
+            {
+                return;
+            }
+
+            if (singleton.Seperator == null)
+            {
+                singleton.Seperator = seperator;
+            }
+
+            var columnRowRef = new ListAggColumnRowReference()
+            {
+                batch = groupingKey.referenceBatch,
+                index = groupingKey.RowIndex,
+                insertValue = column
+            };
+            await singleton.Tree.RMW(columnRowRef, (int)weight, (input, current, exists) =>
+            {
+                if (exists)
+                {
+                    current += input;
+
+                    if (current == 0)
+                    {
+                        return (0, GenericWriteOperation.Delete);
+                    }
+                    return (current, GenericWriteOperation.Upsert);
+                }
+                return (input, GenericWriteOperation.Upsert);
+            });
+        }
+
+        private static async Task Commit(ColumnStringAggAggregationSingleton singleton)
+        {
+            await singleton.Tree.Commit();
+        }
+
+        private static async ValueTask StringAggGetValue(ColumnReference state, ColumnRowReference groupingKey, ColumnStringAggAggregationSingleton singleton, ColumnStore.Column outputColumn)
+        {
+            var rowReference = new ListAggColumnRowReference()
+            {
+                batch = groupingKey.referenceBatch,
+                index = groupingKey.RowIndex
+            };
+
+            var iterator = singleton.iterator;
+            await iterator.Seek(rowReference, singleton.SearchComparer);
+
+            if (!singleton.SearchComparer.noMatch)
+            {
+                StringBuilder sb = new StringBuilder();
+                bool firstPage = true;
+                await foreach (var page in iterator)
+                {
+                    if (!firstPage)
+                    {
+                        var index = singleton.SearchComparer.FindIndex(in rowReference, page.Keys!);
+                        if (singleton.SearchComparer.noMatch)
+                        {
+                            break;
+                        }
+                    }
+                    firstPage = false;
+
+                    // Iterate over all the values
+                    for (int i = singleton.SearchComparer.start; i <= singleton.SearchComparer.end; i++)
+                    {
+                        page.Keys._data.GetColumn(singleton.KeyLength).GetValueAt(i, singleton.dataValueContainer, default);
+                        var weight = page.Values.Get(i);
+
+                        // Add an item for each weight
+                        for (int k = 0; k < weight; k++)
+                        {
+                            sb.Append(singleton.dataValueContainer.AsString.ToString()).Append(singleton.Seperator);
+                        }
+                    }
+                }
+                if (sb.Length > 0)
+                {
+                    sb.Remove(sb.Length - singleton.Seperator!.Length, singleton.Seperator.Length);
+                }
+                outputColumn.Add(new StringValue(sb.ToString()));
+            }
+            else
+            {
+                outputColumn.Add(NullValue.Instance);
+            }
+        }
+
+        public static void Register(IFunctionsRegister functionsRegister)
+        {
+            functionsRegister.RegisterStatefulColumnAggregateFunction<ColumnStringAggAggregationSingleton>(
+                FunctionsString.Uri,
+                FunctionsString.StringAgg,
+                Initialize,
+                (singleton) => { },
+                Commit,
+                StringAggMapFunction,
+                StringAggGetValue
+                );
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StreamingAggregations/ArithmaticStreamingFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StreamingAggregations/ArithmaticStreamingFunctions.cs
@@ -1,0 +1,147 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlexBuffers;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Substrait.FunctionExtensions;
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StreamingAggregations
+{
+    internal static class ArithmaticStreamingFunctions
+    {
+        public static void AddBuiltInArithmaticFunctions(FunctionsRegister functionsRegister)
+        {
+            functionsRegister.RegisterStreamingColumnAggregateFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.Sum,
+                (aggregateFunction, parametersInfo, visitor, stateParameter, weightParameter) =>
+                {
+                    if (aggregateFunction.Arguments.Count != 1)
+                    {
+                        throw new InvalidOperationException("Sum must have one argument.");
+                    }
+                    var arg = visitor.Visit(aggregateFunction.Arguments[0], parametersInfo);
+                    var expr = GetSumBody(arg!.Type);
+                    var body = expr.Body;
+                    var replacer = new ParameterReplacerVisitor(expr.Parameters[0], arg!);
+                    Expression e = replacer.Visit(body);
+                    replacer = new ParameterReplacerVisitor(expr.Parameters[1], stateParameter);
+                    e = replacer.Visit(e);
+                    replacer = new ParameterReplacerVisitor(expr.Parameters[2], weightParameter);
+                    e = replacer.Visit(e);
+                    return e;
+                }, GetSumValue);
+
+            functionsRegister.RegisterStreamingColumnAggregateFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.Sum0,
+                (aggregateFunction, parametersInfo, visitor, stateParameter, weightParameter) =>
+                {
+                    if (aggregateFunction.Arguments.Count != 1)
+                    {
+                        throw new InvalidOperationException("Sum must have one argument.");
+                    }
+                    var arg = visitor.Visit(aggregateFunction.Arguments[0], parametersInfo);
+                    var expr = GetSumBody(arg!.Type);
+                    var body = expr.Body;
+                    var replacer = new ParameterReplacerVisitor(expr.Parameters[0], arg!);
+                    Expression e = replacer.Visit(body);
+                    replacer = new ParameterReplacerVisitor(expr.Parameters[1], stateParameter);
+                    e = replacer.Visit(e);
+                    replacer = new ParameterReplacerVisitor(expr.Parameters[2], weightParameter);
+                    e = replacer.Visit(e);
+                    return e;
+                }, GetSum0Value);
+        }
+
+        private static LambdaExpression GetSumBody(System.Type inputType)
+        {
+            var input = Expression.Parameter(inputType, "input");
+            var state = Expression.Parameter(typeof(ColumnReference), "state");
+            var weight = Expression.Parameter(typeof(long), "weight");
+            var methodInfo = typeof(ArithmaticStreamingFunctions).GetMethod(nameof(DoSum), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            var body = Expression.Call(null, methodInfo!.MakeGenericMethod(inputType), input, state, weight);
+            return Expression.Lambda(body, input, state, weight);
+
+        }
+
+        private static void DoSum<T>(T value, ColumnReference state, long weight)
+            where T : IDataValue
+        {
+            var currentState = state.column.GetValueAt(state.index, default);
+            if (currentState.Type == ArrowTypeId.Int64)
+            {
+                if (value.Type == ArrowTypeId.Int64)
+                {
+                    var count = currentState.AsLong + (value.AsLong * weight);
+                    state.column.UpdateAt(state.index, new Int64Value(count));
+                }
+                else if (value.Type == ArrowTypeId.Double)
+                {
+                    var floatCount = currentState.AsLong + (value.AsDouble * weight);
+                    state.column.UpdateAt(state.index, new DoubleValue(floatCount));
+                }
+            }
+            else if (currentState.Type == ArrowTypeId.Double)
+            {
+                if (value.Type == ArrowTypeId.Int64)
+                {
+                    var count = currentState.AsDouble + (value.AsLong * weight);
+                    state.column.UpdateAt(state.index, new DoubleValue(count));
+                }
+                else if (value.Type == ArrowTypeId.Double)
+                {
+                    var count = currentState.AsDouble + (value.AsDouble * weight);
+                    state.column.UpdateAt(state.index, new DoubleValue(count));
+                }
+            }
+            else if (currentState.Type == ArrowTypeId.Null)
+            {
+                if (value.Type == ArrowTypeId.Int64)
+                {
+                    var count = (value.AsLong * weight);
+                    state.column.UpdateAt(state.index, new Int64Value(count));
+                }
+                else if (value.Type == ArrowTypeId.Double)
+                {
+                    var count = (value.AsDouble * weight);
+                    state.column.UpdateAt(state.index, new DoubleValue(count));
+                }
+            }
+        }
+
+        private static void GetSumValue(ColumnReference state, ColumnStore.Column outputColumn)
+        {
+            var stateVal = state.column.GetValueAt(state.index, default);
+            outputColumn.Add(stateVal);
+        }
+
+        private static void GetSum0Value(ColumnReference state, ColumnStore.Column outputColumn)
+        {
+            var stateVal = state.column.GetValueAt(state.index, default);
+            
+            if (stateVal.Type == ArrowTypeId.Null)
+            {
+                outputColumn.Add(new DoubleValue(0.0));
+            }
+            else
+            {
+                outputColumn.Add(stateVal);
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StreamingAggregations/ArithmaticStreamingFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StreamingAggregations/ArithmaticStreamingFunctions.cs
@@ -13,6 +13,7 @@
 using FlexBuffers;
 using FlowtideDotNet.Core.ColumnStore;
 using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax;
 using FlowtideDotNet.Core.Compute.Internal;
 using FlowtideDotNet.Substrait.FunctionExtensions;
 using System;
@@ -29,6 +30,9 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StreamingAggregations
     {
         public static void AddBuiltInArithmaticFunctions(FunctionsRegister functionsRegister)
         {
+            ColumnMinMaxAggregation.RegisterMin(functionsRegister);
+            ColumnMinMaxAggregation.RegisterMax(functionsRegister);
+
             functionsRegister.RegisterStreamingColumnAggregateFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.Sum,
                 (aggregateFunction, parametersInfo, visitor, stateParameter, weightParameter) =>
                 {

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StreamingAggregations/BuiltInGenericFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StreamingAggregations/BuiltInGenericFunctions.cs
@@ -1,0 +1,88 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlexBuffers;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Substrait.FunctionExtensions;
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StreamingAggregations
+{
+    internal static class BuiltInGenericFunctions
+    {
+        public static void AddBuiltInAggregateGenericFunctions(FunctionsRegister functionsRegister)
+        {
+            functionsRegister.RegisterStreamingColumnAggregateFunction(
+                FunctionsAggregateGeneric.Uri,
+                FunctionsAggregateGeneric.Count,
+                (aggregateFunction, parametersInfo, visitor, stateParameter, weightParameter) =>
+                {
+                    if (aggregateFunction.Arguments != null && aggregateFunction.Arguments.Count != 0)
+                    {
+                        throw new ArgumentException("Count function does not take any arguments");
+                    }
+                    var expr = GetCountBody();
+                    var body = expr.Body;
+                    var replacer = new ParameterReplacerVisitor(expr.Parameters[0], parametersInfo.BatchParameters[0]);
+                    Expression e = replacer.Visit(body);
+                    replacer = new ParameterReplacerVisitor(expr.Parameters[1], parametersInfo.IndexParameters[0]);
+                    e = replacer.Visit(e);
+                    replacer = new ParameterReplacerVisitor(expr.Parameters[2], stateParameter);
+                    e = replacer.Visit(e);
+                    replacer = new ParameterReplacerVisitor(expr.Parameters[3], weightParameter);
+                    e = replacer.Visit(e);
+                    return e;
+                },
+                GetCountValue
+                );
+        }
+
+        private static Expression<Action<EventBatchData, int, ColumnReference, long>> GetCountBody()
+        {
+            return (batch, index, bytes, weight) => DoCount(batch, index, bytes, weight);
+        }
+
+        private static void DoCount(EventBatchData data, int index, ColumnReference state, long weight)
+        {
+            var currentState = state.column.GetValueAt(state.index, default);
+            long count = 0;
+            if (currentState.Type == ArrowTypeId.Int64)
+            {
+                count = currentState.AsLong;
+            }
+            if (weight < 0)
+            {
+
+            }
+            var newCount = count + weight;
+            state.column.UpdateAt(state.index, new Int64Value(newCount));
+        }
+
+        private static void GetCountValue(ColumnReference state, Column outputColumn)
+        {
+            var stateValue = state.column.GetValueAt(state.index, default);
+            if (stateValue.Type == ArrowTypeId.Null)
+            {
+                outputColumn.Add(new Int64Value(0));
+                return;
+            }
+            outputColumn.Add(stateValue);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/IColumnAggregateContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/IColumnAggregateContainer.cs
@@ -1,0 +1,34 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlexBuffers;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar
+{
+    internal interface IColumnAggregateContainer
+    {
+        ValueTask Compute(ColumnRowReference key, EventBatchData rowBatch, int rowIndex, ColumnReference state, long weight);
+
+        void Disponse();
+
+        Task Commit();
+
+        ValueTask GetValue(ColumnRowReference key, ColumnReference state, Column outputColumn);
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/FunctionsRegister.cs
+++ b/src/FlowtideDotNet.Core/Compute/FunctionsRegister.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlexBuffers;
+using FlowtideDotNet.Core.ColumnStore;
 using FlowtideDotNet.Core.Compute.Columnar;
 using FlowtideDotNet.Core.Compute.Internal;
 using FlowtideDotNet.Substrait.Expressions;
@@ -25,6 +26,7 @@ namespace FlowtideDotNet.Core.Compute
         private readonly Dictionary<string, FunctionDefinition> _scalarFunctions;
         private readonly Dictionary<string, AggregateFunctionDefinition> _aggregateFunctions;
         private readonly Dictionary<string, TableFunctionDefinition> _tableFunctions;
+        private readonly Dictionary<string, ColumnAggregateFunctionDefinition> _columnAggregateFunctions;
 
         public FunctionsRegister()
         {
@@ -33,6 +35,7 @@ namespace FlowtideDotNet.Core.Compute
             _tableFunctions = new Dictionary<string, TableFunctionDefinition>(StringComparer.OrdinalIgnoreCase);
 
             _columnScalarFunctions = new Dictionary<string, ColumnFunctionDefinition>(StringComparer.OrdinalIgnoreCase);
+            _columnAggregateFunctions = new Dictionary<string, ColumnAggregateFunctionDefinition>(StringComparer.OrdinalIgnoreCase);
         }
 
         public bool TryGetScalarFunction(string uri, string name, [NotNullWhen(true)] out FunctionDefinition? functionDefinition)
@@ -131,6 +134,22 @@ namespace FlowtideDotNet.Core.Compute
             _aggregateFunctions.Add($"{uri}:{name}", new StreamingAggregateFunctionDefinition(uri, name, mapFunc, stateToValueFunc));
         }
 
+        /// <summary>
+        /// Register a streaming aggregate function that uses columnar data.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="name"></param>
+        /// <param name="mapFunc"></param>
+        /// <param name="stateToValueFunc"></param>
+        public void RegisterStreamingColumnAggregateFunction(
+            string uri,
+            string name,
+            Func<AggregateFunction, ColumnParameterInfo, ColumnarExpressionVisitor, ParameterExpression, ParameterExpression, System.Linq.Expressions.Expression> mapFunc,
+            Action<ColumnReference, ColumnStore.Column> stateToValueFunc)
+        {
+            _columnAggregateFunctions.Add($"{uri}:{name}", new ColumnStreamingAggregateFunctionDefinition(uri, name, mapFunc, stateToValueFunc));
+        }
+
         public bool TryGetAggregateFunction(string uri, string name, [NotNullWhen(true)] out AggregateFunctionDefinition? aggregateFunctionDefinition)
         {
             return _aggregateFunctions.TryGetValue($"{uri}:{name}", out aggregateFunctionDefinition);
@@ -161,6 +180,22 @@ namespace FlowtideDotNet.Core.Compute
         public bool TryGetTableFunction(string uri, string name, [NotNullWhen(true)] out TableFunctionDefinition? tableFunctionDefinition)
         {
             return _tableFunctions.TryGetValue($"{uri}:{name}", out tableFunctionDefinition);
+        }
+
+        public void RegisterStatefulColumnAggregateFunction<T>(string uri, string name, IFunctionsRegister.AggregateInitializeFunction<T> initializeFunction, Action<T> disposeFunction, Func<T, Task> commitFunction, IFunctionsRegister.ColumnAggregateMapFunction mapFunc, IFunctionsRegister.ColumnAggregateStateToValueFunction<T> stateToValueFunc)
+        {
+            _columnAggregateFunctions.Add($"{uri}:{name}", new StatefulColumnAggregateFunctionDefinition<T>(
+                initializeFunction,
+                disposeFunction,
+                commitFunction,
+                mapFunc,
+                stateToValueFunc
+                ));
+        }
+
+        public bool TryGetColumnAggregateFunction(string uri, string name, [NotNullWhen(true)] out ColumnAggregateFunctionDefinition? aggregateFunctionDefinition)
+        {
+            return _columnAggregateFunctions.TryGetValue($"{uri}:{name}", out aggregateFunctionDefinition);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/IFunctionsRegister.cs
+++ b/src/FlowtideDotNet.Core/Compute/IFunctionsRegister.cs
@@ -11,6 +11,8 @@
 // limitations under the License.
 
 using FlexBuffers;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.Compute.Columnar;
 using FlowtideDotNet.Core.Compute.Internal;
 using FlowtideDotNet.Storage.StateManager;
@@ -56,7 +58,16 @@ namespace FlowtideDotNet.Core.Compute
 
 
         delegate Task<T> AggregateInitializeFunction<T>(int groupingLength, IStateManagerClient stateManagerClient);
-        
+
+        delegate System.Linq.Expressions.Expression ColumnAggregateMapFunction(
+            AggregateFunction function,
+            ColumnParameterInfo parametersInfo,
+            ColumnarExpressionVisitor visitor,
+            ParameterExpression stateParameters,
+            ParameterExpression weightParameter,
+            ParameterExpression singletonAccess,
+            ParameterExpression groupingKeyParameter);
+
         delegate System.Linq.Expressions.Expression AggregateMapFunction(
             AggregateFunction function,
             ParametersInfo parametersInfo,
@@ -67,6 +78,8 @@ namespace FlowtideDotNet.Core.Compute
             ParameterExpression groupingKeyParameter);
 
         delegate ValueTask<FlxValue> AggregateStateToValueFunction<T>(byte[]? state, RowEvent groupingKey, T singleton);
+
+        delegate ValueTask ColumnAggregateStateToValueFunction<T>(ColumnReference state, ColumnRowReference groupingKey, T singleton, ColumnStore.Column outputColumn);
 
         /// <summary>
         /// Register a stateful aggregate function.
@@ -88,6 +101,15 @@ namespace FlowtideDotNet.Core.Compute
             Func<T, Task> commitFunction,
             AggregateMapFunction mapFunc,
             AggregateStateToValueFunction<T> stateToValueFunc);
+
+        void RegisterStatefulColumnAggregateFunction<T>(
+            string uri,
+            string name,
+            AggregateInitializeFunction<T> initializeFunction,
+            Action<T> disposeFunction,
+            Func<T, Task> commitFunction,
+            ColumnAggregateMapFunction mapFunc,
+            ColumnAggregateStateToValueFunction<T> stateToValueFunc);
 
         bool TryGetScalarFunction(string uri, string name, [NotNullWhen(true)] out FunctionDefinition? functionDefinition);
 

--- a/src/FlowtideDotNet.Core/Compute/Internal/BuiltInListFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/BuiltInListFunctions.cs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations;
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.ListAgg;
 using FlowtideDotNet.Core.Compute.Internal.StatefulAggregations;
 using FlowtideDotNet.Core.Compute.Internal.TableFunctions;
 
@@ -20,6 +22,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
         public static void AddListFunctions(FunctionsRegister functionsRegister)
         {
             ListAggAggregation.Register(functionsRegister);
+            ColumnListAggAggregation.Register(functionsRegister);
             UnnestTableFunction.AddBuiltInUnnestFunction(functionsRegister);
         }
     }

--- a/src/FlowtideDotNet.Core/Compute/Internal/BuiltinFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/BuiltinFunctions.cs
@@ -22,6 +22,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
             Columnar.Functions.BuiltInComparisonFunctions.AddComparisonFunctions(functionsRegister);
             BuiltInGenericFunctions.AddBuiltInAggregateGenericFunctions(functionsRegister);
             ArithmaticStreamingFunctions.AddBuiltInArithmaticFunctions(functionsRegister);
+            Columnar.Functions.BuiltInStringFunctions.RegisterFunctions(functionsRegister);
 
             BuiltInComparisonFunctions.AddComparisonFunctions(functionsRegister);
             BuiltInBooleanFunctions.AddBooleanFunctions(functionsRegister);

--- a/src/FlowtideDotNet.Core/Compute/Internal/BuiltinFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/BuiltinFunctions.cs
@@ -10,13 +10,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StreamingAggregations;
+
 namespace FlowtideDotNet.Core.Compute.Internal
 {
     internal static class BuiltinFunctions
     {
         public static void RegisterFunctions(FunctionsRegister functionsRegister)
         {
+            // Column functions
             Columnar.Functions.BuiltInComparisonFunctions.AddComparisonFunctions(functionsRegister);
+            BuiltInGenericFunctions.AddBuiltInAggregateGenericFunctions(functionsRegister);
+            ArithmaticStreamingFunctions.AddBuiltInArithmaticFunctions(functionsRegister);
+
             BuiltInComparisonFunctions.AddComparisonFunctions(functionsRegister);
             BuiltInBooleanFunctions.AddBooleanFunctions(functionsRegister);
             BuiltInStringFunctions.AddStringFunctions(functionsRegister);

--- a/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
+++ b/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
@@ -41,6 +41,7 @@ using System.Threading.Tasks;
 using FlowtideDotNet.Base.Vertices.MultipleInput;
 using FlowtideDotNet.Core.Operators.Join;
 using FlowtideDotNet.Base.Vertices.Unary;
+using FlowtideDotNet.Core.Operators.Aggregate.Column;
 
 namespace FlowtideDotNet.Core.Engine
 {
@@ -245,7 +246,7 @@ namespace FlowtideDotNet.Core.Engine
             else
             {
                 var id = _operatorId++;
-                var op = new AggregateOperator(aggregateRelation, functionsRegister, DefaultBlockOptions);
+                var op = new ColumnAggregateOperator(aggregateRelation, functionsRegister, DefaultBlockOptions); //new AggregateOperator(aggregateRelation, functionsRegister, DefaultBlockOptions);
 
                 if (state != null)
                 {

--- a/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
+++ b/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
@@ -246,7 +246,16 @@ namespace FlowtideDotNet.Core.Engine
             else
             {
                 var id = _operatorId++;
-                var op = new ColumnAggregateOperator(aggregateRelation, functionsRegister, DefaultBlockOptions); //new AggregateOperator(aggregateRelation, functionsRegister, DefaultBlockOptions);
+
+                UnaryVertex<StreamEventBatch, AggregateOperatorState>? op;
+                if (_useColumnStore)
+                {
+                    op = new ColumnAggregateOperator(aggregateRelation, functionsRegister, DefaultBlockOptions);
+                }
+                else
+                {
+                    op = new AggregateOperator(aggregateRelation, functionsRegister, DefaultBlockOptions);
+                }
 
                 if (state != null)
                 {

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateOperator.cs
@@ -157,7 +157,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
 
                     if (outputs.Count > 100)
                     {
-                        yield return new StreamEventBatch(outputs);
+                        yield return new StreamEventBatch(outputs, aggregateRelation.OutputLength);
                         outputs = new List<RowEvent>();
                     }
                     
@@ -191,7 +191,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
 
                     if (outputs.Count > 100)
                     {
-                        yield return new StreamEventBatch(outputs);
+                        yield return new StreamEventBatch(outputs, aggregateRelation.OutputLength);
                         outputs = new List<RowEvent>();
                     }
                     
@@ -278,7 +278,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
 
                         if (outputs.Count > 100)
                         {
-                            yield return new StreamEventBatch(outputs);
+                            yield return new StreamEventBatch(outputs, aggregateRelation.OutputLength);
                             outputs = new List<RowEvent>();
                         }
                         
@@ -291,7 +291,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
                 // Output only 100 rows per batch to reduce memory consumption
                 if (outputs.Count > 100)
                 {
-                    yield return new StreamEventBatch(outputs);
+                    yield return new StreamEventBatch(outputs, aggregateRelation.OutputLength);
                     outputs = new List<RowEvent>();
                 }
 
@@ -300,7 +300,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
 
             if (outputs.Count > 0)
             {
-                yield return new StreamEventBatch(outputs);
+                yield return new StreamEventBatch(outputs, aggregateRelation.OutputLength);
             }
         }
 

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateInsertComparer.cs
@@ -1,0 +1,79 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal class AggregateInsertComparer : IBplusTreeComparer<ColumnRowReference, AggregateKeyStorageContainer>
+    {
+        private DataValueContainer dataValueContainer;
+        private readonly int columnCount;
+
+        public bool SeekNextPageForValue => false;
+
+        public AggregateInsertComparer(int columnCount)
+        {
+            dataValueContainer = new DataValueContainer();
+            this.columnCount = columnCount;
+        }
+
+        public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
+        {
+            return x.referenceBatch.CompareRows(y.referenceBatch, x.RowIndex, y.RowIndex);
+        }
+
+        public int CompareTo(in ColumnRowReference key, in AggregateKeyStorageContainer keyContainer, in int index)
+        {
+            return keyContainer._data.CompareRows(key.referenceBatch, index, key.RowIndex);
+        }
+
+        public int FindIndex(in ColumnRowReference key, in AggregateKeyStorageContainer keyContainer)
+        {
+            int index = -1;
+            int start = 0;
+            int end = keyContainer.Count - 1;
+            for (int i = 0; i < columnCount; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
+
+                if (low != 0)
+                {
+                    return low;
+                }
+                else
+                {
+                    index = low;
+                    start = low;
+                    end = high;
+                }
+            }
+            if (columnCount == 0)
+            {
+                if (keyContainer.Count > 0)
+                {
+                    return 0;
+                }
+            }
+            return index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeySerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeySerializer.cs
@@ -1,0 +1,64 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Apache.Arrow.Ipc;
+using Apache.Arrow;
+using FlowtideDotNet.Core.ColumnStore.Serialization;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal class AggregateKeySerializer : IBPlusTreeKeySerializer<ColumnRowReference, AggregateKeyStorageContainer>
+    {
+        private readonly int columnCount;
+
+        public AggregateKeySerializer(int columnCount)
+        {
+            this.columnCount = columnCount;
+        }
+        public AggregateKeyStorageContainer CreateEmpty()
+        {
+            return new AggregateKeyStorageContainer(columnCount);
+        }
+
+        private static readonly FieldInfo _memoryOwnerField = GetMethodArrowBufferMemoryOwner();
+        private static FieldInfo GetMethodArrowBufferMemoryOwner()
+        {
+            var fieldInfo = typeof(RecordBatch).GetField("_memoryOwner", BindingFlags.NonPublic | BindingFlags.Instance);
+            return fieldInfo!;
+        }
+
+        public AggregateKeyStorageContainer Deserialize(in BinaryReader reader)
+        {
+            using var arrowReader = new ArrowStreamReader(reader.BaseStream, new Apache.Arrow.Memory.NativeMemoryAllocator(), true);
+            var recordBatch = arrowReader.ReadNextRecordBatch();
+
+            var eventBatch = EventArrowSerializer.ArrowToBatch(recordBatch);
+            
+            return new AggregateKeyStorageContainer(recordBatch.ColumnCount, eventBatch, recordBatch.Length);
+        }
+
+        public void Serialize(in BinaryWriter writer, in AggregateKeyStorageContainer values)
+        {
+            var recordBatch = EventArrowSerializer.BatchToArrow(values._data);
+            var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);
+            batchWriter.WriteRecordBatch(recordBatch);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
@@ -1,0 +1,148 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore.Memory;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal class AggregateKeyStorageContainer : IKeyContainer<ColumnRowReference>
+    {
+        private readonly int columnCount;
+        internal EventBatchData _data;
+        private DataValueContainer _dataValueContainer;
+        private int _length;
+
+        public AggregateKeyStorageContainer(int columnCount)
+        {
+            IColumn[] columns = new IColumn[columnCount];
+            var memoryManager = GlobalMemoryManager.Instance; //new BatchMemoryManager(columnCount);
+            for (int i = 0; i < columnCount; i++)
+            {
+                columns[i] = ColumnStore.Column.Create(memoryManager);
+            }
+            _data = new EventBatchData(columns);
+            this.columnCount = columnCount;
+            _dataValueContainer = new DataValueContainer();
+            _length = 0;
+        }
+
+        internal AggregateKeyStorageContainer(int columnCount, EventBatchData eventBatchData, int length)
+        {
+            this.columnCount = columnCount;
+            _data = eventBatchData;
+            _dataValueContainer = new DataValueContainer();
+            _length = length;
+        }
+
+        public int Count => _length;
+
+        public void Add(ColumnRowReference key)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, _dataValueContainer, default);
+                _data.Columns[i].Add(_dataValueContainer);
+            }
+            _length++;
+        }
+
+        public void AddRangeFrom(IKeyContainer<ColumnRowReference> container, int start, int count)
+        {
+            if (container is AggregateKeyStorageContainer columnKeyStorageContainer)
+            {
+                for (int i = start; i < start + count; i++)
+                {
+                    Add(columnKeyStorageContainer.Get(i));
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int BinarySearch(ColumnRowReference key, IComparer<ColumnRowReference> comparer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            _data.Dispose();
+        }
+
+        public ColumnRowReference Get(in int index)
+        {
+            return new ColumnRowReference()
+            {
+                referenceBatch = _data,
+                RowIndex = index
+            };
+        }
+
+        public void Insert(int index, ColumnRowReference key)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, _dataValueContainer, default);
+                _data.Columns[i].InsertAt(index, _dataValueContainer);
+                //_data.Columns[i].InsertAt(index, key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, default));
+            }
+            _length++;
+        }
+
+        public void Insert_Internal(int index, ColumnRowReference key)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, _dataValueContainer, default);
+                _data.Columns[i].InsertAt(index, _dataValueContainer);
+            }
+            _length++;
+        }
+
+        public void RemoveAt(int index)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                _data.Columns[i].RemoveAt(index);
+            }
+            _length--;
+        }
+
+        public void RemoveRange(int start, int count)
+        {
+            var end = start + count;
+            for (int i = end - 1; i >= start; i--)
+            {
+                RemoveAt(i);
+            }
+        }
+
+        public void Update(int index, ColumnRowReference key)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, _dataValueContainer, default);
+                _data.Columns[i].UpdateAt(index, _dataValueContainer);
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateSearchComparer.cs
@@ -1,0 +1,90 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal class AggregateSearchComparer : IBplusTreeComparer<ColumnRowReference, AggregateKeyStorageContainer>
+    {
+        private DataValueContainer dataValueContainer;
+        private readonly int columnCount;
+
+        public int start;
+        public int end;
+        public bool noMatch = false;
+
+        public bool SeekNextPageForValue => true;
+
+        public AggregateSearchComparer(int columnCount)
+        {
+            dataValueContainer = new DataValueContainer();
+            this.columnCount = columnCount;
+        }
+
+        public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
+        {
+            return x.referenceBatch.CompareRows(y.referenceBatch, x.RowIndex, y.RowIndex);
+        }
+
+        public int CompareTo(in ColumnRowReference key, in AggregateKeyStorageContainer keyContainer, in int index)
+        {
+            return keyContainer._data.CompareRows(key.referenceBatch, index, key.RowIndex);
+        }
+
+        public int FindIndex(in ColumnRowReference key, in AggregateKeyStorageContainer keyContainer)
+        {
+            int index = -1;
+            start = 0;
+            noMatch = false;
+            end = keyContainer.Count - 1;
+            for (int i = 0; i < columnCount; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
+
+                if (low < 0)
+                {
+                    start = low;
+                    noMatch = true;
+                    return low;
+                }
+                else
+                {
+                    index = low;
+                    start = low;
+                    end = high;
+                }
+            }
+            if (columnCount == 0)
+            {
+                if (keyContainer.Count > 0)
+                {
+                    return 0;
+                }
+                else
+                {
+                    noMatch = true;
+                }
+            }
+            return index;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateOperator.cs
@@ -1,0 +1,478 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlexBuffers;
+using FlowtideDotNet.Base;
+using FlowtideDotNet.Base.Vertices.Unary;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.Memory;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Core.Compute;
+using FlowtideDotNet.Core.Compute.Columnar;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Core.Operators.Set;
+using FlowtideDotNet.Core.Storage;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Substrait.Relations;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using static SqlParser.Ast.TableConstraint;
+using static Substrait.Protobuf.AggregateRel.Types;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal class ColumnAggregateOperator : UnaryVertex<StreamEventBatch, AggregateOperatorState>
+    {
+        private readonly AggregateRelation m_aggregateRelation;
+        private readonly FunctionsRegister m_functionsRegister;
+
+        /// <summary>
+        /// Temporary until column based aggregates are implemented
+        /// </summary>
+        private List<IColumnAggregateContainer> m_measures;
+
+        private List<Action<EventBatchData, int, ColumnStore.Column>>? groupExpressions;
+        private ColumnStore.Column[] m_groupValues;
+        private EventBatchData m_groupValuesBatch;
+
+        private ColumnStore.Column[] m_temporaryStateValues;
+        private EventBatchData m_temporaryStateBatch;
+
+        /// <summary>
+        /// Helper column that only contains a null value.
+        /// This is used to help avoid creating a new column for each null value.
+        /// </summary>
+        //private ColumnStore.Column nullStateColumn;
+
+        private IBPlusTree<ColumnRowReference, ColumnAggregateStateReference, AggregateKeyStorageContainer, ColumnAggregateValueContainer>? _tree;
+        private IBPlusTreeIterator<ColumnRowReference, ColumnAggregateStateReference, AggregateKeyStorageContainer, ColumnAggregateValueContainer>? _treeIterator;
+        private IBPlusTree<ColumnRowReference, int, AggregateKeyStorageContainer, ListValueContainer<int>>? _temporaryTree;
+
+        public ColumnAggregateOperator(AggregateRelation aggregateRelation, FunctionsRegister functionsRegister, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionDataflowBlockOptions)
+        {
+            m_measures = new List<IColumnAggregateContainer>();
+            m_aggregateRelation = aggregateRelation;
+            m_functionsRegister = functionsRegister;
+
+            if (aggregateRelation.Groupings != null && aggregateRelation.Groupings.Count > 0)
+            {
+                if (aggregateRelation.Groupings.Count > 1)
+                {
+                    throw new InvalidOperationException("Aggregate operator only supports one grouping set at this point");
+                }
+
+                var grouping = aggregateRelation.Groupings[0];
+
+                m_groupValues = new ColumnStore.Column[grouping.GroupingExpressions.Count];
+
+                for (int i = 0; i < grouping.GroupingExpressions.Count; i++)
+                {
+                    m_groupValues[i] = ColumnFactory.Get(GlobalMemoryManager.Instance);
+                }
+
+                groupExpressions = new List<Action<EventBatchData, int, ColumnStore.Column>>();
+                foreach (var expr in grouping.GroupingExpressions)
+                {
+                    groupExpressions.Add(ColumnProjectCompiler.Compile(expr, functionsRegister));
+                }
+            }
+            else
+            {
+                m_groupValues = new ColumnStore.Column[0];
+            }
+            m_groupValuesBatch = new EventBatchData(m_groupValues);
+
+            m_temporaryStateValues = new ColumnStore.Column[(aggregateRelation.Measures?.Count ?? 0) * 2];
+
+            for (int i = 0; i < m_temporaryStateValues.Length; i++)
+            {
+                m_temporaryStateValues[i] = ColumnFactory.Get(GlobalMemoryManager.Instance);
+            }
+
+            m_temporaryStateBatch = new EventBatchData(m_temporaryStateValues);
+        }
+
+        public override string DisplayName => "Aggregation";
+
+        public override Task Compact()
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task DeleteAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task<AggregateOperatorState> OnCheckpoint()
+        {
+            return Task.FromResult(new AggregateOperatorState());
+        }
+
+        protected override async IAsyncEnumerable<StreamEventBatch> OnWatermark(Watermark watermark)
+        {
+            Debug.Assert(_tree != null, "Tree should not be null");
+            Debug.Assert(_temporaryTree != null, "Temporary tree should not be null");
+
+            PrimitiveList<int> outputWeights = new PrimitiveList<int>(GlobalMemoryManager.Instance);
+            PrimitiveList<uint> outputIterations = new PrimitiveList<uint>(GlobalMemoryManager.Instance);
+
+            var outputColumnCount = (groupExpressions?.Count ?? 0) + m_measures.Count;
+            ColumnStore.Column[] outputColumns = new ColumnStore.Column[outputColumnCount];
+
+            for (int i = 0; i < outputColumnCount; i++)
+            {
+                outputColumns[i] = ColumnFactory.Get(GlobalMemoryManager.Instance);
+            }
+
+            for (int i = 0; i < m_temporaryStateValues.Length; i++)
+            {
+                m_temporaryStateValues[i].Clear();
+            }
+
+            if (groupExpressions == null || groupExpressions.Count == 0)
+            {
+                // No groups, create an empty row with no columns to find info in the tree.
+                var emptyRow = new ColumnRowReference() { referenceBatch = m_groupValuesBatch, RowIndex = 0 };
+                var comparer = new AggregateSearchComparer(0);
+                await _treeIterator!.Seek(emptyRow, comparer);
+                
+                if (!comparer.noMatch)
+                {
+                    var enumerator = _treeIterator.GetAsyncEnumerator();
+                    await enumerator.MoveNextAsync();
+                    var page = enumerator.Current;
+                    bool deleteAdded = false;
+
+                    var val = page.Values.Get(comparer.start);
+
+                    for (int i = 0; i < m_measures.Count; i++)
+                    {
+                        await m_measures[i].GetValue(emptyRow, new ColumnReference(val.referenceBatch.Columns[i], val.RowIndex), outputColumns[i]);
+                        var previousValueColumn = val.referenceBatch.Columns[m_measures.Count + i];
+                        var previousValue = previousValueColumn.GetValueAt(val.RowIndex, default);
+                        var newValue = outputColumns[i].GetValueAt(outputColumns[i].Count - 1, default);
+                        if (val.valueSent)
+                        {
+                            deleteAdded = true;
+                            outputColumns[i].Add(previousValue);
+                        }
+                        previousValueColumn.UpdateAt(val.RowIndex, newValue);
+                    }
+                    if (!val.valueSent)
+                    {
+                        page.Values._previousValueSent.Update(comparer.start, true);
+                    }
+                    outputIterations.Add(0);
+                    outputWeights.Add(1);
+                    if (deleteAdded)
+                    {
+                        outputIterations.Add(0);
+                        outputWeights.Add(-1);
+                    }
+
+                    // Save all the changes to the page
+                    await page.SavePage();
+                }
+                else
+                {
+                    var notFoundRowIndex = m_temporaryStateBatch.Count;
+                    // Not found happens when there was no row that matched
+                    for (int i = 0; i < m_measures.Count; i++)
+                    {
+                        var stateColumn = m_temporaryStateValues[i];
+                        stateColumn.Add(NullValue.Instance);
+                        await m_measures[i].GetValue(emptyRow, new ColumnReference(stateColumn, notFoundRowIndex), outputColumns[i]);
+                        
+                        // Fetch the value added to the output
+                        var newValue = outputColumns[i].GetValueAt(outputColumns[i].Count - 1, default);
+                        // Add it to the state for previous value, so the value can be removed if changed
+                        m_temporaryStateValues[m_measures.Count + i].Add(newValue);
+                    }
+                    outputIterations.Add(0);
+                    outputWeights.Add(1);
+                    // Add value to the tree so next time the value will be returned 
+                    await _tree.Upsert(emptyRow, new ColumnAggregateStateReference()
+                    {
+                        referenceBatch = m_temporaryStateBatch,
+                        RowIndex = notFoundRowIndex,
+                        weight = 1
+                    });
+                }
+
+                yield return new StreamEventBatch(new EventBatchWeighted(outputWeights, outputIterations, new EventBatchData(outputColumns)));
+            }
+            else
+            {
+                // This iterator can probably be created in init instead to save on memory allocations
+                var iterator = _temporaryTree.CreateIterator();
+                await iterator.SeekFirst();
+
+                await foreach (var page in iterator)
+                {
+                    foreach (var kv in page)
+                    {
+                        var comparer = new AggregateSearchComparer(m_groupValues.Length);
+                        await _treeIterator!.Seek(kv.Key, comparer);
+                        
+                        if (comparer.noMatch)
+                        {
+                            continue;
+                        }
+
+                        var enumerator = _treeIterator.GetAsyncEnumerator();
+                        await enumerator.MoveNextAsync();
+                        var treePage = enumerator.Current;
+
+                        var val = treePage.Values.Get(comparer.start);
+
+                        if (val.weight == 0)
+                        {
+                            if (val.valueSent)
+                            {
+                                // Copy key values into output
+                                for (int i = 0; i < kv.Key.referenceBatch.Columns.Count; i++)
+                                {
+                                    outputColumns[i].Add(kv.Key.referenceBatch.Columns[i].GetValueAt(kv.Key.RowIndex, default));
+                                }
+                                // Add the previous value sent to output
+                                for (int i = 0; i < m_measures.Count; i++)
+                                {
+                                    var previousValueColumn = val.referenceBatch.Columns[m_measures.Count + i];
+                                    var previousValue = previousValueColumn.GetValueAt(val.RowIndex, default);
+                                    outputColumns[groupExpressions.Count + i].Add(previousValue);
+                                }
+                                outputIterations.Add(0);
+                                outputWeights.Add(-1);
+                            }
+                            await _tree.Delete(kv.Key);
+                            continue;
+                        }
+
+                        // Copy key values into output
+                        for (int i = 0; i < kv.Key.referenceBatch.Columns.Count; i++)
+                        {
+                            var colVal = kv.Key.referenceBatch.Columns[i].GetValueAt(kv.Key.RowIndex, default);
+                            outputColumns[i].Add(colVal);
+                            if (val.valueSent)
+                            {
+                                // Add the key value a second time if value has already been sent to add it for deletes.
+                                outputColumns[i].Add(colVal);
+                            }
+                        }
+
+                        // Add measure values
+                        for (int i = 0; i < m_measures.Count; i++)
+                        {
+                            await m_measures[i].GetValue(kv.Key, new ColumnReference(val.referenceBatch.Columns[i], val.RowIndex), outputColumns[groupExpressions.Count + i]);
+                            var previousValueColumn = val.referenceBatch.Columns[m_measures.Count + i];
+                            var previousValue = previousValueColumn.GetValueAt(val.RowIndex, default);
+                            var newValue = outputColumns[groupExpressions.Count + i].GetValueAt(outputColumns[groupExpressions.Count + i].Count - 1, default);
+                            if (val.valueSent)
+                            {
+                                outputColumns[groupExpressions.Count + i].Add(previousValue);
+                            }
+                            previousValueColumn.UpdateAt(val.RowIndex, newValue);
+                        }
+
+                        outputIterations.Add(0);
+                        outputWeights.Add(1);
+
+                        if (val.valueSent)
+                        {
+                            outputIterations.Add(0);
+                            outputWeights.Add(-1);
+                        }
+                        else
+                        {
+                            // Mark the value as sent
+                            treePage.Values._previousValueSent.Update(comparer.start, true);
+                        }
+
+                        await treePage.SavePage();
+                    }
+                }
+
+                yield return new StreamEventBatch(new EventBatchWeighted(outputWeights, outputIterations, new EventBatchData(outputColumns)));
+
+                await _temporaryTree.Clear();
+            }
+            yield break;
+        }
+
+        public override async IAsyncEnumerable<StreamEventBatch> OnRecieve(StreamEventBatch msg, long time)
+        {
+            Debug.Assert(_tree != null, "Tree should not be null");
+            Debug.Assert(_temporaryTree != null, "Temporary tree should not be null");
+            Debug.Assert(_treeIterator != null);
+
+            for(int i = 0; i < m_groupValues.Length; i++)
+            {
+                m_groupValues[i].Clear();
+            }
+            for (int i = 0; i < m_temporaryStateValues.Length; i++)
+            {
+                m_temporaryStateValues[i].Clear();
+            }
+
+            var data = msg.Data;
+            for (int i = 0; i < data.Count; i++)
+            {
+                var groupIndex = i;
+                if (groupExpressions != null)
+                {
+                    Debug.Assert(m_groupValues != null);
+                    for (int k = 0; k < groupExpressions.Count; k++)
+                    {
+                        groupExpressions[k](data.EventBatchData, i, m_groupValues[k]);
+                    }
+
+                    await _temporaryTree.RMWNoResult(new ColumnRowReference()
+                        {
+                            referenceBatch = m_groupValuesBatch,
+                            RowIndex = groupIndex
+                        }, default, (_, current, exist) =>
+                        {
+                            if (exist)
+                            {
+                                return (1, GenericWriteOperation.None);
+                            }
+                            else
+                            {
+                                return (1, GenericWriteOperation.Upsert);
+                            }
+                        });
+                }
+
+                var comparer = new AggregateSearchComparer(m_groupValues.Length);
+                await _treeIterator.Seek(new ColumnRowReference()
+                {
+                    referenceBatch = m_groupValuesBatch,
+                    RowIndex = groupIndex
+                }, comparer);
+                
+
+                if (!comparer.noMatch)
+                {
+                    var enumerator = _treeIterator.GetAsyncEnumerator();
+                    if (await enumerator.MoveNextAsync())
+                    {
+                        var page = enumerator.Current;
+                        var index = comparer.start;
+
+                        var state = page.Values.Get(index);
+
+                        if (m_measures.Count > 0)
+                        {
+                            for (int k = 0; k < m_measures.Count; k++)
+                            {
+                                var stateColumn = page.Values._eventBatch.Columns[k]; //.Get(index);
+                                await m_measures[k].Compute(new ColumnRowReference()
+                                {
+                                    referenceBatch = m_groupValuesBatch,
+                                    RowIndex = groupIndex
+                                }, data.EventBatchData, i, new ColumnReference(stateColumn, index), msg.Data.Weights.Get(i));
+                            }
+                        }
+
+                        var currentWeight = page.Values._weights.Get(index);
+                        page.Values._weights.Update(index, currentWeight + msg.Data.Weights.Get(i));
+
+                        await page.SavePage();
+                    }
+                }
+                else
+                {
+
+                    // No match, a new row must be added to the tree.
+                    int temporaryStateIndex = 0;
+                    if (m_measures.Count > 0)
+                    {
+                        temporaryStateIndex = m_temporaryStateValues[0].Count;
+                        for (int k = 0; k < m_measures.Count; k++)
+                        {
+                            var col = m_temporaryStateValues[k];
+                            // Add a null value for state.
+                            col.Add(NullValue.Instance);
+                            await m_measures[k].Compute(new ColumnRowReference()
+                            {
+                                referenceBatch = m_groupValuesBatch,
+                                RowIndex = groupIndex
+                            }, data.EventBatchData, i, new ColumnReference(col, temporaryStateIndex), msg.Data.Weights.Get(i));
+                        }
+                        for (int k = 0; k < m_measures.Count; k++)
+                        {
+                            // Add null values for the previous value
+                            var col = m_temporaryStateValues[m_measures.Count + k];
+                            col.Add(NullValue.Instance);
+                        }
+                    }
+                    
+
+                    await _tree.Upsert(new ColumnRowReference()
+                    {
+                        referenceBatch = m_groupValuesBatch,
+                        RowIndex = groupIndex
+                    }, new ColumnAggregateStateReference()
+                    {
+                        referenceBatch = m_temporaryStateBatch,
+                        RowIndex = temporaryStateIndex,
+                        weight = msg.Data.Weights.Get(i),
+                        valueSent = false
+                    });
+                }
+            }
+            yield break;
+        }
+
+        protected override async Task InitializeOrRestore(AggregateOperatorState? state, IStateManagerClient stateManagerClient)
+        {
+            if (m_aggregateRelation.Measures != null && m_aggregateRelation.Measures.Count > 0)
+            {
+                m_measures.Clear();
+                for (int i = 0; i < m_aggregateRelation.Measures.Count; i++)
+                {
+                    var measure = m_aggregateRelation.Measures[i];
+                    var aggregateContainer = await ColumnMeasureCompiler.CompileMeasure(groupExpressions?.Count ?? 0, stateManagerClient.GetChildManager(i.ToString()), measure.Measure, m_functionsRegister);
+                    m_measures.Add(aggregateContainer);
+                }
+            }
+
+            _tree = await stateManagerClient.GetOrCreateTree("grouping_set_1_v1",
+                new FlowtideDotNet.Storage.Tree.BPlusTreeOptions<ColumnRowReference, ColumnAggregateStateReference, AggregateKeyStorageContainer, ColumnAggregateValueContainer>()
+                {
+                    KeySerializer = new AggregateKeySerializer(m_groupValues.Length),
+                    ValueSerializer = new ColumnAggregateValueSerializer(m_measures.Count),
+                    Comparer = new AggregateInsertComparer(m_groupValues.Length)
+                });
+            _treeIterator = _tree.CreateIterator();
+            _temporaryTree = await stateManagerClient.GetOrCreateTree("grouping_set_1_v1_temp",
+                new FlowtideDotNet.Storage.Tree.BPlusTreeOptions<ColumnRowReference, int, AggregateKeyStorageContainer, ListValueContainer<int>>()
+                {
+                    KeySerializer = new AggregateKeySerializer(m_groupValues.Length),
+                    ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                    Comparer = new AggregateInsertComparer(m_groupValues.Length)
+                });
+            await _temporaryTree.Clear();
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateOperator.cs
@@ -123,9 +123,17 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             return Task.CompletedTask;
         }
 
-        public override Task<AggregateOperatorState> OnCheckpoint()
+        public override async Task<AggregateOperatorState> OnCheckpoint()
         {
-            return Task.FromResult(new AggregateOperatorState());
+            Debug.Assert(_tree != null);
+            await _tree.Commit();
+
+            // Commit each measure
+            foreach (var measure in m_measures)
+            {
+                await measure.Commit();
+            }
+            return new AggregateOperatorState();
         }
 
         protected override async IAsyncEnumerable<StreamEventBatch> OnWatermark(Watermark watermark)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateStateReference.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateStateReference.cs
@@ -1,0 +1,29 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal struct ColumnAggregateStateReference
+    {
+        public int RowIndex;
+        public EventBatchData referenceBatch;
+        public int weight;
+        public bool valueSent;
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
@@ -45,6 +45,14 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             _previousValueSent = new PrimitiveList<bool>(GlobalMemoryManager.Instance);
         }
 
+        public ColumnAggregateValueContainer(int measureCount, EventBatchData eventBatch, PrimitiveList<int> weights, PrimitiveList<bool> previousValueSent)
+        {
+            this.columnCount = measureCount * 2;
+            _eventBatch = eventBatch;
+            _weights = weights;
+            _previousValueSent = previousValueSent;
+        }
+
         public int Count => _eventBatch.Count;
 
         public void Add(ColumnAggregateStateReference key)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
@@ -83,6 +83,8 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
         public void Dispose()
         {
             _eventBatch.Dispose();
+            _weights.Dispose();
+            _previousValueSent.Dispose();
         }
 
         public ColumnAggregateStateReference Get(int index)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
@@ -1,0 +1,135 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.Memory;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Core.Operators.Normalization;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal class ColumnAggregateValueContainer : IValueContainer<ColumnAggregateStateReference>
+    {
+        private readonly int columnCount;
+        internal EventBatchData _eventBatch;
+        internal PrimitiveList<int> _weights;
+        internal PrimitiveList<bool> _previousValueSent;
+        public ColumnAggregateValueContainer(int measureCount)
+        {
+            this.columnCount = measureCount * 2;
+            ColumnStore.Column[] columns = new ColumnStore.Column[columnCount];
+
+            for (int i = 0; i < columnCount; i++)
+            {
+                columns[i] = ColumnStore.Column.Create(GlobalMemoryManager.Instance);
+            }
+
+            _eventBatch = new EventBatchData(columns);
+            _weights = new PrimitiveList<int>(GlobalMemoryManager.Instance);
+            _previousValueSent = new PrimitiveList<bool>(GlobalMemoryManager.Instance);
+        }
+
+        public int Count => _eventBatch.Count;
+
+        public void Add(ColumnAggregateStateReference key)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                _eventBatch.Columns[i].Add(key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, default));
+            }
+            _weights.Add(key.weight);
+            _previousValueSent.Add(key.valueSent);
+        }
+
+        public void AddRangeFrom(IValueContainer<ColumnAggregateStateReference> container, int start, int count)
+        {
+            if (container is ColumnAggregateValueContainer columnKeyStorageContainer)
+            {
+                for (int i = start; i < start + count; i++)
+                {
+                    Add(columnKeyStorageContainer.Get(i));
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public void Dispose()
+        {
+            _eventBatch.Dispose();
+        }
+
+        public ColumnAggregateStateReference Get(int index)
+        {
+            return new ColumnAggregateStateReference()
+            {
+                referenceBatch = _eventBatch,
+                RowIndex = index,
+                weight = _weights.Get(index),
+                valueSent = _previousValueSent.Get(index)
+            };
+        }
+
+        public ref ColumnAggregateStateReference GetRef(int index)
+        {
+            throw new NotImplementedException("Get by ref is not supported");
+        }
+
+        public void Insert(int index, ColumnAggregateStateReference value)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                _eventBatch.Columns[i].InsertAt(index, value.referenceBatch.Columns[i].GetValueAt(value.RowIndex, default));
+            }
+            _weights.InsertAt(index, value.weight);
+            _previousValueSent.InsertAt(index, value.valueSent);
+        }
+
+        public void RemoveAt(int index)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                _eventBatch.Columns[i].RemoveAt(index);
+            }
+            _weights.RemoveAt(index);
+            _previousValueSent.RemoveAt(index);
+        }
+
+        public void RemoveRange(int start, int count)
+        {
+            var end = start + count;
+            for (int i = end - 1; i >= start; i--)
+            {
+                RemoveAt(i);
+            }
+        }
+
+        public void Update(int index, ColumnAggregateStateReference value)
+        {
+            for (int i = 0; i < columnCount; i++)
+            {
+                _eventBatch.Columns[i].UpdateAt(index, value.referenceBatch.Columns[i].GetValueAt(value.RowIndex, default));
+            }
+            _weights.Update(index, value.weight);
+            _previousValueSent.Update(index, value.valueSent);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueSerializer.cs
@@ -1,0 +1,47 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Operators.Normalization;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal class ColumnAggregateValueSerializer : IBplusTreeValueSerializer<ColumnAggregateStateReference, ColumnAggregateValueContainer>
+    {
+        private readonly int measureCount;
+
+        public ColumnAggregateValueSerializer(int measureCount)
+        {
+            this.measureCount = measureCount;
+        }
+        public ColumnAggregateValueContainer CreateEmpty()
+        {
+            return new ColumnAggregateValueContainer(measureCount);
+        }
+
+        public ColumnAggregateValueContainer Deserialize(in BinaryReader reader)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Serialize(in BinaryWriter writer, in ColumnAggregateValueContainer values)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnMeasureCompiler.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnMeasureCompiler.cs
@@ -1,0 +1,68 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Core.Compute;
+using FlowtideDotNet.Storage.StateManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Core.Compute.Columnar;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.ColumnStore;
+
+namespace FlowtideDotNet.Core.Operators.Aggregate.Column
+{
+    internal static class ColumnMeasureCompiler
+    {
+        public static Task<IColumnAggregateContainer> CompileMeasure(int groupingLength, IStateManagerClient stateManagerClient, AggregateFunction aggregateFunction, FunctionsRegister functionsRegister)
+        {
+            if (functionsRegister.TryGetColumnAggregateFunction(aggregateFunction.ExtensionUri, aggregateFunction.ExtensionName, out var definition))
+            {
+                var param = System.Linq.Expressions.Expression.Parameter(typeof(EventBatchData));
+                var indexParam = System.Linq.Expressions.Expression.Parameter(typeof(int));
+                var stateParam = System.Linq.Expressions.Expression.Parameter(typeof(ColumnReference));
+                var weightParam = System.Linq.Expressions.Expression.Parameter(typeof(long));
+                var groupingKeyParameter = System.Linq.Expressions.Expression.Parameter(typeof(ColumnRowReference));
+                var valueResultExpr = System.Linq.Expressions.Expression.Constant(new DataValueContainer());
+                var parametersInfo = new ColumnParameterInfo(
+                    new List<ParameterExpression>() { param }, 
+                    new List<ParameterExpression>() { indexParam }, 
+                    new List<int> { 0 },
+                    valueResultExpr);
+
+                var expressionVisitor = new ColumnarExpressionVisitor(functionsRegister); //new FlowtideExpressionVisitor(functionsRegister, typeof(RowEvent));
+                var container = definition.CreateContainer(
+                    groupingLength,
+                    stateManagerClient,
+                    aggregateFunction,
+                    parametersInfo,
+                    expressionVisitor,
+                    param,
+                    indexParam,
+                    stateParam,
+                    weightParam,
+                    groupingKeyParameter);
+
+                return container;
+            }
+            else
+            {
+                throw new InvalidOperationException($"The function {aggregateFunction.ExtensionUri}:{aggregateFunction.ExtensionName} is not defined.");
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Buffer/BufferOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Buffer/BufferOperator.cs
@@ -71,14 +71,14 @@ namespace FlowtideDotNet.Core.Operators.Buffer
                 if (output.Count > 100)
                 {
                     _eventsCounter.Add(output.Count);
-                    yield return new StreamEventBatch(output);
+                    yield return new StreamEventBatch(output, bufferRelation.OutputLength);
                     output = new List<RowEvent>();
                 }
             }
             if (output.Count > 0)
             {
                 _eventsCounter.Add(output.Count);
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, bufferRelation.OutputLength);
             }
             await _tree.Clear();
         }

--- a/src/FlowtideDotNet.Core/Operators/Filter/Internal/NormalFilterImpl.cs
+++ b/src/FlowtideDotNet.Core/Operators/Filter/Internal/NormalFilterImpl.cs
@@ -22,12 +22,14 @@ namespace FlowtideDotNet.Core.Operators.Filter.Internal
     {
         private readonly Func<RowEvent, bool> _expression;
         private readonly List<int>? _emitList;
+        private readonly FilterRelation filterRelation;
         private FlexBuffer _flexBuffer;
         public NormalFilterImpl(FilterRelation filterRelation, FunctionsRegister functionsRegister)
         {
             _expression = BooleanCompiler.Compile<RowEvent>(filterRelation.Condition, functionsRegister);
             _emitList = filterRelation.Emit;
             _flexBuffer = new FlexBuffer(ArrayPool<byte>.Shared);
+            this.filterRelation = filterRelation;
         }
 
         public Task Compact()
@@ -90,7 +92,7 @@ namespace FlowtideDotNet.Core.Operators.Filter.Internal
 
             if (output.Count > 0)
             {
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, filterRelation.OutputLength);
             }
         }
 

--- a/src/FlowtideDotNet.Core/Operators/Iteration/IterationOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Iteration/IterationOperator.cs
@@ -85,11 +85,11 @@ namespace FlowtideDotNet.Core.Operators.Iteration
 
             if (egressOutput.Count > 0)
             {
-                yield return new KeyValuePair<int, StreamMessage<StreamEventBatch>>(0, new StreamMessage<StreamEventBatch>(new StreamEventBatch(egressOutput), time));
+                yield return new KeyValuePair<int, StreamMessage<StreamEventBatch>>(0, new StreamMessage<StreamEventBatch>(new StreamEventBatch(egressOutput, _iterationRelation.OutputLength), time));
             }
             if (loopOutput.Count > 0)
             {
-                yield return new KeyValuePair<int, StreamMessage<StreamEventBatch>>(1, new StreamMessage<StreamEventBatch>(new StreamEventBatch(loopOutput), time));
+                yield return new KeyValuePair<int, StreamMessage<StreamEventBatch>>(1, new StreamMessage<StreamEventBatch>(new StreamEventBatch(loopOutput, _iterationRelation.OutputLength), time));
             }
         }
 

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinOperatorBase.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinOperatorBase.cs
@@ -153,7 +153,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                 if (output.Count > 100)
                                 {
                                     _eventsCounter.Add(output.Count);
-                                    yield return new StreamEventBatch(output);
+                                    yield return new StreamEventBatch(output, mergeJoinRelation.OutputLength);
                                     output = new List<RowEvent>();
                                 }
                                 
@@ -179,7 +179,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     if (output.Count > 100)
                     {
                         _eventsCounter.Add(output.Count);
-                        yield return new StreamEventBatch(output);
+                        yield return new StreamEventBatch(output, mergeJoinRelation.OutputLength);
                         output = new List<RowEvent>();
                     }
                     
@@ -226,7 +226,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     outputWriter.WriteLine($"{o.Weight} {o.ToJson()}");
                 }
 #endif
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, mergeJoinRelation.OutputLength);
             }
 #if DEBUG_WRITE
             await leftInput.FlushAsync();
@@ -288,7 +288,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                 if (output.Count > 100)
                                 {
                                     _eventsCounter.Add(output.Count);
-                                    yield return new StreamEventBatch(output);
+                                    yield return new StreamEventBatch(output, mergeJoinRelation.OutputLength);
                                     output = new List<RowEvent>();
                                 }
                                 
@@ -335,7 +335,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     outputWriter.WriteLine($"{o.Weight} {o.ToJson()}");
                 }
 #endif
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, mergeJoinRelation.OutputLength);
             }
 #if DEBUG_WRITE
             await rightInput.FlushAsync();

--- a/src/FlowtideDotNet.Core/Operators/Join/NestedLoopJoin/BlockNestedJoinOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/NestedLoopJoin/BlockNestedJoinOperator.cs
@@ -271,7 +271,7 @@ namespace FlowtideDotNet.Core.Operators.Join.NestedLoopJoin
 
             await _leftTemporary.Clear();
 
-            yield return new StreamEventBatch(output);
+            yield return new StreamEventBatch(output, joinRelation.OutputLength);
         }
 
         public override async IAsyncEnumerable<StreamEventBatch> OnRecieve(int targetId, StreamEventBatch msg, long time)

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizationOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizationOperator.cs
@@ -117,7 +117,7 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             {
                 Debug.Assert(_eventsCounter != null, nameof(_eventsCounter));
                 _eventsCounter.Add(output.Count);
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, normalizationRelation.OutputLength);
             }
             
         }

--- a/src/FlowtideDotNet.Core/Operators/Partition/PartitionOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Partition/PartitionOperator.cs
@@ -50,8 +50,10 @@ namespace FlowtideDotNet.Core.Operators.Partition
         {
             Debug.Assert(_eventsProcessed != null);
             _eventsProcessed.Add(data.Events.Count);
+            int columnCount = 0;
             foreach(var e in data.Events)
             {
+                columnCount = e.Length;
                 var hash = _partitionFunction(e);
                 var partitionId = hash % targetNumber;
                 if (outputs[partitionId] == null)
@@ -64,7 +66,7 @@ namespace FlowtideDotNet.Core.Operators.Partition
             {
                 if (outputs[i] != null)
                 {
-                    yield return new KeyValuePair<int, StreamMessage<StreamEventBatch>>(i, new StreamMessage<StreamEventBatch>(new StreamEventBatch(outputs[i]!), time));
+                    yield return new KeyValuePair<int, StreamMessage<StreamEventBatch>>(i, new StreamMessage<StreamEventBatch>(new StreamEventBatch(outputs[i]!, columnCount), time));
                     outputs[i] = null;
                 }
             }

--- a/src/FlowtideDotNet.Core/Operators/Project/ProjectOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Project/ProjectOperator.cs
@@ -124,7 +124,7 @@ namespace FlowtideDotNet.Core.Operators.Project
             {
                 Debug.Assert(_eventsCounter != null, nameof(_eventsCounter));
                 _eventsCounter.Add(output.Count);
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, projectRelation.OutputLength);
             }
         }
 

--- a/src/FlowtideDotNet.Core/Operators/Read/BatchableReadBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/BatchableReadBaseOperator.cs
@@ -227,14 +227,14 @@ namespace FlowtideDotNet.Core.Operators.Read
 
                 if (outputList.Count > 100)
                 {
-                    await output.SendAsync(new StreamEventBatch(outputList));
+                    await output.SendAsync(new StreamEventBatch(outputList, readRelation.OutputLength));
                     outputList = new List<RowEvent>();
                     sentUpdates = true;
                 }
             }
             if (outputList.Count > 0)
             {
-                await output.SendAsync(new StreamEventBatch(outputList));
+                await output.SendAsync(new StreamEventBatch(outputList, readRelation.OutputLength));
                 outputList = new List<RowEvent>();
                 sentUpdates = true;
             }
@@ -318,14 +318,14 @@ namespace FlowtideDotNet.Core.Operators.Read
 
                 if (outputList.Count > 100)
                 {
-                    await output.SendAsync(new StreamEventBatch(outputList));
+                    await output.SendAsync(new StreamEventBatch(outputList, readRelation.OutputLength));
                     outputList = new List<RowEvent>();
                 }
             }
 
             if (outputList.Count > 0)
             {
-                await output.SendAsync(new StreamEventBatch(outputList));
+                await output.SendAsync(new StreamEventBatch(outputList, readRelation.OutputLength));
                 outputList = new List<RowEvent>();
             }
 
@@ -391,7 +391,7 @@ namespace FlowtideDotNet.Core.Operators.Read
 
                     if (outputList.Count > 100)
                     {
-                        await output.SendAsync(new StreamEventBatch(outputList));
+                        await output.SendAsync(new StreamEventBatch(outputList, readRelation.OutputLength));
                         outputList = new List<RowEvent>();
                     }
                 }
@@ -401,7 +401,7 @@ namespace FlowtideDotNet.Core.Operators.Read
 
             if (outputList.Count > 0)
             {
-                await output.SendAsync(new StreamEventBatch(outputList));
+                await output.SendAsync(new StreamEventBatch(outputList, readRelation.OutputLength));
                 outputList = new List<RowEvent>();
             }
             // Send the new max watermark

--- a/src/FlowtideDotNet.Core/Operators/Set/SetOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Set/SetOperator.cs
@@ -153,7 +153,7 @@ namespace FlowtideDotNet.Core.Operators.Set
 #endif
                 Debug.Assert(_eventsCounter != null, nameof(_eventsCounter));
                 _eventsCounter.Add(output.Count);
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, setRelation.OutputLength);
             }
 #if DEBUG_WRITE
             await outputWriter.FlushAsync();

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOperator.cs
@@ -117,7 +117,7 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
             }
 
             _eventsCounter.Add(output.Count);
-            return new SingleAsyncEnumerable<StreamEventBatch>(new StreamEventBatch(output));
+            return new SingleAsyncEnumerable<StreamEventBatch>(new StreamEventBatch(output, _tableFunctionRelation.OutputLength));
         }
 
         protected override Task InitializeOrRestore(object? state, IStateManagerClient stateManagerClient)

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionReadOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionReadOperator.cs
@@ -28,6 +28,7 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
     {
         private IReadOnlySet<string>? _watermarkNames;
         private readonly Func<RowEvent, IEnumerable<RowEvent>> _func;
+        private readonly TableFunctionRelation _tableFunctionRelation;
         private bool _hasSentInitial = false;
         private RowEvent _emptyRow;
 
@@ -38,6 +39,7 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
         {
             _func = TableFunctionCompiler.CompileWithArg(tableFunctionRelation.TableFunction, functionsRegister);
             _emptyRow = new RowEvent();
+            this._tableFunctionRelation = tableFunctionRelation;
         }
 
         public override string DisplayName => "TableFunction";
@@ -113,7 +115,7 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
                 _eventsProcessed.Add(outputEvents.Count);
 
                 // Send the events
-                await output.SendAsync(new StreamEventBatch(outputEvents));
+                await output.SendAsync(new StreamEventBatch(outputEvents, _tableFunctionRelation.OutputLength));
                 await output.SendWatermark(new Base.Watermark(Name, 1));
                 ScheduleCheckpoint(TimeSpan.FromMilliseconds(1));
                 _hasSentInitial = true;

--- a/src/FlowtideDotNet.Core/Operators/TimestampProvider/TimestampProviderOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TimestampProvider/TimestampProviderOperator.cs
@@ -96,7 +96,7 @@ namespace FlowtideDotNet.Core.Operators.TimestampProvider
                     {
                         b.Add(currentTimestamp);
                     })
-                }));
+                }, 1));
                 _eventsProcessed.Add(1);
             }
             else
@@ -107,7 +107,7 @@ namespace FlowtideDotNet.Core.Operators.TimestampProvider
                     {
                         b.Add(currentTimestamp);
                     })
-                }));
+                }, 1));
                 // Remove the previous row
                 await output.SendAsync(new StreamEventBatch(new List<RowEvent>()
                 {
@@ -115,7 +115,7 @@ namespace FlowtideDotNet.Core.Operators.TimestampProvider
                     {
                         b.Add(_state.LastSentTimestamp.Value);
                     })
-                }));
+                }, 1));
                 _eventsProcessed.Add(2);
             }
 

--- a/src/FlowtideDotNet.Core/Operators/TopN/TopNOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TopN/TopNOperator.cs
@@ -95,7 +95,7 @@ namespace FlowtideDotNet.Core.Operators.TopN
             {
                 Debug.Assert(_eventsOutCounter != null, nameof(_eventsOutCounter));
                 _eventsOutCounter.Add(output.Count);
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, relation.OutputLength);
             }
         }
 

--- a/src/FlowtideDotNet.Core/Operators/Unwrap/UnwrapOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Unwrap/UnwrapOperator.cs
@@ -125,7 +125,7 @@ namespace FlowtideDotNet.Core.Operators.Unwrap
 
             if (output.Count > 0)
             {
-                yield return new StreamEventBatch(output);
+                yield return new StreamEventBatch(output, unwrapRelation.OutputLength);
             }
             
         }

--- a/src/FlowtideDotNet.Core/Operators/VirtualTable/VirtualTableOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/VirtualTable/VirtualTableOperator.cs
@@ -92,7 +92,7 @@ namespace FlowtideDotNet.Core.Operators.VirtualTable
                 
             }
 
-            await output.SendAsync(new StreamEventBatch(outputEvents));
+            await output.SendAsync(new StreamEventBatch(outputEvents, virtualTableReadRelation.OutputLength));
             await output.SendWatermark(new Base.Watermark(Name, 1));
         }
     }

--- a/src/FlowtideDotNet.Core/StreamEventBatch.cs
+++ b/src/FlowtideDotNet.Core/StreamEventBatch.cs
@@ -28,6 +28,8 @@ namespace FlowtideDotNet.Core
 
         private EventBatchWeighted? _data;
         private List<RowEvent>? _events;
+        // Remove later when row events have been removed
+        private int _columnCount;
 
         public EventBatchWeighted Data => GetData();
 
@@ -55,7 +57,7 @@ namespace FlowtideDotNet.Core
             }
             if (_events != null)
             {
-                var columnCount = 0;
+                var columnCount = _columnCount;
                 if (_events.Count > 0)
                 {
                     columnCount = _events[0].RowData.Length;
@@ -70,11 +72,13 @@ namespace FlowtideDotNet.Core
         public StreamEventBatch(EventBatchWeighted data)
         {
             _data = data;
+            _columnCount = _data.EventBatchData.Columns.Count;
         }
 
-        public StreamEventBatch(List<RowEvent> events)
+        public StreamEventBatch(List<RowEvent> events, int columnCount)
         {
             _events = events;
+            _columnCount = columnCount;
         }
 
         public void Rent(int count)

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentStorage.cs
@@ -28,11 +28,10 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
 
         public long CurrentVersion => _version;
 
-        public ValueTask CheckpointAsync(byte[] metadata, bool includeIndex)
+        public async ValueTask CheckpointAsync(byte[] metadata, bool includeIndex)
         {
-            Write(1, metadata);
+            await Write(1, metadata);
             _version++;
-            return ValueTask.CompletedTask;
         }
 
         public ValueTask CompactAsync()

--- a/src/FlowtideDotNet.Substrait/Relations/AggregateRelation.cs
+++ b/src/FlowtideDotNet.Substrait/Relations/AggregateRelation.cs
@@ -100,6 +100,10 @@ namespace FlowtideDotNet.Substrait.Relations
         private int CalculateOutputLength()
         {
             int length = 0;
+            if (EmitSet)
+            {
+                return Emit.Count;
+            }
             if (Groupings != null)
             {
                 foreach(var group in Groupings)

--- a/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
@@ -135,6 +135,8 @@ namespace FlowtideDotNet.AcceptanceTests
                 ");
             await WaitForUpdate();
 
+            await Task.Delay(1000);
+
             await Crash();
 
             GenerateData(1000);

--- a/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
@@ -135,8 +135,6 @@ namespace FlowtideDotNet.AcceptanceTests
                 ");
             await WaitForUpdate();
 
-            await Task.Delay(1000);
-
             await Crash();
 
             GenerateData(1000);

--- a/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
@@ -49,6 +49,25 @@ namespace FlowtideDotNet.AcceptanceTests
             AssertCurrentDataEqual(Orders.GroupBy(x => x.UserKey).Select(x => new { UserKey = x.Key, Count = x.Count() }));
         }
 
+        /// <summary>
+        /// Tests that checks that emit is working correctly from aggregate operator
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task AggregateWithGroupOnlyAggregate()
+        {
+            GenerateData(10000);
+            await StartStream(@"
+                INSERT INTO output 
+                SELECT 
+                    '1' as c, count(*)
+                FROM orders
+                GROUP BY userkey");
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(Orders.GroupBy(x => x.UserKey).Select(x => new { c = "1", Count = x.Count() }));
+        }
+
         [Fact]
         public async Task AggregateOnJoinedData()
         {

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -49,6 +49,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         private int _egressCrashOnCheckpointCount;
         private IPersistentStorage? _persistentStorage;
         private ConnectorManager? _connectorManager;
+        private bool _dataUpdated;
 
         public IReadOnlyList<User> Users  => generator.Users;
 
@@ -222,6 +223,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             lock (_lock)
             {
                 _actualData = actualData;
+                _dataUpdated = true;
             }
         }
 
@@ -229,7 +231,11 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         {
             lock (_lock)
             {
-                updateCounter++;
+                if (_dataUpdated)
+                {
+                    updateCounter++;
+                }
+                _dataUpdated = false;
             }
         }
     

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -190,6 +190,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
                 .WithLoggerFactory(loggerFactory)
 #endif
                 .AddConnectorManager(_connectorManager)
+                .WithNotificationReciever(new NotificationReciever(CheckpointComplete))
                 .SetGetTimestampUpdateInterval(timestampInterval.Value)
                 .WithStateOptions(new Storage.StateManager.StateManagerOptions()
                 {
@@ -221,10 +222,17 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             lock (_lock)
             {
                 _actualData = actualData;
-                updateCounter++;
             }
         }
 
+        private void CheckpointComplete()
+        {
+            lock (_lock)
+            {
+                updateCounter++;
+            }
+        }
+    
         /// <summary>
         /// Simulate a crash on the stream, waits until the stream has failed.
         /// </summary>

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSourceOperator.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSourceOperator.cs
@@ -61,7 +61,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
                 if (o.Count > 100)
                 {
                     sentData = true;
-                    await output.SendAsync(new StreamEventBatch(o));
+                    await output.SendAsync(new StreamEventBatch(o, readRelation.OutputLength));
                     o = new List<RowEvent>();
                 }
             }
@@ -69,7 +69,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             if (o.Count > 0)
             {
                 sentData = true;
-                await output.SendAsync(new StreamEventBatch(o));
+                await output.SendAsync(new StreamEventBatch(o, readRelation.OutputLength));
             }
             _lastestOffset = fetchedOffset;
 
@@ -128,14 +128,14 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
 
                 if (o.Count > 100)
                 {
-                    await output.SendAsync(new StreamEventBatch(o));
+                    await output.SendAsync(new StreamEventBatch(o, readRelation.OutputLength));
                     o = new List<RowEvent>();
                 }
             }
 
             if (o.Count > 0)
             {
-                await output.SendAsync(new StreamEventBatch(o));
+                await output.SendAsync(new StreamEventBatch(o, readRelation.OutputLength));
             }
             _lastestOffset = fetchedOffset;
             await output.SendWatermark(new Base.Watermark(readRelation.NamedTable.DotSeperated, fetchedOffset));

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/MockTable.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/MockTable.cs
@@ -128,6 +128,16 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
                             }
                         });
                     }
+                    else if (column is List<string> listString)
+                    {
+                        b.Vector(b =>
+                        {
+                            foreach (var item in listString)
+                            {
+                                b.Add(item);
+                            }
+                        });
+                    }
                     else if (column is List<KeyValuePair<string, int>> listKeyInt)
                     {
                         b.Vector(v =>

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/NotificationReciever.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/NotificationReciever.cs
@@ -1,0 +1,40 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Base.Engine;
+using FlowtideDotNet.Base.Engine.Internal.StateMachine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.AcceptanceTests.Internal
+{
+    internal class NotificationReciever : IStreamNotificationReciever
+    {
+        private readonly Action onCheckpointComplete;
+
+        public NotificationReciever(Action onCheckpointComplete)
+        {
+            this.onCheckpointComplete = onCheckpointComplete;
+        }
+        public void OnCheckpointComplete()
+        {
+            onCheckpointComplete();
+        }
+
+        public void OnStreamStateChange(StreamStateValue newState)
+        {
+        }
+    }
+}

--- a/tests/FlowtideDotNet.AcceptanceTests/ListTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/ListTests.cs
@@ -53,6 +53,41 @@ namespace FlowtideDotNet.AcceptanceTests
         }
 
         [Fact]
+        public async Task ListAggWithUpdate()
+        {
+            GenerateData();
+            await StartStream(@"
+                INSERT INTO output 
+                SELECT 
+                    list_agg(firstName)
+                FROM users
+                ");
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(new[] { new { list = Users.Select(x => x.FirstName).OrderBy(x => x).ToList() } });
+
+            GenerateUsers(1);
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(new[] { new { list = Users.Select(x => x.FirstName).OrderBy(x => x).ToList() } });
+
+            var firstUser = Users[0];
+            firstUser.FirstName = "Aaa";
+            AddOrUpdateUser(firstUser);
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(new[] { new { list = Users.Select(x => x.FirstName).OrderBy(x => x).ToList() } });
+
+            DeleteUser(firstUser);
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(new[] { new { list = Users.Select(x => x.FirstName).OrderBy(x => x).ToList() } });
+        }
+
+        [Fact]
         public async Task ListAggWithObject()
         {
             GenerateData();

--- a/tests/FlowtideDotNet.AspNetCore.WebTest/DummyReadOperator.cs
+++ b/tests/FlowtideDotNet.AspNetCore.WebTest/DummyReadOperator.cs
@@ -85,7 +85,7 @@ namespace FlowtideDotNet.AspNetCore.WebTest
                         }
                     }));
                 }
-                await output.SendAsync(new StreamEventBatch(o));
+                await output.SendAsync(new StreamEventBatch(o, 16));
                 output.ExitCheckpointLock();
                 ScheduleCheckpoint(TimeSpan.FromSeconds(1));
             }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/BoolColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/BoolColumnTests.cs
@@ -48,16 +48,16 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             column.Add(new BoolValue(false));
             column.Add(new BoolValue(true));
 
-            var (start, end) = column.SearchBoundries(new BoolValue(false), 0,3, default);
+            var (start, end) = column.SearchBoundries(new BoolValue(false), 0,3, default, false);
             Assert.Equal(0, start);
             Assert.Equal(2, end);
 
-            (start, end) = column.SearchBoundries(new BoolValue(true), 0, 3, default);
+            (start, end) = column.SearchBoundries(new BoolValue(true), 0, 3, default, false);
             Assert.Equal(3, start);
             Assert.Equal(3, end);
 
             var emptyColumn = new BoolColumn(new BatchMemoryManager(1));
-            (start, end) = emptyColumn.SearchBoundries(new BoolValue(true), 0, -1, default);
+            (start, end) = emptyColumn.SearchBoundries(new BoolValue(true), 0, -1, default, false);
             Assert.Equal(~0, start);
             Assert.Equal(~0, end);
         }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/BoundarySearchTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/BoundarySearchTests.cs
@@ -1,0 +1,1184 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Tests.ColumnStore
+{
+    public class BoundarySearchTests
+    {
+        [Fact]
+        public void TestBoundarySearchWithIntegersAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+
+
+            var (start, end) = column.SearchBoundries(new Int64Value(0), 0, 3, default);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(1), 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(2), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(3), 0, 3, default);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(4), 0, 3, default);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithIntegersDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new Int64Value(3));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(1));
+
+            var (start, end) = column.SearchBoundries(new Int64Value(0), 0, 3, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(1), 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(2), 0, 3, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(3), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(4), 0, 3, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithIntegersAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(0), 0, 4, default);
+            Assert.Equal(~1, start);
+            Assert.Equal(~1, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(1), 0, 4, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(2), 0, 4, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(3), 0, 4, default);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(4), 0, 4, default);
+            Assert.Equal(~5, start);
+            Assert.Equal(~5, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithIntegersAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new Int64Value(3));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(1));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new Int64Value(0), 0, 4, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(1), 0, 4, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(2), 0, 4, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(3), 0, 4, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(4), 0, 4, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default, true);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithStringsAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new StringValue("b"));
+            column.Add(new StringValue("c"));
+            column.Add(new StringValue("c"));
+            column.Add(new StringValue("d"));
+
+
+            var (start, end) = column.SearchBoundries(new StringValue("a"), 0, 3, default);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("b"), 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("c"), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("d"), 0, 3, default);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("e"), 0, 3, default);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithStringsDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new StringValue("d"));
+            column.Add(new StringValue("c"));
+            column.Add(new StringValue("c"));
+            column.Add(new StringValue("b"));
+
+            var (start, end) = column.SearchBoundries(new StringValue("a"), 0, 3, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("b"), 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("c"), 0, 3, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("d"), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("e"), 0, 3, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithStringsAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new StringValue("b"));
+            column.Add(new StringValue("c"));
+            column.Add(new StringValue("c"));
+            column.Add(new StringValue("d"));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("a"), 0, 4, default);
+            Assert.Equal(~1, start);
+            Assert.Equal(~1, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("b"), 0, 4, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("c"), 0, 4, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("d"), 0, 4, default);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("e"), 0, 4, default);
+            Assert.Equal(~5, start);
+            Assert.Equal(~5, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithStringsAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new StringValue("d"));
+            column.Add(new StringValue("c"));
+            column.Add(new StringValue("c"));
+            column.Add(new StringValue("b"));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new StringValue("a"), 0, 4, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("b"), 0, 4, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("c"), 0, 4, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("d"), 0, 4, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("e"), 0, 4, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default, true);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithBoolAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new BoolValue(false));
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(true));
+
+            var (start, end) = column.SearchBoundries(new BoolValue(false), 0, 2, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new BoolValue(true), 0, 2, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithBoolDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(false));
+
+            var (start, end) = column.SearchBoundries(new BoolValue(false), 0, 2, default, true);
+            Assert.Equal(2, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new BoolValue(true), 0, 2, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithBoolAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new BoolValue(false));
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(true));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new BoolValue(false), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new BoolValue(true), 0, 3, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithBoolAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(false));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new BoolValue(false), 0, 3, default, true);
+            Assert.Equal(2, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new BoolValue(true), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithBinaryAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new BinaryValue(new byte[] { 1 }));
+            column.Add(new BinaryValue(new byte[] { 2 }));
+            column.Add(new BinaryValue(new byte[] { 2 }));
+            column.Add(new BinaryValue(new byte[] { 3 }));
+
+
+            var (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 0 }), 0, 3, default);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 1 }), 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 2 }), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 3 }), 0, 3, default);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 4 }), 0, 3, default);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithBinaryDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new BinaryValue(new byte[] { 3 }));
+            column.Add(new BinaryValue(new byte[] { 2 }));
+            column.Add(new BinaryValue(new byte[] { 2 }));
+            column.Add(new BinaryValue(new byte[] { 1 }));
+
+            var (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 0 }), 0, 3, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 1 }), 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 2 }), 0, 3, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 3 }), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 4 }), 0, 3, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithBinaryAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new BinaryValue(new byte[] { 1 }));
+            column.Add(new BinaryValue(new byte[] { 2 }));
+            column.Add(new BinaryValue(new byte[] { 2 }));
+            column.Add(new BinaryValue(new byte[] { 3 }));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 0 }), 0, 4, default);
+            Assert.Equal(~1, start);
+            Assert.Equal(~1, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 1 }), 0, 4, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 2 }), 0, 4, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 3 }), 0, 4, default);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 4 }), 0, 4, default);
+            Assert.Equal(~5, start);
+            Assert.Equal(~5, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithBinaryAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new BinaryValue(new byte[] { 3 }));
+            column.Add(new BinaryValue(new byte[] { 2 }));
+            column.Add(new BinaryValue(new byte[] { 2 }));
+            column.Add(new BinaryValue(new byte[] { 1 }));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 0 }), 0, 4, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 1 }), 0, 4, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 2 }), 0, 4, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 3 }), 0, 4, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new BinaryValue(new byte[] { 4 }), 0, 4, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default, true);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithDecimalsAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new DecimalValue(1));
+            column.Add(new DecimalValue(2));
+            column.Add(new DecimalValue(2));
+            column.Add(new DecimalValue(3));
+
+
+            var (start, end) = column.SearchBoundries(new DecimalValue(0), 0, 3, default);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(1), 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(2), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(3), 0, 3, default);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(4), 0, 3, default);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithDecimalsDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new DecimalValue(3));
+            column.Add(new DecimalValue(2));
+            column.Add(new DecimalValue(2));
+            column.Add(new DecimalValue(1));
+
+            var (start, end) = column.SearchBoundries(new DecimalValue(0), 0, 3, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(1), 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(2), 0, 3, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(3), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(4), 0, 3, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithDecimalsAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new DecimalValue(1));
+            column.Add(new DecimalValue(2));
+            column.Add(new DecimalValue(2));
+            column.Add(new DecimalValue(3));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(0), 0, 4, default);
+            Assert.Equal(~1, start);
+            Assert.Equal(~1, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(1), 0, 4, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(2), 0, 4, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(3), 0, 4, default);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(4), 0, 4, default);
+            Assert.Equal(~5, start);
+            Assert.Equal(~5, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithDecimalsAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new DecimalValue(3));
+            column.Add(new DecimalValue(2));
+            column.Add(new DecimalValue(2));
+            column.Add(new DecimalValue(1));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new DecimalValue(0), 0, 4, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(1), 0, 4, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(2), 0, 4, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(3), 0, 4, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(4), 0, 4, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default, true);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithDoubleAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new DoubleValue(1));
+            column.Add(new DoubleValue(2));
+            column.Add(new DoubleValue(2));
+            column.Add(new DoubleValue(3));
+
+            var (start, end) = column.SearchBoundries(new DoubleValue(0), 0, 3, default);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(1), 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(2), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(3), 0, 3, default);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(4), 0, 3, default);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithDoubleDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new DoubleValue(3));
+            column.Add(new DoubleValue(2));
+            column.Add(new DoubleValue(2));
+            column.Add(new DoubleValue(1));
+
+            var (start, end) = column.SearchBoundries(new DoubleValue(0), 0, 3, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(1), 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(2), 0, 3, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(3), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(4), 0, 3, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithDoubleAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new DoubleValue(1));
+            column.Add(new DoubleValue(2));
+            column.Add(new DoubleValue(2));
+            column.Add(new DoubleValue(3));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(0), 0, 4, default);
+            Assert.Equal(~1, start);
+            Assert.Equal(~1, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(1), 0, 4, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(2), 0, 4, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(3), 0, 4, default);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(4), 0, 4, default);
+            Assert.Equal(~5, start);
+            Assert.Equal(~5, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithDoubleAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new DoubleValue(3));
+            column.Add(new DoubleValue(2));
+            column.Add(new DoubleValue(2));
+            column.Add(new DoubleValue(1));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new DoubleValue(0), 0, 4, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(1), 0, 4, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(2), 0, 4, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(3), 0, 4, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DoubleValue(4), 0, 4, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default, true);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithListAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new ListValue(new Int64Value(1)));
+            column.Add(new ListValue(new Int64Value(2)));
+            column.Add(new ListValue(new Int64Value(2)));
+            column.Add(new ListValue(new Int64Value(3)));
+
+            var (start, end) = column.SearchBoundries(new ListValue(new Int64Value(0)), 0, 3, default);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(1)), 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(2)), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(3)), 0, 3, default);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(4)), 0, 3, default);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithListDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new ListValue(new Int64Value(3)));
+            column.Add(new ListValue(new Int64Value(2)));
+            column.Add(new ListValue(new Int64Value(2)));
+            column.Add(new ListValue(new Int64Value(1)));
+
+            var (start, end) = column.SearchBoundries(new ListValue(new Int64Value(0)), 0, 3, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(1)), 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(2)), 0, 3, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(3)), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(4)), 0, 3, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithListAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new ListValue(new Int64Value(1)));
+            column.Add(new ListValue(new Int64Value(2)));
+            column.Add(new ListValue(new Int64Value(2)));
+            column.Add(new ListValue(new Int64Value(3)));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(0)), 0, 4, default);
+            Assert.Equal(~1, start);
+            Assert.Equal(~1, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(1)), 0, 4, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(2)), 0, 4, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(3)), 0, 4, default);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(4)), 0, 4, default);
+            Assert.Equal(~5, start);
+            Assert.Equal(~5, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithListAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new ListValue(new Int64Value(3)));
+            column.Add(new ListValue(new Int64Value(2)));
+            column.Add(new ListValue(new Int64Value(2)));
+            column.Add(new ListValue(new Int64Value(1)));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new ListValue(new Int64Value(0)), 0, 4, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(1)), 0, 4, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(2)), 0, 4, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(3)), 0, 4, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new ListValue(new Int64Value(4)), 0, 4, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default, true);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithMapsAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(1))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(3))));
+
+            var (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(0))), 0, 3, default);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(1))), 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(3))), 0, 3, default);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(4))), 0, 3, default);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithMapsDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(3))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(1))));
+
+            var (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(0))), 0, 3, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(1))), 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))), 0, 3, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(3))), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(4))), 0, 3, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithMapsAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(1))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(3))));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(0))), 0, 4, default);
+            Assert.Equal(~1, start);
+            Assert.Equal(~1, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(1))), 0, 4, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))), 0, 4, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(3))), 0, 4, default);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(4))), 0, 4, default);
+            Assert.Equal(~5, start);
+            Assert.Equal(~5, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithMapsAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(3))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))));
+            column.Add(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(1))));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(0))), 0, 4, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(1))), 0, 4, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(2))), 0, 4, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(3))), 0, 4, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new MapValue(new KeyValuePair<IDataValue, IDataValue>(new Int64Value(1), new Int64Value(4))), 0, 4, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default, true);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithUnionAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new Int64Value(1));
+            column.Add(new StringValue("a"));
+            column.Add(new StringValue("a"));
+            column.Add(new DecimalValue(3));
+
+            var (start, end) = column.SearchBoundries(new Int64Value(0), 0, 3, default);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(1), 0, 3, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("a"), 0, 3, default);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(3), 0, 3, default);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(4), 0, 3, default);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithUnionDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new DecimalValue(3));
+            column.Add(new StringValue("a"));
+            column.Add(new StringValue("a"));
+            column.Add(new Int64Value(1));
+
+            var (start, end) = column.SearchBoundries(new Int64Value(0), 0, 3, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(1), 0, 3, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("a"), 0, 3, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(3), 0, 3, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(4), 0, 3, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithUnionAndNullAscending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(NullValue.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new StringValue("a"));
+            column.Add(new StringValue("a"));
+            column.Add(new DecimalValue(3));
+
+            var (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(0), 0, 4, default);
+            Assert.Equal(~1, start);
+            Assert.Equal(~1, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(1), 0, 4, default);
+            Assert.Equal(1, start);
+            Assert.Equal(1, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("a"), 0, 4, default);
+            Assert.Equal(2, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(3), 0, 4, default);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(4), 0, 4, default);
+            Assert.Equal(~5, start);
+            Assert.Equal(~5, end);
+        }
+
+        [Fact]
+        public void TestBoundarySearchWithUnionAndNullDescending()
+        {
+            Column column = Column.Create(GlobalMemoryManager.Instance);
+
+            column.Add(new DecimalValue(3));
+            column.Add(new StringValue("a"));
+            column.Add(new StringValue("a"));
+            column.Add(new Int64Value(1));
+            column.Add(NullValue.Instance);
+
+            var (start, end) = column.SearchBoundries(new Int64Value(0), 0, 4, default, true);
+            Assert.Equal(~4, start);
+            Assert.Equal(~4, end);
+
+            (start, end) = column.SearchBoundries(new Int64Value(1), 0, 4, default, true);
+            Assert.Equal(3, start);
+            Assert.Equal(3, end);
+
+            (start, end) = column.SearchBoundries(new StringValue("a"), 0, 4, default, true);
+            Assert.Equal(1, start);
+            Assert.Equal(2, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(3), 0, 4, default, true);
+            Assert.Equal(0, start);
+            Assert.Equal(0, end);
+
+            (start, end) = column.SearchBoundries(new DecimalValue(4), 0, 4, default, true);
+            Assert.Equal(-1, start);
+            Assert.Equal(-1, end);
+
+            (start, end) = column.SearchBoundries(NullValue.Instance, 0, 4, default, true);
+            Assert.Equal(4, start);
+            Assert.Equal(4, end);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/DoubleColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/DoubleColumnTests.cs
@@ -55,24 +55,24 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             column.Add(new DoubleValue(6));
             column.Add(new DoubleValue(7));
 
-            var (start, end) = column.SearchBoundries(new DoubleValue(2), 0, 9, default);
+            var (start, end) = column.SearchBoundries(new DoubleValue(2), 0, 9, default, false);
             Assert.Equal(1, start);
             Assert.Equal(4, end);
 
-            (start, end) = column.SearchBoundries(new DoubleValue(3), 0, 9, default);
+            (start, end) = column.SearchBoundries(new DoubleValue(3), 0, 9, default, false);
             Assert.Equal(5, start);
             Assert.Equal(5, end);
 
-            (start, end) = column.SearchBoundries(new DoubleValue(4), 0, 9, default);
+            (start, end) = column.SearchBoundries(new DoubleValue(4), 0, 9, default, false);
             Assert.Equal(6, start);
             Assert.Equal(7, end);
 
-            (start, end) = column.SearchBoundries(new DoubleValue(9), 0, 9, default);
+            (start, end) = column.SearchBoundries(new DoubleValue(9), 0, 9, default, false);
             Assert.Equal(~10, start);
             Assert.Equal(~10, end);
 
             var emptyColumn = new DoubleColumn(new BatchMemoryManager(1));
-            (start, end) = emptyColumn.SearchBoundries(new DoubleValue(4), 0, -1, default);
+            (start, end) = emptyColumn.SearchBoundries(new DoubleValue(4), 0, -1, default, false);
             Assert.Equal(~0, start);
             Assert.Equal(~0, end);
         }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/In64ColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/In64ColumnTests.cs
@@ -48,7 +48,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             c1.Add(new Int64Value(1));
             c1.Add(new Int64Value(1));
             c1.Add(new Int64Value(2));
-            var (start, end) = c1.SearchBoundries(new Int64Value(1), 0, 4, default);
+            var (start, end) = c1.SearchBoundries(new Int64Value(1), 0, 4, default, false);
             Assert.Equal(0, start);
             Assert.Equal(2, end);
 
@@ -65,24 +65,24 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             column.Add(new Int64Value(6));
             column.Add(new Int64Value(7));
 
-            (start, end) = column.SearchBoundries(new Int64Value(2), 0, 9, default);
+            (start, end) = column.SearchBoundries(new Int64Value(2), 0, 9, default, false);
             Assert.Equal(1, start);
             Assert.Equal(4, end);
 
-            (start, end) = column.SearchBoundries(new Int64Value(3), 0, 9, default);
+            (start, end) = column.SearchBoundries(new Int64Value(3), 0, 9, default, false);
             Assert.Equal(5, start);
             Assert.Equal(5, end);
 
-            (start, end) = column.SearchBoundries(new Int64Value(4), 0, 9, default);
+            (start, end) = column.SearchBoundries(new Int64Value(4), 0, 9, default, false);
             Assert.Equal(6, start);
             Assert.Equal(7, end);
 
-            (start, end) = column.SearchBoundries(new Int64Value(9), 0, 9, default);
+            (start, end) = column.SearchBoundries(new Int64Value(9), 0, 9, default, false);
             Assert.Equal(~10, start);
             Assert.Equal(~10, end);
 
             var emptyColumn = new Int64Column(new BatchMemoryManager(0));
-            (start, end) = emptyColumn.SearchBoundries(new Int64Value(4), 0, -1, default);
+            (start, end) = emptyColumn.SearchBoundries(new Int64Value(4), 0, -1, default, false);
             Assert.Equal(~0, start);
             Assert.Equal(~0, end);
         }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ListColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ListColumnTests.cs
@@ -381,7 +381,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
                 new Int64Value(4),
                 new Int64Value(5),
                 new Int64Value(6)
-            }), 0, 2, default);
+            }), 0, 2, default, false);
 
             Assert.Equal(1, start);
             Assert.Equal(1, end);

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ListColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ListColumnTests.cs
@@ -287,6 +287,44 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
         }
 
         [Fact]
+        public void InsertNullInMiddleOfList()
+        {
+            ListColumn listColumn = new ListColumn(GlobalMemoryManager.Instance);
+            listColumn.Add(new ListValue(new List<IDataValue>()
+            {
+                new Int64Value(1),
+                new Int64Value(2),
+                new Int64Value(3)
+            }));
+            listColumn.Add(new ListValue(new List<IDataValue>()
+            {
+                new Int64Value(4),
+                new Int64Value(5)
+            }));
+
+            listColumn.InsertAt(1, NullValue.Instance);
+
+            Assert.Equal(3, listColumn.Count);
+
+            var currentValue = listColumn.GetValueAt(0, default);
+            var list = currentValue.AsList;
+            Assert.Equal(3, list.Count);
+            Assert.Equal(1, list.GetAt(0).AsLong);
+            Assert.Equal(2, list.GetAt(1).AsLong);
+            Assert.Equal(3, list.GetAt(2).AsLong);
+
+            currentValue = listColumn.GetValueAt(1, default);
+            list = currentValue.AsList;
+            Assert.Equal(0, list.Count);
+
+            currentValue = listColumn.GetValueAt(2, default);
+            list = currentValue.AsList;
+            Assert.Equal(2, list.Count);
+            Assert.Equal(4, list.GetAt(0).AsLong);
+            Assert.Equal(5, list.GetAt(1).AsLong);
+        }
+
+        [Fact]
         public void InsertAtEndOfList()
         {
             ListColumn listColumn = new ListColumn(GlobalMemoryManager.Instance);

--- a/tests/FlowtideDotNet.Core.Tests/Failure/TestIngress.cs
+++ b/tests/FlowtideDotNet.Core.Tests/Failure/TestIngress.cs
@@ -82,7 +82,7 @@ namespace FlowtideDotNet.Core.Tests.Failure
             await output.SendAsync(new StreamEventBatch(new List<RowEvent>()
             {
                 streamEvent
-            }));
+            }, 3));
             await output.SendWatermark(new FlowtideDotNet.Base.Watermark("test", 1));
             output.ExitCheckpointLock();
             await this.RegisterTrigger("on_check", TimeSpan.FromSeconds(5));

--- a/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
@@ -237,7 +237,7 @@ namespace FlowtideDotNet.SqlServer.Tests.Acceptance
                 {
                     b.Add(1);
                 })
-            }), 0));
+            }, 1), 0));
 
             await sink.SendAsync(new Checkpoint(0, 1));
 


### PR DESCRIPTION
The new column based aggregate operator that will replace the row based on.
There are some improvements that can be made such as changing from List<int> in the aggregate functions for weights to primitivelist which will use unmanaged memory instead of managed to help the cache free up memory earlier.

This PR also adds support for descending boundary search in columns since it is required by the max() aggregate function.