### PR TITLE
Add CountTrue/FalseInRange for bitmap list

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -400,13 +400,7 @@ namespace FlowtideDotNet.Core.ColumnStore
             Debug.Assert(_validityList != null);
             if (_nullCounter > 0)
             {
-                for (var i = 0; i < count; i++)
-                {
-                    if (!_validityList.Get(index + i))
-                    {
-                        _nullCounter--;
-                    }
-                }
+                _nullCounter -= _validityList.CountFalseInRange(index, count);
                 _validityList.RemoveRange(index, count);
             }
             if (_dataColumn != null)


### PR DESCRIPTION
This improves performance for code that needs to count the number of true or false booleans in the list.

Benchmark:

| Method                               | Mean          | Error        | StdDev       | Median        |
|------------------------------------- |--------------:|-------------:|-------------:|--------------:|
| RemoveRange                          |      23.19 us |     3.227 us |     9.463 us |      24.60 us |
| RemoveRangeIterative                 |  95,337.49 us | 1,877.237 us | 1,755.968 us |  95,721.70 us |
| RemoveRangeSystemCollectionList      |      66.95 us |     3.969 us |    11.388 us |      68.00 us |
| InsertRange                          |      55.34 us |     3.094 us |     8.976 us |      55.40 us |
| InsertRangeIterative                 | 266,000.51 us | 5,233.899 us | 8,148.550 us | 267,221.30 us |
| InsertRangeSystemCollectionList      |     114.61 us |     7.916 us |    22.967 us |     111.60 us |
| CountTrueInRange                     |      32.07 us |     3.566 us |    10.402 us |      32.65 us |
| CountTrueInRangeSystemCollectionList |   4,613.74 us |   154.536 us |   455.652 us |   4,829.05 us |