### PR TITLE
Add InsertRange to BitmapList

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
@@ -327,7 +327,8 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                     var previousEndShift = span[endShiftIndex];
                     // Fetch the value of the most right integer and mask it to get the bits that should remain unchanged
                     var endIntPreviousValue = span[endIndex] & topBitsSetMask[countRemainder - 1]; // was -1 before
-                                                                                                    // Copy in the data, this could change the value of the most right integer and most left integer
+                    
+                    // Copy in the data, this could change the value of the most right integer and most left integer
                     other.AccessSpan.Slice(start >> 5, numberOfNewInts).CopyTo(span.Slice(toIndex));
                     
                     if (modDifference > 0)
@@ -339,7 +340,6 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                     {
                         if (endShiftIndex > endIndex)
                         {
-                            
                             // The difference is negative, so the copied values must be shifted right to make them get to the correct indices.
                             ShiftRight(toIndex, endShiftIndex, -modDifference);
                             span[endShiftIndex] = previousEndShift;
@@ -432,10 +432,8 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                         // The difference is negative, so the copied values must be shifted right to make them get to the correct indices.
                         ShiftRight(toIndex, endIndex, -modDifference);
                     }
-
                     span[endIndex] = endIntPreviousValue;
                 }
-                
             }
             if (index >= _length)
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
@@ -321,7 +321,6 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                 // Shift the all bits to the left
                 ShiftLeft(toIndex, _dataLength - 1, count);
 
-
                 if (countRemainder > 0)
                 {
                     var previousEndShift = span[endShiftIndex];

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
@@ -308,10 +308,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             var endIndex = (index + count) >> 5;
             var endShiftIndex = (index + count - modDifference) >> 5;
             var otherCountRemainder = (index + count) & 31;
-            //if (otherCountRemainder > 0)
-            //{
-            //    otherCountRemainder--;
-            //}
+
             int bitIndex = 1 << index;
             var span = AccessSpan;
             if ((_length / 32) >= _dataLength)
@@ -324,15 +321,6 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             {
                 var bottomBitsMask = BitPatternArray[mod - 1];
                 var topBitsMask = topBitsSetMask[mod - 1];
-
-                // Debug code
-                //ref var valRef = ref MemoryMarshal.Cast<int, uint>(span)[toIndex];
-                //ref var otherRef = ref MemoryMarshal.Cast<int, uint>(other.AccessSpan)[start >> 5];
-
-                //ref var endValRef = ref MemoryMarshal.Cast<int, uint>(span)[endIndex];
-                //ref var endValRefPlus1 = ref MemoryMarshal.Cast<int, uint>(span)[endIndex + 1];
-                //ref var otherEndRef = ref MemoryMarshal.Cast<int, uint>(other.AccessSpan)[(start >> 5) + countDivided32];
-                //ref var otherEndRefPlus1 = ref MemoryMarshal.Cast<int, uint>(other.AccessSpan)[(start >> 5) + countDivided32 + 1];
 
                 // Fetch the value of the most left integer and and mask it to get the bits that should remain unchanged
                 var val = span[toIndex] & bottomBitsMask;
@@ -404,10 +392,6 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             }
             else
             {
-                // DEBUG
-                ref var valRef = ref MemoryMarshal.Cast<int, uint>(span)[toIndex];
-                ref var endValRef = ref MemoryMarshal.Cast<int, uint>(span)[endIndex];
-
                 // Shift left to open up space for new values
                 ShiftLeft(toIndex, _dataLength - 1, count);
                 var previousEndShift = span[endShiftIndex];

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
@@ -537,10 +537,6 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             {
                 ShiftRight(fromIndex, _dataLength - 1, count);
             }
-            else
-            {
-                ShiftRight(fromIndex, count);
-            }
         }
 
         private void ShiftRight(int fromIndex, int lastIndex, int count)
@@ -548,7 +544,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             var span = AccessSpan;
             // Loop from BitArray.
             int toIndex = fromIndex;
-            int lastIndex = _dataLength - 1;
+            //int lastIndex = ;
+            var numberOfInts = count / 32;
+            var remainder = (byte)(count & 31);
+            fromIndex = fromIndex + numberOfInts;
             unchecked
             {
                 if (remainder == 0)

--- a/tests/FlowtideDotNet.Benchmarks/BitmapListBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BitmapListBenchmark.cs
@@ -1,0 +1,71 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using BenchmarkDotNet.Attributes;
+using FlowtideDotNet.Core.ColumnStore.Utils;
+using FlowtideDotNet.Storage.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Benchmarks
+{
+    public class BitmapListBenchmark
+    {
+        private BitmapList? _bitmapList;
+
+        [IterationSetup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative)])]
+        public void RemoveRangeIterationSetup()
+        {
+            _bitmapList = new BitmapList(GlobalMemoryManager.Instance);
+            Random r = new Random(123);
+
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                _bitmapList.Add(val);
+            }
+        }
+
+        [IterationCleanup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative)])]
+        public void RemoveRangeCleanup()
+        {
+            if (_bitmapList != null)
+            {
+                _bitmapList.Dispose();
+            }
+        }
+
+        [Benchmark]
+        public void RemoveRange()
+        {
+            _bitmapList!.RemoveRange(100, 10000);
+        }
+
+        [Benchmark]
+        public void RemoveRangeIterative()
+        {
+            var end = 100 + 10000;
+            for (int i = end; i >= 100; i--)
+            {
+                _bitmapList!.RemoveAt(i);
+            }
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Benchmarks/BitmapListBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BitmapListBenchmark.cs
@@ -24,13 +24,37 @@ namespace FlowtideDotNet.Benchmarks
     public class BitmapListBenchmark
     {
         private BitmapList? _bitmapList;
-        private List<bool> _list;
+        private BitmapList? _otherBitmapList;
+        private List<bool>? _list;
+        private List<bool>? _otherList;
 
-        [IterationSetup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative), nameof(RemoveRangeSystemCollectionList)])]
-        public void RemoveRangeIterationSetup()
+        //[IterationSetup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative), nameof(RemoveRangeSystemCollectionList)])]
+        //public void RemoveRangeIterationSetup()
+        //{
+        //    _bitmapList = new BitmapList(GlobalMemoryManager.Instance);
+        //    _list = new List<bool>();
+        //    Random r = new Random(123);
+
+        //    for (int i = 0; i < 1_000_000; i++)
+        //    {
+        //        var v = r.Next(0, 2);
+        //        bool val = true;
+        //        if (v == 0)
+        //        {
+        //            val = false;
+        //        }
+        //        _bitmapList.Add(val);
+        //        _list.Add(val);
+        //    }
+        //}
+
+        [IterationSetup(Targets = [nameof(InsertRange), nameof(InsertRangeIterative), nameof(InsertRangeSystemCollectionList)])]
+        public void InsertRangeIterationSetup()
         {
             _bitmapList = new BitmapList(GlobalMemoryManager.Instance);
+            _otherBitmapList = new BitmapList(GlobalMemoryManager.Instance);
             _list = new List<bool>();
+            _otherList = new List<bool>();
             Random r = new Random(123);
 
             for (int i = 0; i < 1_000_000; i++)
@@ -43,38 +67,81 @@ namespace FlowtideDotNet.Benchmarks
                 }
                 _bitmapList.Add(val);
                 _list.Add(val);
+                v = r.Next(0, 2);
+                val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                _otherBitmapList.Add(val);
+                _otherList.Add(val);
             }
         }
 
-        [IterationCleanup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative)])]
-        public void RemoveRangeCleanup()
+        //[IterationCleanup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative)])]
+        //public void RemoveRangeCleanup()
+        //{
+        //    if (_bitmapList != null)
+        //    {
+        //        _bitmapList.Dispose();
+        //    }
+        //}
+
+        [IterationCleanup(Targets = [nameof(InsertRange), nameof(InsertRangeIterative)])]
+        public void InsertRangeCleanup()
         {
             if (_bitmapList != null)
             {
                 _bitmapList.Dispose();
             }
+            if (_otherBitmapList != null)
+            {
+                _otherBitmapList.Dispose();
+            }
         }
 
+        //[Benchmark]
+        //public void RemoveRange()
+        //{
+        //    _bitmapList!.RemoveRange(100, 10000);
+        //}
+
+        //[Benchmark]
+        //public void RemoveRangeIterative()
+        //{
+        //    var end = 100 + 10000;
+        //    for (int i = end; i >= 100; i--)
+        //    {
+        //        _bitmapList!.RemoveAt(i);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void RemoveRangeSystemCollectionList()
+        //{
+        //    _list!.RemoveRange(100, 10000);
+        //}
+
         [Benchmark]
-        public void RemoveRange()
+        public void InsertRange()
         {
-            _bitmapList!.RemoveRange(100, 10000);
+            _bitmapList!.InsertRangeFrom(100, _otherBitmapList!, 100, 10000);
         }
 
         [Benchmark]
-        public void RemoveRangeIterative()
+        public void InsertRangeIterative()
         {
             var end = 100 + 10000;
-            for (int i = end; i >= 100; i--)
+            for (int i = 100; i < end; i++)
             {
-                _bitmapList!.RemoveAt(i);
+                _bitmapList!.InsertAt(i, _otherBitmapList![i]);
             }
         }
 
         [Benchmark]
-        public void RemoveRangeSystemCollectionList()
+        public void InsertRangeSystemCollectionList()
         {
-            _list.RemoveRange(100, 10000);
+            _list!.InsertRange(100, _otherList!.Skip(100).Take(10000));
         }
     }
 }

--- a/tests/FlowtideDotNet.Benchmarks/BitmapListBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BitmapListBenchmark.cs
@@ -24,11 +24,13 @@ namespace FlowtideDotNet.Benchmarks
     public class BitmapListBenchmark
     {
         private BitmapList? _bitmapList;
+        private List<bool> _list;
 
-        [IterationSetup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative)])]
+        [IterationSetup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative), nameof(RemoveRangeSystemCollectionList)])]
         public void RemoveRangeIterationSetup()
         {
             _bitmapList = new BitmapList(GlobalMemoryManager.Instance);
+            _list = new List<bool>();
             Random r = new Random(123);
 
             for (int i = 0; i < 1_000_000; i++)
@@ -40,6 +42,7 @@ namespace FlowtideDotNet.Benchmarks
                     val = false;
                 }
                 _bitmapList.Add(val);
+                _list.Add(val);
             }
         }
 
@@ -66,6 +69,12 @@ namespace FlowtideDotNet.Benchmarks
             {
                 _bitmapList!.RemoveAt(i);
             }
+        }
+
+        [Benchmark]
+        public void RemoveRangeSystemCollectionList()
+        {
+            _list.RemoveRange(100, 10000);
         }
     }
 }

--- a/tests/FlowtideDotNet.Benchmarks/BitmapListBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BitmapListBenchmark.cs
@@ -28,25 +28,25 @@ namespace FlowtideDotNet.Benchmarks
         private List<bool>? _list;
         private List<bool>? _otherList;
 
-        //[IterationSetup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative), nameof(RemoveRangeSystemCollectionList)])]
-        //public void RemoveRangeIterationSetup()
-        //{
-        //    _bitmapList = new BitmapList(GlobalMemoryManager.Instance);
-        //    _list = new List<bool>();
-        //    Random r = new Random(123);
+        [IterationSetup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative), nameof(RemoveRangeSystemCollectionList)])]
+        public void RemoveRangeIterationSetup()
+        {
+            _bitmapList = new BitmapList(GlobalMemoryManager.Instance);
+            _list = new List<bool>();
+            Random r = new Random(123);
 
-        //    for (int i = 0; i < 1_000_000; i++)
-        //    {
-        //        var v = r.Next(0, 2);
-        //        bool val = true;
-        //        if (v == 0)
-        //        {
-        //            val = false;
-        //        }
-        //        _bitmapList.Add(val);
-        //        _list.Add(val);
-        //    }
-        //}
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                _bitmapList.Add(val);
+                _list.Add(val);
+            }
+        }
 
         [IterationSetup(Targets = [nameof(InsertRange), nameof(InsertRangeIterative), nameof(InsertRangeSystemCollectionList)])]
         public void InsertRangeIterationSetup()
@@ -78,14 +78,14 @@ namespace FlowtideDotNet.Benchmarks
             }
         }
 
-        //[IterationCleanup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative)])]
-        //public void RemoveRangeCleanup()
-        //{
-        //    if (_bitmapList != null)
-        //    {
-        //        _bitmapList.Dispose();
-        //    }
-        //}
+        [IterationCleanup(Targets = [nameof(RemoveRange), nameof(RemoveRangeIterative)])]
+        public void RemoveRangeCleanup()
+        {
+            if (_bitmapList != null)
+            {
+                _bitmapList.Dispose();
+            }
+        }
 
         [IterationCleanup(Targets = [nameof(InsertRange), nameof(InsertRangeIterative)])]
         public void InsertRangeCleanup()
@@ -100,27 +100,27 @@ namespace FlowtideDotNet.Benchmarks
             }
         }
 
-        //[Benchmark]
-        //public void RemoveRange()
-        //{
-        //    _bitmapList!.RemoveRange(100, 10000);
-        //}
+        [Benchmark]
+        public void RemoveRange()
+        {
+            _bitmapList!.RemoveRange(100, 10000);
+        }
 
-        //[Benchmark]
-        //public void RemoveRangeIterative()
-        //{
-        //    var end = 100 + 10000;
-        //    for (int i = end; i >= 100; i--)
-        //    {
-        //        _bitmapList!.RemoveAt(i);
-        //    }
-        //}
+        [Benchmark]
+        public void RemoveRangeIterative()
+        {
+            var end = 100 + 10000;
+            for (int i = end; i >= 100; i--)
+            {
+                _bitmapList!.RemoveAt(i);
+            }
+        }
 
-        //[Benchmark]
-        //public void RemoveRangeSystemCollectionList()
-        //{
-        //    _list!.RemoveRange(100, 10000);
-        //}
+        [Benchmark]
+        public void RemoveRangeSystemCollectionList()
+        {
+            _list!.RemoveRange(100, 10000);
+        }
 
         [Benchmark]
         public void InsertRange()

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -613,15 +613,20 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                     }
                     var index = r.Next(0, otherList.Count);
                     other.InsertAt(index, val);
-                    otherList.Add(val);
+                    otherList.Insert(index, val);
                 }
 
 
+                // Error on index 2
                 for (int i = 0; i < 10_000; i++)
                 {
                     var insertLocation = r.Next(0, expected.Count);
                     var index = r.Next(0, otherList.Count);
                     var toAdd = r.Next(0, otherList.Count - index);
+                    if (i == 2)
+                    {
+
+                    }
                     list.InsertRangeFrom(insertLocation, other, index, toAdd);
 
                     expected.InsertRange(insertLocation, otherList.GetRange(index, toAdd));

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -414,5 +414,225 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                 list.Dispose();
             }
         }
+
+        [Fact]
+        public void TestInsertRangeStartNoOffset()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            var other = new BitmapList(GlobalMemoryManager.Instance);
+
+            Random r = new Random(1);
+
+            List<bool> expected = new List<bool>();
+            List<bool> otherList = new List<bool>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                var index = r.Next(0, expected.Count);
+                list.InsertAt(index, val);
+                expected.Insert(index, val);
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                var index = r.Next(0, otherList.Count);
+                other.InsertAt(index, val);
+                otherList.Insert(index, val);
+            }
+
+            list.InsertRangeFrom(1, other, 0, 10);
+            expected.InsertRange(1, otherList.GetRange(0, 10));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertRangeStartOffsetOne()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            var other = new BitmapList(GlobalMemoryManager.Instance);
+
+            Random r = new Random(1);
+
+            List<bool> expected = new List<bool>();
+            List<bool> otherList = new List<bool>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                var index = r.Next(0, expected.Count);
+                list.InsertAt(index, val);
+                expected.Insert(index, val);
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                var index = r.Next(0, otherList.Count);
+                other.InsertAt(index, val);
+                otherList.Insert(index, val);
+            }
+
+            list.InsertRangeFrom(1, other, 1, 9);
+            expected.InsertRange(1, otherList.GetRange(1, 9));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+
+        [Fact]
+        public void TestInsertRangeSimple()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            var other = new BitmapList(GlobalMemoryManager.Instance);
+
+            Random r = new Random(1);
+
+            List<bool> expected = new List<bool>();
+            List<bool> otherList = new List<bool>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                var index = r.Next(0, expected.Count);
+                list.InsertAt(index, val);
+                expected.Insert(index, val);
+            }
+
+            for (int i = 0; i < 40; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                var index = r.Next(0, otherList.Count);
+                other.InsertAt(index, val);
+                otherList.Insert(index, val);
+            }
+
+            list.InsertRangeFrom(1, other, 2, 32);
+            expected.InsertRange(1, otherList.GetRange(2, 32));
+            //expected.InsertRange(1, otherList);
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            //for (int seed = 0; seed < 20; seed++)
+            //{
+
+
+
+            //    for (int i = 0; i < 10_000; i++)
+            //    {
+            //        var insertLocation = r.Next(0, expected.Count);
+            //        var index = r.Next(0, otherList.Count);
+            //        var toAdd = r.Next(0, otherList.Count - index);
+            //        list.InsertRangeFrom(insertLocation, other, index, toAdd);
+
+            //        expected.InsertRange(insertLocation, otherList.GetRange(index, toAdd));
+
+            //        for (int k = 0; k < expected.Count; k++)
+            //        {
+            //            Assert.Equal(expected[k], list.Get(k));
+            //        }
+            //    }
+            //    list.Dispose();
+            //}
+        }
+
+        [Fact]
+        public void TestInsertRange()
+        {
+            for (int seed = 0; seed < 20; seed++)
+            {
+                var list = new BitmapList(GlobalMemoryManager.Instance);
+                var other = new BitmapList(GlobalMemoryManager.Instance);
+
+                Random r = new Random(seed);
+
+                List<bool> expected = new List<bool>();
+                List<bool> otherList = new List<bool>();
+
+                for (int i = 0; i < 100_000; i++)
+                {
+                    var v = r.Next(0, 2);
+                    bool val = true;
+                    if (v == 0)
+                    {
+                        val = false;
+                    }
+                    var index = r.Next(0, expected.Count);
+                    list.InsertAt(index, val);
+                    expected.Insert(index, val);
+                }
+
+                for (int i = 0; i < 100_000; i++)
+                {
+                    var v = r.Next(0, 2);
+                    bool val = true;
+                    if (v == 0)
+                    {
+                        val = false;
+                    }
+                    var index = r.Next(0, otherList.Count);
+                    other.InsertAt(index, val);
+                    otherList.Add(val);
+                }
+
+
+                for (int i = 0; i < 10_000; i++)
+                {
+                    var insertLocation = r.Next(0, expected.Count);
+                    var index = r.Next(0, otherList.Count);
+                    var toAdd = r.Next(0, otherList.Count - index);
+                    list.InsertRangeFrom(insertLocation, other, index, toAdd);
+
+                    expected.InsertRange(insertLocation, otherList.GetRange(index, toAdd));
+
+                    for (int k = 0; k < expected.Count; k++)
+                    {
+                        Assert.Equal(expected[k], list.Get(k));
+                    }
+                }
+                list.Dispose();
+            }
+        }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -373,41 +373,45 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
         [Fact]
         public void TestRemoveRange()
         {
-            var list = new BitmapList(GlobalMemoryManager.Instance);
-
-            Random r = new Random(123);
-
-            List<bool> expected = new List<bool>();
-
-            for (int i = 0; i < 100_000; i++)
+            for (int seed = 0; seed < 20; seed++)
             {
-                var v = r.Next(0, 2);
-                bool val = true;
-                if (v == 0)
+                var list = new BitmapList(GlobalMemoryManager.Instance);
+
+                Random r = new Random(seed);
+
+                List<bool> expected = new List<bool>();
+
+                for (int i = 0; i < 100_000; i++)
                 {
-                    val = false;
+                    var v = r.Next(0, 2);
+                    bool val = true;
+                    if (v == 0)
+                    {
+                        val = false;
+                    }
+                    var index = r.Next(0, expected.Count);
+                    list.InsertAt(index, val);
+                    expected.Insert(index, val);
                 }
-                var index = r.Next(0, expected.Count);
-                list.InsertAt(index, val);
-                expected.Insert(index, val);
-            }
 
-            for (int i = 0; i < expected.Count; i++)
-            {
-                Assert.Equal(expected[i], list.Get(i));
-            }
-
-            for (int i = 0; i < 10_000; i++)
-            {
-                var index = r.Next(0, expected.Count);
-                var toRemove = r.Next(0, expected.Count - index);
-                list.RemoveRange(index, toRemove);
-                expected.RemoveRange(index, toRemove);
-
-                for (int k = 0; k < expected.Count; k++)
+                for (int i = 0; i < expected.Count; i++)
                 {
-                    Assert.Equal(expected[k], list.Get(k));
+                    Assert.Equal(expected[i], list.Get(i));
                 }
+
+                for (int i = 0; i < 10_000; i++)
+                {
+                    var index = r.Next(0, expected.Count);
+                    var toRemove = r.Next(0, expected.Count - index);
+                    list.RemoveRange(index, toRemove);
+                    expected.RemoveRange(index, toRemove);
+
+                    for (int k = 0; k < expected.Count; k++)
+                    {
+                        Assert.Equal(expected[k], list.Get(k));
+                    }
+                }
+                list.Dispose();
             }
         }
     }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -618,42 +618,21 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
 
 
                 // Error on index 2
-                for (int i = 0; i < 10_000; i++)
+                for (int i = 0; i < 100; i++)
                 {
                     var insertLocation = r.Next(0, expected.Count);
                     var index = r.Next(0, otherList.Count);
                     var toAdd = r.Next(0, otherList.Count - index);
-                    if (i == 367)
-                    {
-
-                    }
                     list.InsertRangeFrom(insertLocation, other, index, toAdd);
 
                     expected.InsertRange(insertLocation, otherList.GetRange(index, toAdd));
-
-                    
-
-                   
                 }
-                uint expectedBits = 0;
+
                 for (int k = 0; k < expected.Count; k++)
                 {
-                    if (k % 32 == 0)
-                    {
-                        expectedBits = 0;
-                        for (int z = 0; z < 32; z++)
-                        {
-                            if (k + z < expected.Count)
-                            {
-                                if (expected[k + z])
-                                {
-                                    expectedBits |= (uint)(1 << z);
-                                }
-                            }
-                        }
-                    }
                     Assert.Equal(expected[k], list.Get(k));
                 }
+
                 list.Dispose();
             }
         }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -547,34 +547,11 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
 
             list.InsertRangeFrom(1, other, 2, 32);
             expected.InsertRange(1, otherList.GetRange(2, 32));
-            //expected.InsertRange(1, otherList);
 
             for (int i = 0; i < expected.Count; i++)
             {
                 Assert.Equal(expected[i], list.Get(i));
             }
-
-            //for (int seed = 0; seed < 20; seed++)
-            //{
-
-
-
-            //    for (int i = 0; i < 10_000; i++)
-            //    {
-            //        var insertLocation = r.Next(0, expected.Count);
-            //        var index = r.Next(0, otherList.Count);
-            //        var toAdd = r.Next(0, otherList.Count - index);
-            //        list.InsertRangeFrom(insertLocation, other, index, toAdd);
-
-            //        expected.InsertRange(insertLocation, otherList.GetRange(index, toAdd));
-
-            //        for (int k = 0; k < expected.Count; k++)
-            //        {
-            //            Assert.Equal(expected[k], list.Get(k));
-            //        }
-            //    }
-            //    list.Dispose();
-            //}
         }
 
         [Fact]

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -623,7 +623,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                     var insertLocation = r.Next(0, expected.Count);
                     var index = r.Next(0, otherList.Count);
                     var toAdd = r.Next(0, otherList.Count - index);
-                    if (i == 2)
+                    if (i == 367)
                     {
 
                     }
@@ -631,10 +631,28 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
 
                     expected.InsertRange(insertLocation, otherList.GetRange(index, toAdd));
 
-                    for (int k = 0; k < expected.Count; k++)
+                    
+
+                   
+                }
+                uint expectedBits = 0;
+                for (int k = 0; k < expected.Count; k++)
+                {
+                    if (k % 32 == 0)
                     {
-                        Assert.Equal(expected[k], list.Get(k));
+                        expectedBits = 0;
+                        for (int z = 0; z < 32; z++)
+                        {
+                            if (k + z < expected.Count)
+                            {
+                                if (expected[k + z])
+                                {
+                                    expectedBits |= (uint)(1 << z);
+                                }
+                            }
+                        }
                     }
+                    Assert.Equal(expected[k], list.Get(k));
                 }
                 list.Dispose();
             }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -369,5 +369,46 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                 Assert.Equal(expected[i], list.Get(i));
             }
         }
+
+        [Fact]
+        public void TestRemoveRange()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+
+            Random r = new Random(123);
+
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 100_000; i++)
+            {
+                var v = r.Next(0, 2);
+                bool val = true;
+                if (v == 0)
+                {
+                    val = false;
+                }
+                var index = r.Next(0, expected.Count);
+                list.InsertAt(index, val);
+                expected.Insert(index, val);
+            }
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            for (int i = 0; i < 10_000; i++)
+            {
+                var index = r.Next(0, expected.Count);
+                var toRemove = r.Next(0, expected.Count - index);
+                list.RemoveRange(index, toRemove);
+                expected.RemoveRange(index, toRemove);
+
+                for (int k = 0; k < expected.Count; k++)
+                {
+                    Assert.Equal(expected[k], list.Get(k));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This is added to be used in the future for InsertRange on a column.
This will help improve performance when splitting/merging data in the B+ tree, also when handling list objects.