### PR TITLE
Fix so sql server source uses column and fix so convert to union disposes old column directly

### DIFF
--- a/src/FlowtideDotNet.Connector.SqlServer/Extensions/ReadWriteFactoryExtensions.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/Extensions/ReadWriteFactoryExtensions.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Connector.SqlServer;
+using FlowtideDotNet.Connector.SqlServer.SqlServer;
 using FlowtideDotNet.SqlServer.SqlServer;
 using FlowtideDotNet.Substrait.Relations;
 using FlowtideDotNet.Substrait.Tests.SqlServer;
@@ -36,7 +37,7 @@ namespace FlowtideDotNet.Core.Engine
                 }
                 transform?.Invoke(relation);
 
-                var source = new SqlServerDataSource(connectionStringFunc, relation.NamedTable.DotSeperated, relation, dataflowopt);
+                var source = new ColumnSqlServerDataSource(connectionStringFunc, relation.NamedTable.DotSeperated, relation, dataflowopt);
                 var primaryKeys = source.GetPrimaryKeys();
 
                 if (!source.IsChangeTrackingEnabled())

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -204,7 +204,9 @@ namespace FlowtideDotNet.Core.ColumnStore
                     // Convert from single buffer to union buffer
                     var unionColumn = ConvertToUnion();
                     _type = ArrowTypeId.Union;
+                    var previousColumn = _dataColumn;
                     _dataColumn = unionColumn;
+                    previousColumn.Dispose();
                     _validityList.Clear();
                     _nullCounter = 0;
                     _dataColumn.Add(value);
@@ -302,7 +304,12 @@ namespace FlowtideDotNet.Core.ColumnStore
                 {
                     // Convert from single buffer to union buffer
                     var unionColumn = ConvertToUnion();
+                    var previousColumn = _dataColumn;
                     _dataColumn = unionColumn;
+                    if (previousColumn != null)
+                    {
+                        previousColumn.Dispose();
+                    }
                     _type = ArrowTypeId.Union;
                     _validityList.Clear();
                     _nullCounter = 0;
@@ -649,7 +656,12 @@ namespace FlowtideDotNet.Core.ColumnStore
             {
                 var unionColumn = ConvertToUnion();
                 _type = ArrowTypeId.Union;
+                var previousColumn = _dataColumn;
                 _dataColumn = unionColumn;
+                if (previousColumn != null)
+                {
+                    previousColumn.Dispose();
+                }
                 if (_validityList != null)
                 {
                     _validityList.Clear();
@@ -687,7 +699,12 @@ namespace FlowtideDotNet.Core.ColumnStore
             {
                 var unionColumn = ConvertToUnion();
                 _type = ArrowTypeId.Union;
+                var previousColumn = _dataColumn;
                 _dataColumn = unionColumn;
+                if (previousColumn != null)
+                {
+                    previousColumn.Dispose();
+                }
                 if (_validityList != null)
                 {
                     _validityList.Clear();


### PR DESCRIPTION
The dispose only helps clean up memory faster.