### PR TITLE
Improve performance of search boundries for int64 column

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -132,9 +132,9 @@ namespace FlowtideDotNet.Core.ColumnStore
             var val = dataValue.AsLong;
             if (desc)
             {
-                return BoundarySearch.SearchBoundries(_data, val, start, end, Int64ComparerDesc.Instance);
+                return BoundarySearch.SearchBoundriesInt64Desc(_data, start, end, val);
             }
-            return BoundarySearch.SearchBoundries(_data, val, start, end, Int64Comparer.Instance);
+            return BoundarySearch.SearchBoundriesInt64Asc(_data, start, end, val);
         }
 
         public int Update(in int index, in IDataValue value)

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/BoundarySearch.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/BoundarySearch.cs
@@ -443,6 +443,98 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             return (lowerbound, upperbound);
         }
 
+
+        public static unsafe (int, int) SearchBoundriesInt64Asc(in NativeLongList list, int start, int end, long value)
+        {
+            if (end < start)
+            {
+                return (~start, ~start);
+            }
+            var arr = list.Pointer + start;
+            var size = end - start + 1;
+            while (size > 2)
+            {
+                var middle = size >> 1;
+                size = (size + 1) >> 1;
+                // Hack since cmov is not available so far from what has been benchmarked.
+                // Clt returns 0 or 1, so we can multiply by the result to get the correct index.
+                arr += (middle * UnsafeEx.Clt(arr[middle], value));
+            }
+
+            arr += UnsafeEx.Cgt(size, 1) & UnsafeEx.Clt(*arr, value);
+            arr += UnsafeEx.Cgt(size, 0) & UnsafeEx.Clt(*arr, value);
+
+            
+            start = (int)(arr - list.Pointer);
+            int lowIndex = start;
+            if (start > end || *arr != value)
+            {
+                return (~start, ~start);
+            }
+
+            if (start == end || arr[1] != value)
+            {
+                return (start, start);
+            }
+
+            size = end - start + 1;
+            while (size > 2)
+            {
+                var middle = size >> 1;
+                size = (size + 1) >> 1;
+                arr += middle * UnsafeEx.Cle(arr[middle], value);
+            }
+            arr += UnsafeEx.Cgt(size, 1) & UnsafeEx.Cle(*arr, value);
+            arr += UnsafeEx.Cgt(size, 0) & UnsafeEx.Cle(*arr, value);
+
+            return (lowIndex, (int)(arr - list.Pointer) - 1);
+        }
+
+        public static unsafe (int, int) SearchBoundriesInt64Desc(in NativeLongList list, int start, int end, long value)
+        {
+            if (end < start)
+            {
+                return (~start, ~start);
+            }
+            var arr = list.Pointer + start;
+            var size = end - start + 1;
+            while (size > 2)
+            {
+                var middle = size >> 1;
+                size = (size + 1) >> 1;
+                // Hack since cmov is not available so far from what has been benchmarked.
+                // Clt returns 0 or 1, so we can multiply by the result to get the correct index.
+                arr += (middle * UnsafeEx.Cgt(arr[middle], value));
+            }
+
+            arr += UnsafeEx.Cgt(size, 1) & UnsafeEx.Cgt(*arr, value);
+            arr += UnsafeEx.Cgt(size, 0) & UnsafeEx.Cgt(*arr, value);
+
+            start = (int)(arr - list.Pointer);
+            int lowIndex = start;
+            if (start > end || *arr != value)
+            {
+                return (~start, ~start);
+            }
+
+            if (start == end || arr[1] != value)
+            {
+                return (start, start);
+            }
+
+            size = end - start + 1;
+            while (size > 2)
+            {
+                var middle = size >> 1;
+                size = (size + 1) >> 1;
+                arr += middle * UnsafeEx.Cge(arr[middle], value);
+            }
+            arr += UnsafeEx.Cgt(size, 1) & UnsafeEx.Cge(*arr, value);
+            arr += UnsafeEx.Cgt(size, 0) & UnsafeEx.Cge(*arr, value);
+
+            return (lowIndex, (int)(arr - list.Pointer) - 1);
+        }
+
         public static (int, int) SearchBoundries(in NativeLongList list, in long value, in int index, in int end, IColumnComparer<long> comparer)
         {
             int lo = index;

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/NativeLongList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/NativeLongList.cs
@@ -82,6 +82,8 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
 
         public Memory<byte> Memory => _memoryOwner?.Memory ?? new Memory<byte>();
 
+        internal long* Pointer => _longData;
+
         public NativeLongList(IMemoryOwner<byte> memory, int length, IMemoryAllocator memoryAllocator)
         {
             _memoryOwner = memory;

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/UnsafeEx.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/UnsafeEx.cs
@@ -1,0 +1,87 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using InlineIL;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using InlineIL;
+using static InlineIL.IL.Emit;
+
+namespace FlowtideDotNet.Core.ColumnStore.Utils
+{
+    public unsafe static class UnsafeEx
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Cle(long first, long second)
+        {
+            Ldarg_0();
+            Ldarg_1();
+            IL.Emit.Cgt();
+            IL.Emit.Ldc_I4_0();
+            IL.Emit.Ceq();
+            Ret();
+            throw IL.Unreachable();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Clt(long first, long second)
+        {
+            Ldarg_0();
+            Ldarg_1();
+            IL.Emit.Clt();
+            Ret();
+            throw IL.Unreachable();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Cgt(int first, int second)
+        {
+            Ldarg_0();
+            Ldarg_1();
+            IL.Emit.Cgt();
+            Ret();
+            throw IL.Unreachable();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Cgt(long first, long second)
+        {
+            Ldarg_0();
+            Ldarg_1();
+            IL.Emit.Cgt();
+            Ret();
+            throw IL.Unreachable();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Cge(long first, long second)
+        {
+            Ldarg_0();
+            Ldarg_1();
+            IL.Emit.Clt();
+            IL.Emit.Ldc_I4_0();
+            IL.Emit.Ceq();
+            Ret();
+            throw IL.Unreachable();
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/FlowtideDotNet.Core.csproj
+++ b/src/FlowtideDotNet.Core/FlowtideDotNet.Core.csproj
@@ -18,6 +18,9 @@
   <ItemGroup>
     <PackageReference Include="Apache.Arrow" Version="16.1.0" />
     <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+
+	  <PackageReference Include="Fody" Version="6.6.3" PrivateAssets="all" />
+	  <PackageReference Include="InlineIL.Fody" Version="1.7.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FlowtideDotNet.Core/FodyWeavers.xml
+++ b/src/FlowtideDotNet.Core/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <InlineIL />
+</Weavers>

--- a/tests/FlowtideDotNet.Benchmarks/BinarySearchBenchmarks.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BinarySearchBenchmarks.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.Memory;
+using InlineIL;
+using static InlineIL.IL.Emit;
+using static Substrait.Protobuf.Expression.Types.Literal.Types;
+
+namespace FlowtideDotNet.Benchmarks
+{
+    [HardwareCounters(HardwareCounter.BranchMispredictions, HardwareCounter.BranchInstructions)]
+    public class BinarySearchBenchmarks
+    {
+        private const int SearchSpace = 1024 * 1;
+
+        private long[] _arr;
+        private Column _column;
+        private NativeLongList _nativeLongList;
+        private Int64Column _int64Column;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _arr = Enumerable.Range(0, SearchSpace).Select(x => (long)x).ToArray();
+            _column = new Column(GlobalMemoryManager.Instance);
+            _nativeLongList = new NativeLongList(GlobalMemoryManager.Instance);
+            _int64Column = new Int64Column(GlobalMemoryManager.Instance);
+            foreach (var item in _arr)
+            {
+                _column.Add(new Int64Value(item));
+                _nativeLongList.Add(item);
+                _int64Column.Add(new Int64Value(item));
+            }
+        }
+
+        [Benchmark]
+        public void ArrayBinarySearchBenchmark()
+        {
+            for (int i = 0; i < SearchSpace; i++)
+            {
+                Array.BinarySearch(_arr, i);
+            }
+        }
+
+
+        [Benchmark]
+        public void ColumnBoundarySearchBenchmark()
+        {
+            for (int i = 0; i < SearchSpace; i++)
+            {
+                _column.SearchBoundries(new Int64Value(i), 0, SearchSpace - 1, default);
+            }
+        }
+
+        [Benchmark]
+        public void NativeLongListBoundarySearchBenchmark()
+        {
+            for (int i = 0; i < SearchSpace; i++)
+            {
+                BoundarySearch.SearchBoundriesInt64Asc(_nativeLongList, 0, SearchSpace - 1, i);
+            }
+        }
+
+        [Benchmark]
+        public void Int64ColumnBoundarySearchBenchmark()
+        {
+            for (int i = 0; i < SearchSpace; i++)
+            {
+                _int64Column.SearchBoundries(new Int64Value(i), 0, SearchSpace - 1, default, false);
+            }
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Benchmarks/BoundarySearchInt64Benchmarks.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BoundarySearchInt64Benchmarks.cs
@@ -1,28 +1,26 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
-using System.Text;
-using System.Threading.Tasks;
+﻿//// Licensed under the Apache License, Version 2.0 (the "License")
+//// you may not use this file except in compliance with the License.
+//// You may obtain a copy of the License at
+////
+////     http://www.apache.org/licenses/LICENSE-2.0
+////  
+//// Unless required by applicable law or agreed to in writing, software
+//// distributed under the License is distributed on an "AS IS" BASIS,
+//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//// See the License for the specific language governing permissions and
+//// limitations under the License.
+
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
 using FlowtideDotNet.Core.ColumnStore;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Storage.Memory;
-using InlineIL;
-using static InlineIL.IL.Emit;
-using static Substrait.Protobuf.Expression.Types.Literal.Types;
 
 namespace FlowtideDotNet.Benchmarks
 {
     [HardwareCounters(HardwareCounter.BranchMispredictions, HardwareCounter.BranchInstructions)]
-    public class BinarySearchBenchmarks
+    public class BoundarySearchInt64Benchmarks
     {
         private const int SearchSpace = 1024 * 1;
 

--- a/tests/FlowtideDotNet.Benchmarks/FlowtideDotNet.Benchmarks.csproj
+++ b/tests/FlowtideDotNet.Benchmarks/FlowtideDotNet.Benchmarks.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/In64ColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/In64ColumnTests.cs
@@ -12,6 +12,8 @@
 
 using FlowtideDotNet.Core.ColumnStore;
 using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Storage.Memory;
 using System;
 using System.Collections.Generic;
@@ -168,6 +170,94 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
                     Assert.True(column.GetValueAt(i, default).IsNull);
                 }
             }
+        }
+
+        [Fact]
+        public void TestBoundarySearchInt64Asc()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+            column.Add(new Int64Value(4));
+
+            var result = column.SearchBoundries(new Int64Value(0), 0, 3, default);
+            Assert.Equal(~0, result.Item1);
+            Assert.Equal(~0, result.Item2);
+
+            result = column.SearchBoundries(new Int64Value(5), 0, 3, default);
+            Assert.Equal(~4, result.Item1);
+            Assert.Equal(~4, result.Item2);
+
+            result = column.SearchBoundries(new Int64Value(3), 1, 3, default);
+            Assert.Equal(2, result.Item1);
+            Assert.Equal(2, result.Item2);
+        }
+
+        [Fact]
+        public void TestBoundarySearchInt64EmptyListAsc()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+
+            var result = column.SearchBoundries(new Int64Value(0), 0, -1, default);
+            Assert.Equal(~0, result.Item1);
+            Assert.Equal(~0, result.Item2);
+        }
+
+        [Fact]
+        public void TestBoundarySearchInt64RangeInMiddleAsc()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+            column.Add(new Int64Value(4));
+
+            var result = column.SearchBoundries(new Int64Value(2), 0, 5, default);
+            Assert.Equal(1, result.Item1);
+            Assert.Equal(3, result.Item2);
+        }
+
+        [Fact]
+        public void TestBoundarySearchInt64RangeInEndAsc()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+            column.Add(new Int64Value(4));
+            column.Add(new Int64Value(4));
+            column.Add(new Int64Value(4));
+
+            var result = column.SearchBoundries(new Int64Value(4), 0, 7, default);
+            Assert.Equal(5, result.Item1);
+            Assert.Equal(7, result.Item2);
+        }
+
+        [Fact]
+        public void TestBoundarySearchInt64RangeInStartAsc()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+            column.Add(new Int64Value(4));
+            column.Add(new Int64Value(4));
+            column.Add(new Int64Value(4));
+
+            var result = column.SearchBoundries(new Int64Value(1), 0, 7, default);
+            Assert.Equal(0, result.Item1);
+            Assert.Equal(2, result.Item2);
         }
     }
 }


### PR DESCRIPTION
Benchmark:

| Method                                | Mean     | Error    | StdDev   | BranchInstructions/Op | BranchMispredictions/Op |
|-------------------------------------- |---------:|---------:|---------:|----------------------:|------------------------:|
| ArrayBinarySearchBenchmark            | 37.28 us | 0.452 us | 0.353 us |                73,647 |                   3,058 |
| ColumnBoundarySearchBenchmark         | 24.04 us | 0.149 us | 0.139 us |                44,430 |                      26 |
| NativeLongListBoundarySearchBenchmark | 14.56 us | 0.042 us | 0.039 us |                12,489 |                       9 |
| Int64ColumnBoundarySearchBenchmark    | 16.33 us | 0.151 us | 0.141 us |                17,667 |                      12 |