### PR TITLE
Change internal node to use native memory for children

### DIFF
--- a/samples/MonitoringPrometheus/DummyReadOperator.cs
+++ b/samples/MonitoringPrometheus/DummyReadOperator.cs
@@ -20,6 +20,7 @@ using FlowtideDotNet.Core.Operators.Read;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Substrait.Relations;
 using System.Threading.Tasks.Dataflow;
+using FlowtideDotNet.Storage.DataStructures;
 
 namespace MonitoringPrometheus
 {

--- a/samples/SqlSampleWithUI/DummyReadOperator.cs
+++ b/samples/SqlSampleWithUI/DummyReadOperator.cs
@@ -17,6 +17,7 @@ using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Core.Connectors;
 using FlowtideDotNet.Core.Operators.Read;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Substrait.Relations;
 using System.Threading.Tasks.Dataflow;

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricSeries.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricSeries.cs
@@ -66,7 +66,7 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             _valueSerializer = new DoubleValueSerializer(GlobalMemoryManager.Instance);
             _client = await _stateManager.CreateClientAsync<IBPlusTreeNode, BPlusTreeMetadata>(string.Empty, new FlowtideDotNet.Storage.StateManager.Internal.StateClientOptions<IBPlusTreeNode>()
             {
-                ValueSerializer = new BPlusTreeSerializer<long, double, TimestampKeyContainer, DoubleValueContainer>(_keySerializer, _valueSerializer),
+                ValueSerializer = new BPlusTreeSerializer<long, double, TimestampKeyContainer, DoubleValueContainer>(_keySerializer, _valueSerializer, GlobalMemoryManager.Instance),
             });
         }
 
@@ -91,6 +91,7 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
                     BucketSize = 1024,
                     UseByteBasedPageSizes = false,
                     PageSizeBytes = 32 * 1024,
+                    MemoryAllocator = GlobalMemoryManager.Instance
                 });
                 await tree.InitializeAsync();
                 serie = new MetricSerie(name, tags, tree);

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueContainer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueContainer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueSerializer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueSerializer.cs
@@ -12,6 +12,7 @@
 
 using Apache.Arrow.Memory;
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeyContainer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeyContainer.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeySerializer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeySerializer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 

--- a/src/FlowtideDotNet.Connector.CosmosDB/Internal/CosmosDbSink.cs
+++ b/src/FlowtideDotNet.Connector.CosmosDB/Internal/CosmosDbSink.cs
@@ -292,8 +292,9 @@ namespace FlowtideDotNet.Connector.CosmosDB.Internal
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(PrimaryKeyComparer!),
                 ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
-                KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer())
-            });
+                KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
+                });
 
             // Clear the modified tree in case of a crash
             await m_modified.Clear();

--- a/src/FlowtideDotNet.Connector.Sharepoint/Internal/SharepointSink.cs
+++ b/src/FlowtideDotNet.Connector.Sharepoint/Internal/SharepointSink.cs
@@ -85,7 +85,8 @@ namespace FlowtideDotNet.Connector.Sharepoint.Internal
             {
                 Comparer = new BPlusTreeListComparer<string>(StringComparer.OrdinalIgnoreCase),
                 KeySerializer = new KeyListSerializer<string>(new StringSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
             listId = await sharepointGraphListClient.GetListId(writeRelation.NamedObject.DotSeperated);
             encoders = await sharepointGraphListClient.GetColumnEncoders(writeRelation.NamedObject.DotSeperated, writeRelation.TableSchema.Names, stateManagerClient);

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/ColumnSqlServerDataSource.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/ColumnSqlServerDataSource.cs
@@ -17,6 +17,7 @@ using FlowtideDotNet.Core.ColumnStore;
 using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Core.Operators.Read;
 using FlowtideDotNet.SqlServer.SqlServer;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Substrait.Relations;
 using FlowtideDotNet.Substrait.Tests.SqlServer;

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerSink.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerSink.cs
@@ -262,7 +262,8 @@ namespace FlowtideDotNet.SqlServer.SqlServer
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(PrimaryKeyComparer),
                 ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
-                KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer())
+                KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
             // Clear the modified tree in case of a crash
             await m_modified.Clear();

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -12,14 +12,8 @@
 
 using Apache.Arrow;
 using FlowtideDotNet.Core.ColumnStore.DataValues;
-using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Substrait.Expressions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using static SqlParser.Ast.TableConstraint;
 
 namespace FlowtideDotNet.Core.ColumnStore
 {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -17,6 +17,7 @@ using FlowtideDotNet.Core.ColumnStore.Comparers;
 using FlowtideDotNet.Core.ColumnStore.Serialization.CustomTypes;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
 using System;

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -15,6 +15,7 @@ using Apache.Arrow.Types;
 using FlowtideDotNet.Core.ColumnStore.Comparers;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
 using System;

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -16,6 +16,7 @@ using Apache.Arrow.Types;
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
 using System;

--- a/src/FlowtideDotNet.Core/ColumnStore/EventBatchWeighted.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/EventBatchWeighted.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Base;
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;

--- a/src/FlowtideDotNet.Core/ColumnStore/RowEventToEventBatchData.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/RowEventToEventBatchData.cs
@@ -14,6 +14,7 @@ using FlexBuffers;
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using System;
 using System.Collections.Generic;

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ColumnListAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ColumnListAggAggregation.cs
@@ -73,6 +73,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
                     KeySerializer = new ListAggKeyStorageSerializer(groupingLength, memoryAllocator),
                     ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
                     UseByteBasedPageSizes = true,
+                    MemoryAllocator = memoryAllocator
                 });
 
             return new ColumnListAggAggregationSingleton(tree, groupingLength);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/ColumnMinMaxAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/ColumnMinMaxAggregation.cs
@@ -199,6 +199,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.Mi
                     KeySerializer = new ListAggKeyStorageSerializer(groupingLength, memoryAllocator),
                     ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
                     UseByteBasedPageSizes = true,
+                    MemoryAllocator = memoryAllocator
                 });
 
             return new MinMaxColumnAggregationSingleton(tree, searchComparer, tree.CreateIterator(), groupingLength);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/StringAgg/ColumnStringAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/StringAgg/ColumnStringAggAggregation.cs
@@ -77,6 +77,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.St
                     KeySerializer = new ListAggKeyStorageSerializer(groupingLength, memoryAllocator),
                     ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
                     UseByteBasedPageSizes = true,
+                    MemoryAllocator = memoryAllocator
                 });
 
             return new ColumnStringAggAggregationSingleton(tree, groupingLength);

--- a/src/FlowtideDotNet.Core/Compute/Internal/StatefulAggregations/ListAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/StatefulAggregations/ListAggAggregation.cs
@@ -92,8 +92,9 @@ namespace FlowtideDotNet.Core.Compute.Internal.StatefulAggregations
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(new ListAggAggregationInsertComparer(groupingLength + 1)),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
-            });
+                ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                MemoryAllocator = memoryAllocator
+                });
 
             return new ListAggAggregationSingleton(tree, groupingLength);
         }

--- a/src/FlowtideDotNet.Core/Compute/Internal/StatefulAggregations/MinMaxAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/StatefulAggregations/MinMaxAggregation.cs
@@ -136,7 +136,8 @@ namespace FlowtideDotNet.Core.Compute.Internal.StatefulAggregations
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(comparer),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             });
 
             return new MinMaxAggregationSingleton(tree, groupingLength);

--- a/src/FlowtideDotNet.Core/Compute/Internal/StatefulAggregations/StringAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/StatefulAggregations/StringAggAggregation.cs
@@ -113,7 +113,8 @@ namespace FlowtideDotNet.Core.Compute.Internal.StatefulAggregations
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(new ListAggAggregationInsertComparer(groupingLength + 1)),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                MemoryAllocator = memoryAllocator
             });
 
             return new StringAggAggregationSingleton(tree, groupingLength);

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/AggregateOperator.cs
@@ -435,14 +435,16 @@ namespace FlowtideDotNet.Core.Operators.Aggregate
             {
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
                 ValueSerializer = new ValueListSerializer<AggregateRowState>(new AggregateRowStateSerializer()),
-                Comparer = new BPlusTreeListComparer<RowEvent>(new BPlusTreeStreamEventComparer())
+                Comparer = new BPlusTreeListComparer<RowEvent>(new BPlusTreeStreamEventComparer()),
+                MemoryAllocator = MemoryAllocator
             });
             _temporaryTree = await stateManagerClient.GetOrCreateTree("grouping_set_1_v1_temp", 
                 new FlowtideDotNet.Storage.Tree.BPlusTreeOptions<RowEvent, int, ListKeyContainer<RowEvent>, ListValueContainer<int>>()
             {
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
                 ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
-                Comparer = new BPlusTreeListComparer<RowEvent>(new BPlusTreeStreamEventComparer())
+                Comparer = new BPlusTreeListComparer<RowEvent>(new BPlusTreeStreamEventComparer()),
+                MemoryAllocator = MemoryAllocator
             });
             await _temporaryTree.Clear();
         }

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateOperator.cs
@@ -23,6 +23,7 @@ using FlowtideDotNet.Core.Compute.Columnar;
 using FlowtideDotNet.Core.Compute.Internal;
 using FlowtideDotNet.Core.Operators.Set;
 using FlowtideDotNet.Core.Storage;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Serializers;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
@@ -696,7 +697,8 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
                     KeySerializer = new AggregateKeySerializer(m_groupValues.Length, MemoryAllocator),
                     ValueSerializer = new ColumnAggregateValueSerializer(m_measures.Count, MemoryAllocator),
                     Comparer = new AggregateInsertComparer(m_groupValues.Length),
-                    UseByteBasedPageSizes = true
+                    UseByteBasedPageSizes = true,
+                    MemoryAllocator = MemoryAllocator
                 });
             _treeIterator = _tree.CreateIterator();
             _temporaryTree = await stateManagerClient.GetOrCreateTree("grouping_set_1_v1_temp",
@@ -705,7 +707,8 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
                     KeySerializer = new AggregateKeySerializer(m_groupValues.Length, MemoryAllocator),
                     ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
                     Comparer = new AggregateInsertComparer(m_groupValues.Length),
-                    UseByteBasedPageSizes = true
+                    UseByteBasedPageSizes = true,
+                    MemoryAllocator = MemoryAllocator
                 });
             await _temporaryTree.Clear();
         }

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
@@ -14,6 +14,7 @@ using FlowtideDotNet.Core.ColumnStore;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Core.Operators.Normalization;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueSerializer.cs
@@ -14,6 +14,7 @@ using Apache.Arrow.Ipc;
 using FlowtideDotNet.Core.ColumnStore.Serialization;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.Operators.Normalization;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;
@@ -56,8 +57,8 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             var recordBatch = arrowReader.ReadNextRecordBatch();
 
             var eventBatch = EventArrowSerializer.ArrowToBatch(recordBatch, memoryAllocator);
-            var previousValueList = new ColumnStore.Utils.PrimitiveList<bool>(previousValueNativeMemory, recordBatch.Length, memoryAllocator);
-            var weightsList = new ColumnStore.Utils.PrimitiveList<int>(weightNativeMemory, recordBatch.Length, memoryAllocator);
+            var previousValueList = new PrimitiveList<bool>(previousValueNativeMemory, recordBatch.Length, memoryAllocator);
+            var weightsList = new PrimitiveList<int>(weightNativeMemory, recordBatch.Length, memoryAllocator);
 
             return new ColumnAggregateValueContainer(measureCount, eventBatch, weightsList, previousValueList);
         }

--- a/src/FlowtideDotNet.Core/Operators/Buffer/BufferOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Buffer/BufferOperator.cs
@@ -136,7 +136,8 @@ namespace FlowtideDotNet.Core.Operators.Buffer
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(new BPlusTreeStreamEventComparer()),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
         }
     }

--- a/src/FlowtideDotNet.Core/Operators/Filter/ColumnFilterOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Filter/ColumnFilterOperator.cs
@@ -15,6 +15,7 @@ using FlowtideDotNet.Core.ColumnStore;
 using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Core.Compute.Columnar;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Substrait.Relations;
 using System;

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnStoreMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnStoreMergeJoin.cs
@@ -34,6 +34,7 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Core.Compute.Columnar;
+using FlowtideDotNet.Storage.DataStructures;
 
 namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 {
@@ -682,7 +683,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     Comparer = _leftInsertComparer,
                     KeySerializer = new ColumnStoreSerializer(_mergeJoinRelation.Left.OutputLength, MemoryAllocator),
                     ValueSerializer = new JoinWeightsSerializer(MemoryAllocator),
-                    UseByteBasedPageSizes = true
+                    UseByteBasedPageSizes = true,
+                    MemoryAllocator = MemoryAllocator
                 });
             _rightTree = await stateManagerClient.GetOrCreateTree("right",
                 new BPlusTreeOptions<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>()
@@ -690,7 +692,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     Comparer = _rightInsertComparer,
                     KeySerializer = new ColumnStoreSerializer(_mergeJoinRelation.Right.OutputLength, MemoryAllocator),
                     ValueSerializer = new JoinWeightsSerializer(MemoryAllocator),
-                    UseByteBasedPageSizes = true
+                    UseByteBasedPageSizes = true,
+                    MemoryAllocator = MemoryAllocator
                 });
 
             _leftIterator = _leftTree.CreateIterator();

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsValueContainer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinOperatorBase.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinOperatorBase.cs
@@ -401,14 +401,16 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             {
                 Comparer = new BPlusTreeListComparer<JoinStreamEvent>(leftComparer),
                 KeySerializer = new KeyListSerializer<JoinStreamEvent>(new JoinStreamEvenBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer())
+                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
             _rightTree = await stateManagerClient.GetOrCreateTree("right", 
                 new BPlusTreeOptions<JoinStreamEvent, JoinStorageValue, ListKeyContainer<JoinStreamEvent>, ListValueContainer<JoinStorageValue>>()
             {
                 Comparer = new BPlusTreeListComparer<JoinStreamEvent>(rightComparer),
                 KeySerializer = new KeyListSerializer<JoinStreamEvent>(new JoinStreamEvenBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer())
+                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
         }
     }

--- a/src/FlowtideDotNet.Core/Operators/Join/NestedLoopJoin/BlockNestedJoinOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/NestedLoopJoin/BlockNestedJoinOperator.cs
@@ -335,30 +335,34 @@ namespace FlowtideDotNet.Core.Operators.Join.NestedLoopJoin
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(new NestedJoinStreamEventComparer()),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer())
+                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
             _rightTree = await stateManagerClient.GetOrCreateTree("right", 
                 new BPlusTreeOptions<RowEvent, JoinStorageValue, ListKeyContainer<RowEvent>, ListValueContainer<JoinStorageValue>>()
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(new NestedJoinStreamEventComparer()),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer())
+                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
 
             _leftTemporary = await stateManagerClient.GetOrCreateTree("left_tmp", 
                 new BPlusTreeOptions<RowEvent, JoinStorageValue, ListKeyContainer<RowEvent>, ListValueContainer<JoinStorageValue>>()
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(new NestedJoinStreamEventComparer()),
-                    KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                    ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer())
-                });
+                KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
+                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
+            });
 
             _rightTemporary = await stateManagerClient.GetOrCreateTree("right_tmp", 
                 new BPlusTreeOptions<RowEvent, JoinStorageValue, ListKeyContainer<RowEvent>, ListValueContainer<JoinStorageValue>>()
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(new NestedJoinStreamEventComparer()),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer())
+                ValueSerializer = new ValueListSerializer<JoinStorageValue>(new JoinStorageValueBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
 
             if (_eventsProcessed == null)

--- a/src/FlowtideDotNet.Core/Operators/Normalization/ColumnNormalizationOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/ColumnNormalizationOperator.cs
@@ -20,6 +20,7 @@ using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Core.Compute.Columnar;
 using FlowtideDotNet.Core.Compute.Internal;
 using FlowtideDotNet.Core.Utils;
+using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Serializers;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
@@ -331,6 +332,7 @@ namespace FlowtideDotNet.Core.Operators.Normalization
                     KeySerializer = new NormalizeKeyStorageSerializer(_normalizationRelation.KeyIndex, MemoryAllocator),
                     ValueSerializer = new NormalizeValueSerializer(_otherColumns, MemoryAllocator),
                     UseByteBasedPageSizes = true,
+                    MemoryAllocator = MemoryAllocator
                 });
         }
     }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizationOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizationOperator.cs
@@ -264,7 +264,8 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             {
                 Comparer = new BPlusTreeListComparer<string>(StringComparer.Ordinal),
                 KeySerializer = new KeyListSerializer<string>(new StringSerializer()),
-                ValueSerializer = new ValueListSerializer<IngressData>(new IngressDataStateSerializer())
+                ValueSerializer = new ValueListSerializer<IngressData>(new IngressDataStateSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
         }
 

--- a/src/FlowtideDotNet.Core/Operators/Read/BatchableReadBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/BatchableReadBaseOperator.cs
@@ -126,7 +126,8 @@ namespace FlowtideDotNet.Core.Operators.Read
             {
                 Comparer = new BPlusTreeListComparer<string>(StringComparer.Ordinal),
                 KeySerializer = new KeyListSerializer<string>(new StringSerializer()),
-                ValueSerializer = new ValueListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer())
+                ValueSerializer = new ValueListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
             await _fullLoadTempTree.Clear();
 
@@ -135,7 +136,8 @@ namespace FlowtideDotNet.Core.Operators.Read
             {
                 Comparer = new BPlusTreeListComparer<string>(StringComparer.Ordinal),
                 KeySerializer = new KeyListSerializer<string>(new StringSerializer()),
-                ValueSerializer = new ValueListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer())
+                ValueSerializer = new ValueListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
 
             _deletionsTree = await stateManagerClient.GetOrCreateTree("deletions", 
@@ -143,7 +145,8 @@ namespace FlowtideDotNet.Core.Operators.Read
             {
                 Comparer = new BPlusTreeListComparer<string>(StringComparer.Ordinal),
                 KeySerializer = new KeyListSerializer<string>(new StringSerializer()),
-                ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
             await _deletionsTree.Clear();
         }

--- a/src/FlowtideDotNet.Core/Operators/Set/SetOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Set/SetOperator.cs
@@ -234,7 +234,8 @@ namespace FlowtideDotNet.Core.Operators.Set
                 {
                     Comparer = new BPlusTreeListComparer<RowEvent>(new BPlusTreeStreamEventComparer()),
                     KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                    ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                    ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                    MemoryAllocator = MemoryAllocator
                 }));
                 
             }

--- a/src/FlowtideDotNet.Core/Operators/TopN/TopNOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TopN/TopNOperator.cs
@@ -257,7 +257,8 @@ namespace FlowtideDotNet.Core.Operators.TopN
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(_comparer),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
         }
     }

--- a/src/FlowtideDotNet.Core/Operators/Write/GroupedWriteBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/GroupedWriteBaseOperator.cs
@@ -127,7 +127,8 @@ namespace FlowtideDotNet.Core.Operators.Write
             { 
                 Comparer = new BPlusTreeListComparer<GroupedStreamEvent>(new GroupedStreamEventComparer(_comparer)),
                 ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
-                KeySerializer = new KeyListSerializer<GroupedStreamEvent>(new GroupedStreamEventBPlusTreeSerializer())
+                KeySerializer = new KeyListSerializer<GroupedStreamEvent>(new GroupedStreamEventBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
 
             await Initialize(restoreTime, state, stateManagerClient);

--- a/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/SimpleGroupedWriteOperator.cs
@@ -277,7 +277,8 @@ namespace FlowtideDotNet.Core.Operators.Write
             {
                 Comparer = new BPlusTreeListComparer<RowEvent>(PrimaryKeyComparer),
                 ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
-                KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer())
+                KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
+                MemoryAllocator = MemoryAllocator
             });
             await m_modified.Clear();
 
@@ -290,7 +291,8 @@ namespace FlowtideDotNet.Core.Operators.Write
                 {
                     Comparer = new BPlusTreeListComparer<RowEvent>(PrimaryKeyComparer),
                     ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
-                    KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer())
+                    KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
+                    MemoryAllocator = MemoryAllocator
                 });
 
                 Logger.FetchingExistingDataInDataSource(StreamName, Name);

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -21,7 +21,7 @@ using System.Threading.Tasks;
 using System.Collections;
 using FlowtideDotNet.Storage.Memory;
 
-namespace FlowtideDotNet.Core.ColumnStore.Utils
+namespace FlowtideDotNet.Storage.DataStructures
 {
     public unsafe class PrimitiveList<T> : IDisposable, IReadOnlyList<T>
         where T: unmanaged
@@ -94,6 +94,15 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
         {
             EnsureCapacity(_length + 1);
             AccessSpan[_length++] = value;
+        }
+
+        public void AddRangeFrom(PrimitiveList<T> list, int index, int count)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+            var sourceSpan = list.AccessSpan;
+            sourceSpan.Slice(index, count).CopyTo(span.Slice(_length, count));
+            _length += count;
         }
 
         public void InsertAt(int index, T value)

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/StateManagerSyncClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/StateManagerSyncClient.cs
@@ -38,7 +38,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             where TKeyContainer : IKeyContainer<K>
             where TValueContainer : IValueContainer<V>
         {
-            var stateClient = await CreateStateClient<IBPlusTreeNode, BPlusTreeMetadata>(name, new BPlusTreeSerializer<K, V, TKeyContainer, TValueContainer>(options.KeySerializer, options.ValueSerializer));
+            var stateClient = await CreateStateClient<IBPlusTreeNode, BPlusTreeMetadata>(name, new BPlusTreeSerializer<K, V, TKeyContainer, TValueContainer>(options.KeySerializer, options.ValueSerializer, options.MemoryAllocator));
 
             if (options.BucketSize == null)
             {

--- a/src/FlowtideDotNet.Storage/Tree/BPlusTreeOptions.cs
+++ b/src/FlowtideDotNet.Storage/Tree/BPlusTreeOptions.cs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage.Memory;
+
 namespace FlowtideDotNet.Storage.Tree
 {
     public class BPlusTreeOptions<K, V, TKeyContainer, TValueContainer>
@@ -36,5 +38,7 @@ namespace FlowtideDotNet.Storage.Tree
         public bool UseByteBasedPageSizes { get; set; }
 
         public int? PageSizeBytes { get; set; }
+
+        public required IMemoryAllocator MemoryAllocator { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.GenericWrite.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.GenericWrite.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage.DataStructures;
 using System.Diagnostics;
 
 namespace FlowtideDotNet.Storage.Tree.Internal
@@ -82,10 +83,10 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                     var nextId = m_stateClient.GetNewPageId();
                     var emptyKeys = m_options.KeySerializer.CreateEmpty();
-                    var newParentNode = new InternalNode<K, V, TKeyContainer>(nextId, emptyKeys);
+                    var newParentNode = new InternalNode<K, V, TKeyContainer>(nextId, emptyKeys, m_options.MemoryAllocator);
 
                     // No lock required
-                    newParentNode.children.Insert(0, leafNode.Id);
+                    newParentNode.children.InsertAt(0, leafNode.Id);
                     m_stateClient.Metadata.Root = nextId;
 
                     var (newNode, _) = SplitLeafNode(newParentNode, 0, leafNode);
@@ -146,9 +147,9 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             {
                 var nextId = m_stateClient.GetNewPageId();
                 var emptyKeys = m_options.KeySerializer.CreateEmpty();
-                var newParentNode = new InternalNode<K, V, TKeyContainer>(nextId, emptyKeys);
+                var newParentNode = new InternalNode<K, V, TKeyContainer>(nextId, emptyKeys, m_options.MemoryAllocator);
                 // No lock requireds
-                newParentNode.children.Insert(0, internalNode.Id);
+                newParentNode.children.InsertAt(0, internalNode.Id);
                 m_stateClient.Metadata.Root = nextId;
 
                 var (newNode, _) = SplitInternalNode(newParentNode, 0, internalNode);
@@ -729,7 +730,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             // Add the children to the parent node
             parent.EnterWriteLock();
             parent.keys.Insert_Internal(index, splitKey);
-            parent.children.Insert(index + 1, newNodeId);
+            parent.children.InsertAt(index + 1, newNodeId);
             parent.ExitWriteLock();
             return (newNode, splitKey);
         }
@@ -834,15 +835,15 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                 // Set the split key to the most right value
                 splitKey = rightNode.keys.Get(remainder - 1);
-                leftNode.children.AddRange(rightNode.children.GetRange(0, remainder));
 
+                leftNode.children.AddRangeFrom(rightNode.children, 0, remainder);
                 var rightNodeSize = rightNode.keys.Count - remainder;
                 var rightKeys = m_options.KeySerializer.CreateEmpty(); //new List<K>(rightNodeSize);
-                var rightChildren = new List<long>(rightNodeSize);
+                var rightChildren = new PrimitiveList<long>(m_options.MemoryAllocator);
 
                 rightKeys.AddRangeFrom(rightNode.keys, remainder, rightNodeSize);
-                rightChildren.AddRange(rightNode.children.GetRange(remainder, rightNode.children.Count - remainder));
 
+                rightChildren.AddRangeFrom(rightNode.children, remainder, rightNode.children.Count - remainder);
                 // Set the right node keys as disposable since it will no longer be used
                 splitKeyDisposable = rightNode.keys;
 
@@ -853,7 +854,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             else
             {
                 var rightKeys = m_options.KeySerializer.CreateEmpty(); // new List<K>(half);
-                var rightChildren = new List<long>(half);
+                var rightChildren = new PrimitiveList<long>(m_options.MemoryAllocator);
 
                 var remainder = half - rightNode.keys.Count;
 
@@ -862,10 +863,9 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 // Copy values from left to right at the beginning
                 rightKeys.AddRangeFrom(leftNode.keys, leftNode.keys.Count - remainder, remainder);
                 rightKeys.AddRangeFrom(rightNode.keys, 0, rightNode.keys.Count);
-                //rightKeys.AddRange(leftNode.keys.GetRange(leftNode.keys.Count - remainder, remainder));
-                //rightKeys.AddRange(rightNode.keys);
-                rightChildren.AddRange(leftNode.children.GetRange(leftNode.children.Count - remainder, remainder));
-                rightChildren.AddRange(rightNode.children);
+
+                rightChildren.AddRangeFrom(leftNode.children, leftNode.children.Count - remainder, remainder);
+                rightChildren.AddRangeFrom(rightNode.children, 0, rightNode.children.Count);
 
                 leftNode.keys.RemoveRange(leftNode.keys.Count - remainder, remainder);
                 leftNode.children.RemoveRange(leftNode.children.Count - remainder, remainder);
@@ -890,7 +890,9 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             leftNode.keys.Add(parentKey);
 
             leftNode.keys.AddRangeFrom(rightNode.keys, 0, rightNode.keys.Count);
-            leftNode.children.AddRange(rightNode.children);
+
+            leftNode.children.AddRangeFrom(rightNode.children, 0, rightNode.children.Count);
+
             leftNode.ExitWriteLock();
         }
 
@@ -902,18 +904,19 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             Debug.Assert(m_stateClient.Metadata != null);
             var newNodeId = m_stateClient.GetNewPageId(); // _metadata.GetNextId();
             var emptyKeys = m_options.KeySerializer.CreateEmpty();
-            var newNode = new InternalNode<K, V, TKeyContainer>(newNodeId, emptyKeys);
+            var newNode = new InternalNode<K, V, TKeyContainer>(newNodeId, emptyKeys, m_options.MemoryAllocator);
 
             newNode.keys.AddRangeFrom(child.keys, m_stateClient.Metadata.BucketLength / 2, child.keys.Count - m_stateClient.Metadata.BucketLength / 2);
             //newNode.keys.AddRange(child.keys.GetRange(m_stateClient.Metadata.BucketLength / 2, child.keys.Count - m_stateClient.Metadata.BucketLength / 2));
-            newNode.children.AddRange(child.children.GetRange(m_stateClient.Metadata.BucketLength / 2, (m_stateClient.Metadata.BucketLength / 2) + 1));
+
+            newNode.children.AddRangeFrom(child.children, m_stateClient.Metadata.BucketLength / 2, (m_stateClient.Metadata.BucketLength / 2) + 1);
 
             var splitKey = child.keys.Get(m_stateClient.Metadata.BucketLength / 2 - 1);
 
             // Insert the split key to parent before removing from child since the removal from child can clear memory.
             parent.EnterWriteLock();
             parent.keys.Insert_Internal(index, splitKey);
-            parent.children.Insert(index + 1, newNodeId);
+            parent.children.InsertAt(index + 1, newNodeId);
             parent.ExitWriteLock();
 
             child.EnterWriteLock();

--- a/src/FlowtideDotNet.Storage/Tree/Internal/InternalNode.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/InternalNode.cs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
 using System.Text;
 
 namespace FlowtideDotNet.Storage.Tree.Internal
@@ -17,11 +19,16 @@ namespace FlowtideDotNet.Storage.Tree.Internal
     internal class InternalNode<K, V, TKeyContainer> : BaseNode<K, TKeyContainer>
         where TKeyContainer : IKeyContainer<K>
     {
-        public List<long> children;
+        public PrimitiveList<long> children;
 
-        public InternalNode(long id, TKeyContainer keyContainer) : base(id, keyContainer)
+        public InternalNode(long id, TKeyContainer keyContainer, IMemoryAllocator memoryAllocator) : base(id, keyContainer)
         {
-            children = new List<long>();
+            children = new PrimitiveList<long>(memoryAllocator);
+        }
+
+        public InternalNode(long id, TKeyContainer keyContainer, PrimitiveList<long> children) : base(id, keyContainer)
+        {
+            this.children = children;
         }
 
         public override async Task Print(StringBuilder stringBuilder, Func<long, ValueTask<BaseNode<K, TKeyContainer>>> lookupFunc)
@@ -63,6 +70,25 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         public override Task PrintNextPointers(StringBuilder stringBuilder)
         {
             return Task.CompletedTask;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                children.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        public override int GetByteSize()
+        {
+            return keys.GetByteSize() + children.Count * sizeof(long);
+        }
+
+        public override int GetByteSize(int start, int end)
+        {
+            return keys.GetByteSize(start, end) + (end - start + 1) * sizeof(long);
         }
     }
 }

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeInsertionBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeInsertionBenchmark.cs
@@ -17,6 +17,7 @@ using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
 using FASTER.core;
 using Microsoft.Extensions.Logging.Abstractions;
+using FlowtideDotNet.Storage.Memory;
 
 namespace DifferntialCompute.Benchmarks
 {
@@ -54,7 +55,8 @@ namespace DifferntialCompute.Benchmarks
                 BucketSize = 1024,
                 Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
                 KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator =  GlobalMemoryManager.Instance
             }).GetAwaiter().GetResult();
             tree.Clear();
         }

--- a/tests/FlowtideDotNet.Benchmarks/ColumnStoreTreeBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/ColumnStoreTreeBenchmark.cs
@@ -83,7 +83,8 @@ namespace FlowtideDotNet.Benchmarks
                 BucketSize = 1024,
                 Comparer = new ColumnComparer(1),
                 KeySerializer = new ColumnStoreSerializer(1, GlobalMemoryManager.Instance),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             }).GetAwaiter().GetResult();
             tree.Clear();
             flxTree = nodeClient.GetOrCreateTree("flxtree", new BPlusTreeOptions<RowEvent, string, ListKeyContainer<RowEvent>, ListValueContainer<string>>()
@@ -91,7 +92,8 @@ namespace FlowtideDotNet.Benchmarks
                 BucketSize = 1024,
                 Comparer = new BPlusTreeListComparer<RowEvent>(new BPlusTreeStreamEventComparer()),
                 KeySerializer = new KeyListSerializer<RowEvent>(new StreamEventBPlusTreeSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             }).GetAwaiter().GetResult();
         }
 

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/BPlusTreeColumnStoreTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/BPlusTreeColumnStoreTests.cs
@@ -50,7 +50,8 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
                     BucketSize = 4,
                     Comparer = new ColumnComparer(1),
                     KeySerializer = new ColumnStoreSerializer(1, GlobalMemoryManager.Instance),
-                    ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                    ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                    MemoryAllocator = GlobalMemoryManager.Instance
                 });
 
             var valueColumn = new Column(GlobalMemoryManager.Instance);

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeByteBased/BPlusTreeByteBasedTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeByteBased/BPlusTreeByteBasedTests.cs
@@ -12,6 +12,7 @@
 
 using FASTER.core;
 using FlowtideDotNet.Storage.Comparers;
+using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Persistence.CacheStorage;
 using FlowtideDotNet.Storage.Serializers;
 using FlowtideDotNet.Storage.StateManager;
@@ -51,7 +52,8 @@ namespace FlowtideDotNet.Storage.Tests.BPlusTreeByteBased
                     Comparer = new ListWithSizeComparer(new LongComparer()),
                     KeySerializer = new ListKeyWithSizeSerializer(17000),
                     ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
-                    UseByteBasedPageSizes = true
+                    UseByteBasedPageSizes = true,
+                    MemoryAllocator = GlobalMemoryManager.Instance
                 });
             return tree;
         }

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeTests.cs
@@ -18,6 +18,7 @@ using FASTER.core;
 using FlowtideDotNet.Storage.Persistence.CacheStorage;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics.Metrics;
+using FlowtideDotNet.Storage.Memory;
 
 namespace FlowtideDotNet.Storage.Tests
 {
@@ -48,7 +49,8 @@ namespace FlowtideDotNet.Storage.Tests
                 BucketSize = 8,
                 Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
                 KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             });
             return tree;
         }

--- a/tests/FlowtideDotNet.Storage.Tests/CheckpointTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/CheckpointTests.cs
@@ -18,6 +18,7 @@ using FlowtideDotNet.Storage.Persistence.FasterStorage;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics.Metrics;
 using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Memory;
 
 namespace FlowtideDotNet.Storage.Tests
 {
@@ -45,7 +46,8 @@ namespace FlowtideDotNet.Storage.Tests
                 BucketSize = 8,
                 Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
                 KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             });
 
             await tree.Upsert(1, "hello");
@@ -99,7 +101,8 @@ namespace FlowtideDotNet.Storage.Tests
                 BucketSize = 8,
                 Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
                 KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             });
 
             await tree.Upsert(0, "hello0");
@@ -162,7 +165,8 @@ namespace FlowtideDotNet.Storage.Tests
                 BucketSize = 8,
                 Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
                 KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             });
 
             await tree.Upsert(1, "hello");

--- a/tests/FlowtideDotNet.Storage.Tests/DeviceFailureTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/DeviceFailureTests.cs
@@ -12,6 +12,7 @@
 
 using FASTER.core;
 using FlowtideDotNet.Storage.Comparers;
+using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Persistence.FasterStorage;
 using FlowtideDotNet.Storage.Serializers;
 using FlowtideDotNet.Storage.StateManager;
@@ -254,7 +255,8 @@ namespace FlowtideDotNet.Storage.Tests
                 BucketSize = 8,
                 Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
                 KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             });
 
             await tree.Upsert(3, "hello");
@@ -304,7 +306,8 @@ namespace FlowtideDotNet.Storage.Tests
                 BucketSize = 8,
                 Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
                 KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer())
+                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             });
 
             for (int i = 0; i < 4096; i++)

--- a/tests/FlowtideDotNet.Storage.Tests/SyncStateClientTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/SyncStateClientTests.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Storage.Comparers;
+using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Persistence.CacheStorage;
 using FlowtideDotNet.Storage.Serializers;
 using FlowtideDotNet.Storage.StateManager;
@@ -57,7 +58,8 @@ namespace FlowtideDotNet.Storage.Tests
             {
                 Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
                 KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                ValueSerializer = new ValueListSerializer<int>(new IntSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
             });
             //Version 0
             await tree.Upsert(1, 1);


### PR DESCRIPTION
This also moves PrimitiveList into storage under data structures.
This is required to use in the internal node.