### PR TITLE
Add Insert range to columns and start using it in the stream

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -227,10 +227,8 @@ namespace FlowtideDotNet.Core.ColumnStore
                 // Check if the current buffer is a null buffer
                 if (_type == ArrowTypeId.Null)
                 {
-                    //CheckNullInitialization();
                     var index = _nullCounter;
                     _nullCounter++;
-                    //_validityList.Unset(index);
                 }
                 else
                 {
@@ -249,10 +247,6 @@ namespace FlowtideDotNet.Core.ColumnStore
             if (_nullCounter == 0)
             {
                 _validityList.InsertTrueInRange(0, Count);
-                //for (int i = 0; i < Count; i++)
-                //{
-                //    _validityList.Set(i);
-                //}
             }
         }
 
@@ -272,8 +266,6 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void InsertAt<T>(in int index, in T value)
             where T: IDataValue
         {
-           // operations.Add(new Operation("InsertAt", Count, _validityList!.Count, _nullCounter));
-            
             Debug.Assert(_validityList != null);
             if (value.Type != _type)
             {
@@ -333,7 +325,6 @@ namespace FlowtideDotNet.Core.ColumnStore
                 if (_type == ArrowTypeId.Null)
                 {
                     _nullCounter++;
-                    //_validityList.InsertAt(index, false);
                 }
                 else
                 {
@@ -349,7 +340,6 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void UpdateAt<T>(in int index, in T value)
             where T : IDataValue
         {
-            //operations.Add(new Operation("UpdateAt", Count, _validityList!.Count, _nullCounter));
             Debug.Assert(_validityList != null);
             if (_type == ArrowTypeId.Union)
             {
@@ -397,7 +387,6 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void RemoveAt(in int index)
         {
-            //operations.Add(new Operation("RemoveAt", Count, _validityList!.Count, _nullCounter));
             Debug.Assert(_validityList != null);
             if (_nullCounter > 0)
             {
@@ -422,7 +411,6 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void RemoveRange(in int index, in int count)
         {
-            //operations.Add(new Operation("RemoveRAnge", Count, _validityList!.Count, _nullCounter));
             Debug.Assert(_validityList != null);
             if (_nullCounter > 0)
             {
@@ -707,7 +695,6 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void AddToNewList<T>(in T value) where T : IDataValue
         {
-            //operations.Add(new Operation("AddTonewList", Count, _validityList!.Count, _nullCounter));
             if (_type == ArrowTypeId.List)
             {
                 _dataColumn!.AddToNewList(value);
@@ -751,7 +738,6 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public int EndNewList()
         {
-            //operations.Add(new Operation("EndNewList", Count, _validityList!.Count, _nullCounter));
             if (_type == ArrowTypeId.List)
             {
                 return _dataColumn!.EndNewList();
@@ -818,7 +804,6 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void InsertRangeFrom(int index, IColumn otherColumn, int start, int count)
         {
-            //operations.Add(new Operation("InsertRange", Count, _validityList!.Count, _nullCounter));
             if (otherColumn is Column column)
             {
                 if (_type == otherColumn.Type)
@@ -885,10 +870,6 @@ namespace FlowtideDotNet.Core.ColumnStore
                         if (_type == ArrowTypeId.Union)
                         {
                             _dataColumn.InsertNullRange(0, _nullCounter);
-                            //for (var i = 0; i < _nullCounter; i++)
-                            //{
-                            //    _dataColumn.Add(in NullValue.Instance);
-                            //}
                             _validityList.Clear();
                             _nullCounter = 0;
                         }
@@ -897,10 +878,6 @@ namespace FlowtideDotNet.Core.ColumnStore
                         if (_nullCounter > 0)
                         {
                             _dataColumn.InsertNullRange(0, _nullCounter);
-                            //for (var i = 0; i < _nullCounter; i++)
-                            //{
-                            //    _dataColumn.Add(in NullValue.Instance);
-                            //}
                             _validityList.Unset(Count - 1);
                         }
                         // Check if we need to copy over null values

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -94,12 +94,6 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public static Column Create(int nullCounter, IDataColumn? dataColumn, BitmapList validityList, ArrowTypeId type, IMemoryAllocator memoryAllocator)
         {
-            if (type == ArrowTypeId.Null && nullCounter > 0)
-            {
-                // Make sure that the validity list contains data
-                // This can be changed later on to only be initialized if the column changes type
-                validityList.Unset(nullCounter - 1);
-            }
             return ColumnFactory.Get(nullCounter, dataColumn, validityList, type, memoryAllocator);
         }
 
@@ -134,6 +128,16 @@ namespace FlowtideDotNet.Core.ColumnStore
         IDataColumn IColumn.DataColumn =>  _dataColumn!;
 
         public IDataValue this[int index] => GetValueAt(index, default);
+
+        /// <summary>
+        /// Used only for debugging
+        /// </summary>
+        /// <returns></returns>
+        internal int GetValidityListCount()
+        {
+            Debug.Assert(_validityList != null);
+            return _validityList.Count;
+        }
 
         private IDataColumn CreateArray(in ArrowTypeId type)
         {
@@ -223,10 +227,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                 // Check if the current buffer is a null buffer
                 if (_type == ArrowTypeId.Null)
                 {
-                    CheckNullInitialization();
+                    //CheckNullInitialization();
                     var index = _nullCounter;
                     _nullCounter++;
-                    _validityList.Unset(index);
+                    //_validityList.Unset(index);
                 }
                 else
                 {
@@ -268,6 +272,8 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void InsertAt<T>(in int index, in T value)
             where T: IDataValue
         {
+           // operations.Add(new Operation("InsertAt", Count, _validityList!.Count, _nullCounter));
+            
             Debug.Assert(_validityList != null);
             if (value.Type != _type)
             {
@@ -277,13 +283,11 @@ namespace FlowtideDotNet.Core.ColumnStore
                     _type = value.Type;
 
                     // Add null values as undefined values to the array.
-                    for (var i = 0; i < _nullCounter; i++)
-                    {
-                        _dataColumn.Add(in NullValue.Instance);
-                    }
+                    _dataColumn.InsertNullRange(0, _nullCounter);
 
                     if (_nullCounter > 0)
                     {
+                        _validityList.Unset(Count - 1);
                         _validityList.InsertAt(index, true);
                     }
 
@@ -329,7 +333,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                 if (_type == ArrowTypeId.Null)
                 {
                     _nullCounter++;
-                    _validityList.InsertAt(index, false);
+                    //_validityList.InsertAt(index, false);
                 }
                 else
                 {
@@ -345,6 +349,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void UpdateAt<T>(in int index, in T value)
             where T : IDataValue
         {
+            //operations.Add(new Operation("UpdateAt", Count, _validityList!.Count, _nullCounter));
             Debug.Assert(_validityList != null);
             if (_type == ArrowTypeId.Union)
             {
@@ -352,11 +357,18 @@ namespace FlowtideDotNet.Core.ColumnStore
             }
             else if (value.Type == ArrowTypeId.Null)
             {
-                CheckNullInitialization();
-                if (_validityList.Get(index))
+                if (_type == ArrowTypeId.Null)
                 {
-                    _validityList.Unset(index);
                     _nullCounter++;
+                }
+                else
+                {
+                    CheckNullInitialization();
+                    if (_validityList.Get(index))
+                    {
+                        _validityList.Unset(index);
+                        _nullCounter++;
+                    }
                 }
             }
             else
@@ -369,6 +381,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                     {
                         _dataColumn.Add(in NullValue.Instance);
                     }
+                    _validityList.Unset(Count - 1);
                 }
                 _dataColumn!.Update<T>(index, value);
 
@@ -384,14 +397,22 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void RemoveAt(in int index)
         {
+            //operations.Add(new Operation("RemoveAt", Count, _validityList!.Count, _nullCounter));
             Debug.Assert(_validityList != null);
             if (_nullCounter > 0)
             {
-                if (!_validityList.Get(index))
+                if (_type == ArrowTypeId.Null)
                 {
                     _nullCounter--;
                 }
-                _validityList.RemoveAt(index);
+                else
+                {
+                    if (!_validityList.Get(index))
+                    {
+                        _nullCounter--;
+                    }
+                    _validityList.RemoveAt(index);
+                }
             }
             if (_dataColumn != null)
             {
@@ -401,6 +422,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void RemoveRange(in int index, in int count)
         {
+            //operations.Add(new Operation("RemoveRAnge", Count, _validityList!.Count, _nullCounter));
             Debug.Assert(_validityList != null);
             if (_nullCounter > 0)
             {
@@ -410,8 +432,16 @@ namespace FlowtideDotNet.Core.ColumnStore
                 }
                 else
                 {
-                    _nullCounter -= _validityList.CountFalseInRange(index, count);
-                    _validityList.RemoveRange(index, count);
+                    try
+                    {
+                        _nullCounter -= _validityList.CountFalseInRange(index, count);
+                        _validityList.RemoveRange(index, count);
+                    }
+                    catch (Exception e)
+                    {
+                        throw;
+                    }
+                    
                 }
             }
             if (_dataColumn != null)
@@ -423,10 +453,16 @@ namespace FlowtideDotNet.Core.ColumnStore
         public IDataValue GetValueAt(in int index, in ReferenceSegment? child)
         {
             Debug.Assert(_validityList != null);
-            if (_nullCounter > 0 &&
-            !_validityList.Get(index))
+            if (_nullCounter > 0)
             {
-                return NullValue.Instance;
+                if (_type == ArrowTypeId.Null)
+                {
+                    return NullValue.Instance;
+                }
+                else if (!_validityList.Get(index))
+                {
+                    return NullValue.Instance;
+                }
             }
             return _dataColumn!.GetValueAt(index, child);
         }
@@ -438,10 +474,16 @@ namespace FlowtideDotNet.Core.ColumnStore
             {
                 return _dataColumn!.GetTypeAt(index, child);
             }
-            if (_nullCounter > 0 &&
-            !_validityList.Get(index))
+            if (_nullCounter > 0)
             {
-                return ArrowTypeId.Null;
+                if (_type == ArrowTypeId.Null)
+                {
+                    return ArrowTypeId.Null;
+                }
+                else if (!_validityList.Get(index))
+                {
+                    return ArrowTypeId.Null;
+                }
             }
             return _type;
         }
@@ -449,11 +491,18 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void GetValueAt(in int index, in DataValueContainer dataValueContainer, in ReferenceSegment? child)
         {
             Debug.Assert(_validityList != null);
-            if (_nullCounter > 0 &&
-                !_validityList.Get(index))
+            if (_nullCounter > 0)
             {
-                dataValueContainer._type = ArrowTypeId.Null;
-                return;
+                if (_type == ArrowTypeId.Null)
+                {
+                    dataValueContainer._type = ArrowTypeId.Null;
+                    return;
+                }
+                else if (!_validityList.Get(index))
+                {
+                    dataValueContainer._type = ArrowTypeId.Null;
+                    return;
+                }
             }
             _dataColumn!.GetValueAt(in index, in dataValueContainer, child);
         }
@@ -658,6 +707,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void AddToNewList<T>(in T value) where T : IDataValue
         {
+            //operations.Add(new Operation("AddTonewList", Count, _validityList!.Count, _nullCounter));
             if (_type == ArrowTypeId.List)
             {
                 _dataColumn!.AddToNewList(value);
@@ -701,6 +751,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public int EndNewList()
         {
+            //operations.Add(new Operation("EndNewList", Count, _validityList!.Count, _nullCounter));
             if (_type == ArrowTypeId.List)
             {
                 return _dataColumn!.EndNewList();
@@ -767,6 +818,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void InsertRangeFrom(int index, IColumn otherColumn, int start, int count)
         {
+            //operations.Add(new Operation("InsertRange", Count, _validityList!.Count, _nullCounter));
             if (otherColumn is Column column)
             {
                 if (_type == otherColumn.Type)
@@ -849,15 +901,35 @@ namespace FlowtideDotNet.Core.ColumnStore
                             //{
                             //    _dataColumn.Add(in NullValue.Instance);
                             //}
-                            _validityList.Set(Count);
+                            _validityList.Unset(Count - 1);
                         }
                         // Check if we need to copy over null values
-                        if (column._nullCounter > 0)
+                        if (column._nullCounter > 0 || _nullCounter  > 0)
                         {
-                            Debug.Assert(column._validityList != null);
-                            _validityList.InsertRangeFrom(index, column._validityList!, start, count);
-                            _nullCounter = column._validityList.CountFalseInRange(start, count);   
+                            if (column._nullCounter > 0)
+                            {
+                                Debug.Assert(column._validityList != null);
+                                _validityList.InsertRangeFrom(index, column._validityList!, start, count);
+                                _nullCounter += column._validityList.CountFalseInRange(start, count);
+                            }
+                            else
+                            {
+                                _validityList.InsertTrueInRange(index, count);
+                            }
                         }
+                    }
+                    else if (column.Type == ArrowTypeId.Null)
+                    {
+                        Debug.Assert(_dataColumn != null);
+                        if (_type != ArrowTypeId.Union)
+                        {
+                            CheckNullInitialization();
+                            Debug.Assert(_validityList != null);
+                            _validityList.InsertFalseInRange(index, count);
+                            _nullCounter += count;
+                        }
+                        _dataColumn.InsertNullRange(index, count);
+                        return;
                     }
                     else if (_type != ArrowTypeId.Union)
                     {
@@ -872,12 +944,6 @@ namespace FlowtideDotNet.Core.ColumnStore
                         previousColumn.Dispose();
                         _validityList.Clear();
                         _nullCounter = 0;
-                    }
-                    else if (column.Type == ArrowTypeId.Null)
-                    {
-                        Debug.Assert(_dataColumn != null);
-                        _dataColumn.InsertNullRange(index, count);
-                        return;
                     }
 
                     Debug.Assert(_dataColumn != null);

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -420,16 +420,8 @@ namespace FlowtideDotNet.Core.ColumnStore
                 }
                 else
                 {
-                    try
-                    {
-                        _nullCounter -= _validityList.CountFalseInRange(index, count);
-                        _validityList.RemoveRange(index, count);
-                    }
-                    catch (Exception e)
-                    {
-                        throw;
-                    }
-                    
+                    _nullCounter -= _validityList.CountFalseInRange(index, count);
+                    _validityList.RemoveRange(index, count);   
                 }
             }
             if (_dataColumn != null)

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -759,5 +759,10 @@ namespace FlowtideDotNet.Core.ColumnStore
             }
             return _dataColumn!.GetByteSize() + _validityList!.GetByteSize(0, Count - 1);
         }
+
+        public void InsertRangeFrom(int index, IColumn otherColumn, int start, int count)
+        {
+
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -125,6 +125,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             throw new NotSupportedException("Column with offset does not support InsertAt.");
         }
 
+        public void InsertRangeFrom(int index, IColumn otherColumn, int start, int count)
+        {
+            throw new NotSupportedException("Column with offset does not support InsertRangeFrom.");
+        }
+
         public void RemoveAt(in int index)
         {
             throw new NotSupportedException("Column with offset does not support RemoveAt.");

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -190,5 +190,17 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return _data.GetByteSize(0, Count - 1);
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            if (other is BinaryColumn binaryColumn)
+            {
+                _data.InsertRangeFrom(index, binaryColumn._data, start, count);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -202,5 +202,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotImplementedException();
             }
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            _data.InsertNullRange(index, count);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -232,5 +232,17 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return _data.GetByteSize(0, Count - 1);
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            if (other is BoolColumn boolColumn)
+            {
+                _data.InsertRangeFrom(index, boolColumn._data, start, count);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -216,11 +216,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void RemoveRange(int start, int count)
         {
-            var end = start + count;
-            for (int i = end - 1; i >= start; i--)
-            {
-                _data.RemoveAt(i);
-            }
+            _data.RemoveRange(start, count);
         }
 
         public int GetByteSize(int start, int end)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -244,5 +244,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotImplementedException();
             }
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            _data.InsertFalseInRange(index, count);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -213,5 +213,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotImplementedException();
             }
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            _values.InsertStaticRange(index, 0, count);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -201,5 +201,17 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return Count * sizeof(decimal);
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            if (other is DecimalColumn decimalColumn)
+            {
+                _values.InsertRangeFrom(index, decimalColumn._values, start, count);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -203,5 +203,17 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return Count * sizeof(double);
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            if (other is DoubleColumn doubleColumn)
+            {
+                _data.InsertRangeFrom(index, doubleColumn._data, start, count);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -215,5 +215,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotImplementedException();
             }
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            _data.InsertStaticRange(index, 0, count);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
@@ -66,5 +66,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         int GetByteSize(int start, int end);
 
         int GetByteSize();
+
+        void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList);
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
@@ -68,5 +68,13 @@ namespace FlowtideDotNet.Core.ColumnStore
         int GetByteSize();
 
         void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList);
+
+        /// <summary>
+        /// Inserts null on all elements in the range.
+        /// Used as an optimization to not have to insert nulls one by one.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="count"></param>
+        void InsertNullRange(int index, int count);
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -262,5 +262,19 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return Count * sizeof(long);
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            Debug.Assert(_data != null);
+            if (other is Int64Column int64Column)
+            {
+                Debug.Assert(int64Column._data != null);
+                _data.InsertRangeFrom(index, int64Column._data, start, count);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -276,5 +276,11 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotImplementedException();
             }
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            Debug.Assert(_data != null);
+            _data.InsertStaticRange(index, 0, count);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
@@ -358,5 +358,26 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return _internalColumn.GetByteSize() + (_offsets.Count * sizeof(int));
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            if (other is ListColumn listColumn)
+            {
+                var startOffset = _offsets.Get(index);
+
+                var otherStartOffset = listColumn._offsets.Get(start);
+                var otherEndOffset = listColumn._offsets.Get(start + count);
+
+                // Insert the values
+                _internalColumn.InsertRangeFrom(startOffset, listColumn._internalColumn, otherStartOffset, otherEndOffset - otherStartOffset);
+
+                // Insert the offsets
+                _offsets.InsertRangeFrom(index + 1, listColumn._offsets, start + 1, count, count, otherStartOffset - startOffset);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
@@ -392,5 +392,11 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotImplementedException();
             }
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            var startOffset = _offsets.Get(index);
+            _offsets.InsertRangeStaticValue(index, count, startOffset);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -491,5 +491,27 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return _keyColumn.GetByteSize() + _valueColumn.GetByteSize() + (_offsets.Count * sizeof(int));
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            if (other is MapColumn mapColumn)
+            {
+                var startOffset = _offsets.Get(index);
+
+                var otherStartOffset = mapColumn._offsets.Get(start);
+                var otherEndOffset = mapColumn._offsets.Get(start + count);
+
+                // Insert the keys and values
+                _keyColumn.InsertRangeFrom(startOffset, mapColumn._keyColumn, otherStartOffset, otherEndOffset - otherStartOffset);
+                _valueColumn.InsertRangeFrom(startOffset, mapColumn._valueColumn, otherStartOffset, otherEndOffset - otherStartOffset);
+
+                // Insert the offsets
+                _offsets.InsertRangeFrom(index, mapColumn._offsets, start, count, count, startOffset - otherStartOffset);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -525,5 +525,11 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotImplementedException();
             }
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            var offset = _offsets.Get(index);
+            _offsets.InsertRangeStaticValue(index, count, offset);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -481,9 +481,12 @@ namespace FlowtideDotNet.Core.ColumnStore
             // Remove offsets
             _offsets.RemoveRange(start, count, startOffset - endOffset);
 
-            // Remove the keys and values
-            _keyColumn.RemoveRange(startOffset, endOffset - startOffset);
-            _valueColumn.RemoveRange(startOffset, endOffset - startOffset);
+            if (endOffset > startOffset)
+            {
+                // Remove the keys and values
+                _keyColumn.RemoveRange(startOffset, endOffset - startOffset);
+                _valueColumn.RemoveRange(startOffset, endOffset - startOffset);
+            }
         }
 
         public int GetByteSize(int start, int end)
@@ -513,9 +516,12 @@ namespace FlowtideDotNet.Core.ColumnStore
                 var otherStartOffset = mapColumn._offsets.Get(start);
                 var otherEndOffset = mapColumn._offsets.Get(start + count);
 
-                // Insert the keys and values
-                _keyColumn.InsertRangeFrom(startOffset, mapColumn._keyColumn, otherStartOffset, otherEndOffset - otherStartOffset);
-                _valueColumn.InsertRangeFrom(startOffset, mapColumn._valueColumn, otherStartOffset, otherEndOffset - otherStartOffset);
+                if (otherStartOffset < otherEndOffset)
+                {
+                    // Insert the keys and values if there are any values
+                    _keyColumn.InsertRangeFrom(startOffset, mapColumn._keyColumn, otherStartOffset, otherEndOffset - otherStartOffset);
+                    _valueColumn.InsertRangeFrom(startOffset, mapColumn._valueColumn, otherStartOffset, otherEndOffset - otherStartOffset);
+                }
 
                 // Insert the offsets
                 _offsets.InsertRangeFrom(index, mapColumn._offsets, start, count, otherEndOffset - otherStartOffset, startOffset - otherStartOffset);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
@@ -133,5 +133,10 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
             _count += count;
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            _count += count;
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
@@ -131,14 +131,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
         public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
         {
-            if (other is NullColumn)
-            {
-                _count += count;
-            }
-            else
-            {
-                throw new NotImplementedException();
-            }
+            _count += count;
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
@@ -128,5 +128,17 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
             return 0;
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            if (other is NullColumn)
+            {
+                _count += count;
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -225,5 +225,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotImplementedException();
             }
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            _binaryList.InsertNullRange(index, count);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -213,5 +213,17 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return _binaryList.GetByteSize(0, Count - 1);
         }
+
+        public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
+        {
+            if (other is StringColumn stringColumn)
+            {
+                _binaryList.InsertRangeFrom(index, stringColumn._binaryList, start, count);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -80,6 +80,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             }
         }
 
+        internal IDataColumn GetDataColumn(int i)
+        {
+            return _valueColumns[i];
+        }
+
 
         private void CheckArrayExist(in ArrowTypeId type, sbyte[] typeIds, List<IDataColumn> valueColumns)
         {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -499,7 +499,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 }
                 valueColumn.InsertRangeFrom(nextOccurenceOffset, other, start, count, default);
                 // Insert range to offsets, requires special method to only increase offset of the same type.
-                _offsets.InsertRangeFromConditionalAdditionOnExisting(index, other., start, count, _typeList.Span, valueColumnIndex, count, start - nextOccurenceOffset);
+                _offsets.InsertIncrementalRangeConditionalAdditionOnExisting(index, other., start, count, _typeList.Span, valueColumnIndex, count, start - nextOccurenceOffset);
+            }
+            else
+            {
+
             }
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -594,7 +594,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             }
         }
 
-        //[SkipLocalsInit]
+        [SkipLocalsInit]
         private unsafe void InsertRangeFromUnionColumn(int index, UnionColumn other, int start, int count, BitmapList? validityList)
         {
             // Must find which types are missing, and also what index they exist on in other and also in this column.

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/DecimalValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/DecimalValue.cs
@@ -14,12 +14,14 @@ using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.Flexbuffer;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.ColumnStore
 {
+    [DebuggerDisplay(@"\{Dec: {value}\}")]
     public struct DecimalValue : IDataValue
     {
         private readonly decimal value;
@@ -53,6 +55,11 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             container._type = ArrowTypeId.Decimal128;
             container._decimalValue = this;
+        }
+
+        public override string ToString()
+        {
+            return value.ToString();
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/Int64Value.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/Int64Value.cs
@@ -14,12 +14,15 @@ using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.Flexbuffer;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.ColumnStore
 {
+    // Debugger display that uses to string
+    [DebuggerDisplay(@"\{Int64: {_value}\}")]
     public struct Int64Value : IDataValue
     {
         private long _value;

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/NullValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/NullValue.cs
@@ -13,12 +13,14 @@
 using FlowtideDotNet.Core.Flexbuffer;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.ColumnStore.DataValues
 {
+    [DebuggerDisplay(@"\{null\}")]
     public struct NullValue : IDataValue
     {
         public static readonly NullValue Instance = new NullValue();
@@ -45,6 +47,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataValues
         public void CopyToContainer(DataValueContainer container)
         {
             container._type = ArrowTypeId.Null;
+        }
+
+        public override string ToString()
+        {
+            return "null";
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/ReferenceListValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/ReferenceListValue.cs
@@ -23,9 +23,9 @@ namespace FlowtideDotNet.Core.ColumnStore
 {
     public struct ReferenceListValue : IListValue, IEnumerable<IDataValue>
     {
-        private readonly Column column;
-        private readonly int start;
-        private readonly int end;
+        internal readonly Column column;
+        internal readonly int start;
+        internal readonly int end;
 
         public ReferenceListValue(Column column, int start, int end)
         {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/StringValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/StringValue.cs
@@ -14,6 +14,7 @@ using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.Flexbuffer;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
@@ -21,6 +22,7 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.ColumnStore
 {
+    [DebuggerDisplay(@"\{String: {ToString()}\}")]
     public struct StringValue : IDataValue
     {
         private Memory<byte> _utf8;

--- a/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
@@ -65,5 +65,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         int GetByteSize();
 
         int GetByteSize(int start, int end);
+
+        void InsertRangeFrom(int index, IColumn otherColumn, int start, int count);
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ArrowToInternalVisitor.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ArrowToInternalVisitor.cs
@@ -62,10 +62,6 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
         {
             get
             {
-                if (_dataColumn == null)
-                {
-                    return null;
-                }
                 BitmapList? bitmapList = _bitmapList;
                 if (bitmapList == null)
                 {
@@ -188,6 +184,10 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             {
                 array.Fields[i].Accept(this);
 
+                if (_typeId == ArrowTypeId.Null)
+                {
+                    _dataColumn = new NullColumn(_nullCount);
+                }
                 if (_nullCount > 0 && _typeId != ArrowTypeId.Null)
                 {
                     throw new InvalidOperationException("Inner columns in a union should not have null values, they should be on the union level");
@@ -212,7 +212,7 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
 
         public void Visit(NullArray array)
         {
-            _dataColumn = new NullColumn(array.NullCount);
+            _dataColumn = null;
             _typeId = ArrowTypeId.Null;
             _bitmapList = null;
             _nullCount = array.NullCount;

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -61,9 +61,9 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
         {
             if (container is ColumnKeyStorageContainer columnKeyStorageContainer)
             {
-                for (int i = start; i < start + count; i++)
+                for (int i = 0; i < columnCount; i++)
                 {
-                    Add(columnKeyStorageContainer.Get(i));
+                    _data.Columns[i].InsertRangeFrom(_data.Columns[i].Count, columnKeyStorageContainer._data.Columns[i], start, count);
                 }
             }
             else

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
@@ -334,5 +334,11 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             var offsetDifference = offsetToInsertAt - offsetToCopyStart;
             _offsets.InsertRangeFrom(index, binaryList._offsets, start, count, toCopyLength, offsetDifference);
         }
+
+        public void InsertNullRange(int index, int count)
+        {
+            var offsetToInsertAt = _offsets.Get(index);
+            _offsets.InsertRangeStaticValue(index, count, offsetToInsertAt);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BitmapList.cs
@@ -234,6 +234,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
 
         public int CountTrueInRange(int index, int count)
         {
+            if (count == 0)
+            {
+                return 0;
+            }
             var span = AccessSpan;
             var fromIndex = index >> 5;
             var toIndex = (index + count) >> 5;
@@ -334,8 +338,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
 
             var startMod32 = start & 31;
             var numberOfNewInts = ((count + startMod32 + 31) / 32);
-            
-            EnsureSize(_dataLength + numberOfNewInts + 1);
+
+            var expectedNumberOfInts = ((_length + count + startMod32 + 31) / 32);
+
+            EnsureSize(expectedNumberOfInts + 1);
 
             var mod = index % 32;
             var modDifference = mod - startMod32;
@@ -876,11 +882,6 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                 }
                 else
                 {
-                    // If there are more than 16 integers to copy, use AVX2
-                    if (fromIndex + 16 <= lastIndex && Avx2.IsSupported)
-                    {
-                        ShiftRightAvxSelector(ref span, ref fromIndex, ref toIndex, ref lastIndex, remainder);
-                    }
                     while (fromIndex < lastIndex)
                     {
                         uint right = (uint)span[fromIndex] >> remainder;

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
@@ -168,15 +168,25 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             _length += count;
         }
 
-        public void InsertRangeFromTypeBasedAddition(int index, IntList other, int start, int count, Span<sbyte> typeIds, Span<int> toAdd, int typeCount)
+
+        public void InsertRangeFromTypeBasedAddition(
+            int index, 
+            IntList other, 
+            int start, 
+            int count, 
+            Span<sbyte> thisTypeIds, 
+            Span<int> thisToAdd,
+            Span<sbyte> otherTypeIds,
+            Span<int> otherToAdd,
+            int typeCount)
         {
             EnsureCapacity(_length + count);
             var span = AccessSpan;
             var sourceSpan = other.AccessSpan;
             var source = other.AccessSpan.Slice(start, count);
             var dest = span.Slice(index);
-            AvxUtils.InPlaceMemCopyAdditionByType(span, typeIds, index, index + count, _length - index, toAdd, typeCount);
-            AvxUtils.MemCopyAdditionByType(sourceSpan, span, typeIds, start, index, count, toAdd, typeCount);
+            AvxUtils.InPlaceMemCopyAdditionByType(span, thisTypeIds, index, index + count, _length - index, thisToAdd, typeCount);
+            AvxUtils.MemCopyAdditionByType(sourceSpan, span, otherTypeIds, start, index, count, otherToAdd, typeCount);
             _length += count;
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
@@ -163,10 +163,8 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             EnsureCapacity(_length + count);
             var span = AccessSpan;
             var sourceSpan = other.AccessSpan;
-            var source = sourceSpan.Slice(start, count);
-            var dest = span.Slice(index);
             AvxUtils.InPlaceMemCopyWithAddition(span, index, index + count, _length - index, additionOnMovedExisting);
-            AvxUtils.MemCpyWithAdd(sourceSpan, span, additionOnCopied);
+            AvxUtils.MemCpyWithAdd(sourceSpan.Slice(start, count), span.Slice(index), additionOnCopied);
             _length += count;
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
@@ -168,6 +168,22 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             _length += count;
         }
 
+        public void InsertRangeStaticValue(int index, int count, int staticValue)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+
+            // Move data
+            span.Slice(index, _length - index).CopyTo(span.Slice(index + count));
+
+            for (int i = 0; i < count; i++)
+            {
+                span[index + i] = staticValue;
+            }
+            _length += count;
+
+        }
+
 
         public void InsertRangeFromTypeBasedAddition(
             int index, 

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
@@ -162,10 +162,11 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
         {
             EnsureCapacity(_length + count);
             var span = AccessSpan;
-            var source = other.AccessSpan.Slice(start, count);
+            var sourceSpan = other.AccessSpan;
+            var source = sourceSpan.Slice(start, count);
             var dest = span.Slice(index);
             AvxUtils.InPlaceMemCopyWithAddition(span, index, index + count, _length - index, additionOnMovedExisting);
-            AvxUtils.MemCpyWithAdd(source, dest, additionOnCopied);
+            AvxUtils.MemCpyWithAdd(sourceSpan, span, additionOnCopied);
             _length += count;
         }
 
@@ -173,10 +174,11 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
         {
             EnsureCapacity(_length + count);
             var span = AccessSpan;
+            var sourceSpan = other.AccessSpan;
             var source = other.AccessSpan.Slice(start, count);
             var dest = span.Slice(index);
             AvxUtils.InPlaceMemCopyAdditionByType(span, typeIds, index, index + count, _length - index, toAdd, typeCount);
-            AvxUtils.By(source, dest);
+            AvxUtils.MemCopyAdditionByType(sourceSpan, span, typeIds, start, index, count, toAdd, typeCount);
             _length += count;
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
@@ -169,6 +169,17 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             _length += count;
         }
 
+        public void InsertRangeFromTypeBasedAddition(int index, IntList other, int start, int count, Span<sbyte> typeIds, Span<int> toAdd, int typeCount)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+            var source = other.AccessSpan.Slice(start, count);
+            var dest = span.Slice(index);
+            AvxUtils.InPlaceMemCopyAdditionByType(span, typeIds, index, index + count, _length - index, toAdd, typeCount);
+            AvxUtils.By(source, dest);
+            _length += count;
+        }
+
         public void InsertIncrementalRangeConditionalAdditionOnExisting(
             int index,  
             int startValue, 

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/NativeLongList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/NativeLongList.cs
@@ -187,6 +187,18 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             _length += count;
         }
 
+        public void InsertStaticRange(int index, long value, int count)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+            span.Slice(index, _length - index).CopyTo(span.Slice(index + count, _length - index));
+            for (int i = 0; i < count; i++)
+            {
+                span[index + i] = value;
+            }
+            _length += count;
+        }
+
         public void RemoveAt(int index)
         {
             var span = AccessSpan;

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/TypeList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/TypeList.cs
@@ -1,0 +1,321 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.ColumnStore.Utils
+{
+    internal unsafe class TypeList : IDisposable, IReadOnlyList<sbyte>
+    {
+        private void* _data;
+        private int _dataLength;
+        private int _length;
+        private bool _disposedValue;
+        private readonly IMemoryAllocator _memoryAllocator;
+        private IMemoryOwner<byte>? _memoryOwner;
+        private int _rentCounter;
+
+        public TypeList(IMemoryAllocator memoryAllocator)
+        {
+            _data = null;
+            _memoryAllocator = memoryAllocator;
+        }
+
+        public TypeList(IMemoryOwner<byte> memory, int length, IMemoryAllocator memoryAllocator)
+        {
+            _memoryOwner = memory;
+            _data = _memoryOwner.Memory.Pin().Pointer;
+            _dataLength = memory.Memory.Length / sizeof(sbyte);
+            _length = length;
+            _memoryAllocator = memoryAllocator;
+        }
+
+        public Span<sbyte> Span => new Span<sbyte>(_data, _length);
+
+        public Memory<byte> Memory => _memoryOwner?.Memory ?? new Memory<byte>();
+
+        public Memory<byte> SlicedMemory => _memoryOwner?.Memory.Slice(0, _length * sizeof(sbyte)) ?? new Memory<byte>();
+
+        public TypeList(void* data, int dataLength, int length, IMemoryAllocator memoryAllocator)
+        {
+            _data = data;
+            _dataLength = dataLength;
+            _length = length;
+            _memoryAllocator = memoryAllocator;
+        }
+
+        private void EnsureCapacity(int length)
+        {
+            if (_dataLength < length)
+            {
+                var newLength = length * 2;
+                if (newLength < 64)
+                {
+                    newLength = 64;
+                }
+                var allocSize = newLength * sizeof(sbyte);
+
+                if (_memoryOwner == null)
+                {
+                    _memoryOwner = _memoryAllocator.Allocate(allocSize, 64);
+                    _data = _memoryOwner.Memory.Pin().Pointer;
+                }
+                else
+                {
+                    _memoryOwner = _memoryAllocator.Realloc(_memoryOwner, allocSize, 64);
+                    _data = _memoryOwner.Memory.Pin().Pointer;
+                }
+                _dataLength = newLength;
+            }
+        }
+
+        private Span<sbyte> AccessSpan => new Span<sbyte>(_data, _dataLength);
+
+        public void Add(sbyte value)
+        {
+            EnsureCapacity(_length + 1);
+            AccessSpan[_length++] = value;
+        }
+
+        public void AddRangeFrom(TypeList list, int index, int count)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+            var sourceSpan = list.AccessSpan;
+            sourceSpan.Slice(index, count).CopyTo(span.Slice(_length, count));
+            _length += count;
+        }
+
+        public void InsertAt(int index, sbyte value)
+        {
+            if (index == _length)
+            {
+                Add(value);
+                return;
+            }
+
+            EnsureCapacity(_length + 1);
+            var span = AccessSpan;
+            span.Slice(index, _length - index).CopyTo(span.Slice(index + 1, _length - index));
+            span[index] = value;
+            _length++;
+        }
+
+        public void InsertRangeFrom(int index, TypeList other, int start, int count)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+            var sourceSpan = other.AccessSpan;
+            span.Slice(index, _length - index).CopyTo(span.Slice(index + count, _length - index));
+            sourceSpan.Slice(start, count).CopyTo(span.Slice(index, count));
+            _length += count;
+        }
+
+        public void InsertRangeFrom(int index, TypeList other, int start, int count, Span<sbyte> mapping, int typeCount)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+            var sourceSpan = other.AccessSpan;
+
+            // Copy existing data
+            span.Slice(index, _length - index).CopyTo(span.Slice(index + count, _length - index));
+
+            int i = 0;
+            if (Avx2.IsSupported && typeCount <= 8)
+            {
+                // Code that runs it using avx
+
+                fixed (sbyte* pDest = span)
+                fixed (sbyte* pSource = sourceSpan)
+                fixed (sbyte* pMapping = mapping)
+                {
+                    Vector128<sbyte> mappingVector = Vector128.Load(pMapping);
+
+                    int vectorSize = Vector128<sbyte>.Count;
+
+                    
+                    for (; i <= count - vectorSize; i += vectorSize)
+                    {
+                        Vector128<sbyte> sourceVector = Vector128.Load(pSource + start + i);
+                        Vector128<sbyte> resultVector = Avx.Shuffle(mappingVector, sourceVector);
+                        Avx.Store(pDest + index + i, resultVector);
+                    }
+                }
+                    
+
+
+                //int vecLength = Vector256<sbyte>.Count;
+                //fixed (sbyte* pDest = span)
+                //fixed (sbyte* pSource = sourceSpan)
+                //fixed (sbyte* pMapping = mapping)
+                //{
+                //    Vector256<int> mappingVec = Avx2.ConvertToVector256Int32(pMapping);
+
+                //    int i;
+                //    for (i = 0; i <= count - vecLength; i += vecLength)
+                //    {
+
+                //        Vector128<sbyte> srcVec = Avx2.LoadVector128(pSource + start + i);
+                //        //Vector128<sbyte> typeIdVec = Avx2.LoadVector128(pDest + index + i);
+
+                //        var srcVecInt = Avx2.ConvertToVector256Int32(srcVec);
+                //        //var typeIdVecInt = Avx2.ConvertToVector256Int32(typeIdVec);
+
+                //        var newTypes = Avx2.PermuteVar8x32(mappingVec, srcVecInt);
+
+                //        Avx2.Store(pDest + index + i, newTypes);
+                //    }
+
+                //}
+
+            }
+
+            // Insert the new data
+            for (; i < count; i++)
+            {
+                span[index + i] = mapping[sourceSpan[start + i]];
+            }
+            _length += count;
+        }
+
+        public void InsertStaticRange(int index, sbyte value, int count)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+            span.Slice(index, _length - index).CopyTo(span.Slice(index + count, _length - index));
+            for (var i = 0; i < count; i++)
+            {
+                span[index + i] = value;
+            }
+            _length += count;
+        }
+
+        public void RemoveAt(int index)
+        {
+            var span = AccessSpan;
+            span.Slice(index + 1, _length - index - 1).CopyTo(span.Slice(index, _length - index - 1));
+            _length--;
+        }
+
+        public void RemoveRange(int index, int count)
+        {
+            var span = AccessSpan;
+            var length = _length - index - count;
+            span.Slice(index + count, length).CopyTo(span.Slice(index));
+            _length -= count;
+        }
+
+        public sbyte Get(in int index)
+        {
+            var span = AccessSpan;
+            return span[index];
+        }
+
+        public ref sbyte GetRef(scoped in int index)
+        {
+            var span = AccessSpan;
+            return ref span[index];
+        }
+
+        public void Update(in int index, in sbyte value)
+        {
+            AccessSpan[index] = value;
+        }
+
+        public sbyte this[int index]
+        {
+            get
+            {
+                return Get(index);
+            }
+            set
+            {
+                Update(index, value);
+            }
+        }
+
+        public int Count => _length;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (_memoryOwner != null)
+                {
+                    _memoryOwner.Dispose();
+                    _memoryOwner = null;
+                    _data = null;
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        ~TypeList()
+        {
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        private IEnumerable<sbyte> GetEnumerable()
+        {
+            for (var i = 0; i < _length; i++)
+            {
+                yield return Get(i);
+            }
+        }
+
+        public IEnumerator<sbyte> GetEnumerator()
+        {
+            return GetEnumerable().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerable().GetEnumerator();
+        }
+
+        public void Rent(int count)
+        {
+            Interlocked.Add(ref _rentCounter, count);
+        }
+
+        public void Return()
+        {
+            var result = Interlocked.Decrement(ref _rentCounter);
+            if (result <= 0)
+            {
+                Dispose();
+            }
+        }
+
+        public void Clear()
+        {
+            _length = 0;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/TypeList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/TypeList.cs
@@ -151,7 +151,6 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                     Vector128<sbyte> mappingVector = Vector128.Load(pMapping);
 
                     int vectorSize = Vector128<sbyte>.Count;
-
                     
                     for (; i <= count - vectorSize; i += vectorSize)
                     {
@@ -160,33 +159,6 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                         Avx.Store(pDest + index + i, resultVector);
                     }
                 }
-                    
-
-
-                //int vecLength = Vector256<sbyte>.Count;
-                //fixed (sbyte* pDest = span)
-                //fixed (sbyte* pSource = sourceSpan)
-                //fixed (sbyte* pMapping = mapping)
-                //{
-                //    Vector256<int> mappingVec = Avx2.ConvertToVector256Int32(pMapping);
-
-                //    int i;
-                //    for (i = 0; i <= count - vecLength; i += vecLength)
-                //    {
-
-                //        Vector128<sbyte> srcVec = Avx2.LoadVector128(pSource + start + i);
-                //        //Vector128<sbyte> typeIdVec = Avx2.LoadVector128(pDest + index + i);
-
-                //        var srcVecInt = Avx2.ConvertToVector256Int32(srcVec);
-                //        //var typeIdVecInt = Avx2.ConvertToVector256Int32(typeIdVec);
-
-                //        var newTypes = Avx2.PermuteVar8x32(mappingVec, srcVecInt);
-
-                //        Avx2.Store(pDest + index + i, newTypes);
-                //    }
-
-                //}
-
             }
 
             // Insert the new data

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
@@ -65,9 +65,9 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
         {
             if (container is ListAggKeyStorageContainer columnKeyStorageContainer)
             {
-                for (int i = start; i < start + count; i++)
+                for (int i = 0; i < (_groupingKeyLength + 1); i++)
                 {
-                    Add(columnKeyStorageContainer.Get(i));
+                    _data.Columns[i].InsertRangeFrom(_data.Columns[i].Count, columnKeyStorageContainer._data.Columns[i], start, count);
                 }
             }
             else

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
@@ -68,10 +68,11 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
         {
             if (container is AggregateKeyStorageContainer columnKeyStorageContainer)
             {
-                for (int i = start; i < start + count; i++)
+                for (int i = 0; i < columnCount; i++)
                 {
-                    Add(columnKeyStorageContainer.Get(i));
+                    _data.Columns[i].InsertRangeFrom(_data.Columns[i].Count, columnKeyStorageContainer._data.Columns[i], start, count);
                 }
+                _length += count;
             }
             else
             {

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
@@ -70,10 +70,12 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
         {
             if (container is ColumnAggregateValueContainer columnKeyStorageContainer)
             {
-                for (int i = start; i < start + count; i++)
+                for (int i =0; i < columnCount; i++)
                 {
-                    Add(columnKeyStorageContainer.Get(i));
+                    _eventBatch.Columns[i].InsertRangeFrom(_eventBatch.Columns[i].Count, columnKeyStorageContainer._eventBatch.Columns[i], start, count);
                 }
+                _weights.AddRangeFrom(columnKeyStorageContainer._weights, start, count);
+                _previousValueSent.AddRangeFrom(columnKeyStorageContainer._previousValueSent, start, count);
             }
             else
             {
@@ -136,11 +138,12 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
 
         public void RemoveRange(int start, int count)
         {
-            var end = start + count;
-            for (int i = end - 1; i >= start; i--)
+            for (int i = 0; i < columnCount; i++)
             {
-                RemoveAt(i);
+                _eventBatch.Columns[i].RemoveRange(start, count);
             }
+            _weights.RemoveRange(start, count);
+            _previousValueSent.RemoveRange(start, count);
         }
 
         public void Update(int index, ColumnAggregateStateReference value)

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorage.cs
@@ -64,9 +64,9 @@ namespace FlowtideDotNet.Core.Operators.Normalization
         {
             if (container is NormalizeKeyStorage columnKeyStorageContainer)
             {
-                for (int i = start; i < start + count; i++)
+                for (int i = 0; i < _columnsToStore.Count; i++)
                 {
-                    Add(columnKeyStorageContainer.Get(i));
+                    _data.Columns[i].InsertRangeFrom(_data.Columns[i].Count, columnKeyStorageContainer._data.Columns[i], start, count);
                 }
             }
             else

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueStorage.cs
@@ -66,10 +66,11 @@ namespace FlowtideDotNet.Core.Operators.Normalization
         {
             if (container is NormalizeValueStorage columnKeyStorageContainer)
             {
-                for (int i = start; i < start + count; i++)
+                for (int i = 0; i < _columnsToStore.Count; i++)
                 {
-                    Add(columnKeyStorageContainer.Get(i));
+                    _data.Columns[i].InsertRangeFrom(_data.Columns[i].Count, columnKeyStorageContainer._data.Columns[i], start, count);
                 }
+                _length += count;
             }
             else
             {

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -130,6 +130,18 @@ namespace FlowtideDotNet.Storage.DataStructures
             _length += count;
         }
 
+        public void InsertStaticRange(int index, T value, int count)
+        {
+            EnsureCapacity(_length + count);
+            var span = AccessSpan;
+            span.Slice(index, _length - index).CopyTo(span.Slice(index + count, _length - index));
+            for (var i = 0; i < count; i++)
+            {
+                span[index + i] = value;
+            }
+            _length += count;
+        }
+
         public void RemoveAt(int index)
         {
             var span = AccessSpan;

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
@@ -162,7 +162,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
                     await session.Write(kv.Key, bytes);
 
                     if (!useReadCache)
-                    {
+                    {   
                         m_fileCache.Free(kv.Key);
                     }
                     else

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ListColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ListColumnTests.cs
@@ -517,5 +517,538 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
                 }
             }
         }
+
+        [Fact]
+        public void InsertRangeNoNullIntoEmptyColumn()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            Column other = new Column(GlobalMemoryManager.Instance);
+
+            List<byte[]> expected = new List<byte[]>();
+            Random r = new Random(123);
+            for (int i = 0; i < 1000; i++)
+            {
+                var byteSize = r.Next(20);
+                byte[] data = new byte[byteSize];
+                r.NextBytes(data);
+                expected.Add(data);
+                other.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+            }
+
+            column.InsertRangeFrom(0, other, 5, 50);
+
+            Assert.Equal(50, column.Count);
+
+            for (int i = 0; i < 50; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                List<byte> actualByteList = new List<byte>();
+                for (int k = 0; k < actual.AsList.Count; k++)
+                {
+                    actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                }
+                Assert.Equal(expected[i + 5], actualByteList.ToArray());
+            }
+        }
+
+        [Fact]
+        public void InsertRangeNoNullIntoNonEmptyColumn()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            Column other = new Column(GlobalMemoryManager.Instance);
+
+            List<byte[]> existing = new List<byte[]>();
+            List<byte[]> expected = new List<byte[]>();
+            Random r = new Random(123);
+
+            // Was 50
+            for (int i = 0; i < 50; i++)
+            {
+                var byteSize = r.Next(20);
+                byte[] data = new byte[byteSize];
+                r.NextBytes(data);
+                existing.Add(data);
+                column.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+            }
+
+            for (int i = 0; i < 1000; i++)
+            {
+                var byteSize = r.Next(20);
+                byte[] data = new byte[byteSize];
+                r.NextBytes(data);
+                expected.Add(data);
+                other.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+            }
+
+            // Was 13 and 50
+            column.InsertRangeFrom(13, other, 5, 50);
+
+            Assert.Equal(100, column.Count);
+
+            for (int i = 0; i < 13; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                List<byte> actualByteList = new List<byte>();
+                for (int k = 0; k < actual.AsList.Count; k++)
+                {
+                    actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                }
+                Assert.Equal(existing[i], actualByteList.ToArray());
+            }
+
+            for (int i = 0; i < 50; i++)
+            {
+                var actual = column.GetValueAt(i + 13, default);
+                List<byte> actualByteList = new List<byte>();
+                for (int k = 0; k < actual.AsList.Count; k++)
+                {
+                    actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                }
+                Assert.Equal(expected[i + 5], actualByteList.ToArray());
+            }
+
+            for (int i = 0; i < 37; i++)
+            {
+                var actual = column.GetValueAt(i + 63, default);
+                List<byte> actualByteList = new List<byte>();
+                for (int k = 0; k < actual.AsList.Count; k++)
+                {
+                    actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                }
+                Assert.Equal(existing[i + 13], actualByteList.ToArray());
+            }
+        }
+
+        [Fact]
+        public void InsertRangeWithNullIntoEmptyColumn()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            Column other = new Column(GlobalMemoryManager.Instance);
+
+            List<byte[]?> expected = new List<byte[]?>();
+            Random r = new Random(123);
+            for (int i = 0; i < 1000; i++)
+            {
+                var isNull = r.Next(2) == 0;
+
+                if (isNull)
+                {
+                    expected.Add(null);
+                    other.Add(NullValue.Instance);
+                }
+                else
+                {
+                    var byteSize = r.Next(20);
+                    byte[] data = new byte[byteSize];
+                    r.NextBytes(data);
+                    expected.Add(data);
+                    other.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+                }
+            }
+
+            column.InsertRangeFrom(0, other, 5, 50);
+
+            Assert.Equal(50, column.Count);
+
+            for (int i = 0; i < 50; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                if (expected[i + 5] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(expected[i + 5], actualByteList.ToArray());
+                }
+            }
+        }
+
+        [Fact]
+        public void InsertRangeWithNullIntoNullColumnWithNull()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            Column other = new Column(GlobalMemoryManager.Instance);
+
+            List<byte[]?> expected = new List<byte[]?>();
+            Random r = new Random(123);
+            for (int i = 0; i < 1000; i++)
+            {
+                var isNull = r.Next(2) == 0;
+
+                if (isNull)
+                {
+                    expected.Add(null);
+                    other.Add(NullValue.Instance);
+                }
+                else
+                {
+                    var byteSize = r.Next(20);
+                    byte[] data = new byte[byteSize];
+                    r.NextBytes(data);
+                    expected.Add(data);
+                    other.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+                }
+            }
+
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+
+            column.InsertRangeFrom(5, other, 5, 50);
+
+            Assert.Equal(58, column.Count);
+
+            for (int i = 0; i < 5; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                Assert.True(actual.IsNull);
+            } 
+
+            for (int i = 5; i < 55; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                if (expected[i] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(expected[i], actualByteList.ToArray());
+                }
+            }
+
+            for (int i = 55; i < 58; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                Assert.True(actual.IsNull);
+            }
+        }
+
+        [Fact]
+        public void InsertRangeWithNullIntoNonEmptyColumn()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            Column other = new Column(GlobalMemoryManager.Instance);
+
+            List<byte[]?> existing = new List<byte[]?>();
+            List<byte[]?> expected = new List<byte[]?>();
+            Random r = new Random(123);
+
+            // Was 50
+            for (int i = 0; i < 50; i++)
+            {
+                var isNull = r.Next(2) == 0;
+
+                if (isNull)
+                {
+                    existing.Add(null);
+                    column.Add(NullValue.Instance);
+                }
+                else
+                {
+                    var byteSize = r.Next(20);
+                    byte[] data = new byte[byteSize];
+                    r.NextBytes(data);
+                    existing.Add(data);
+                    column.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+                }
+            }
+
+            for (int i = 0; i < 1000; i++)
+            {
+                var isNull = r.Next(2) == 0;
+
+                if (isNull)
+                {
+                    expected.Add(null);
+                    other.Add(NullValue.Instance);
+                }
+                else
+                {
+                    var byteSize = r.Next(20);
+                    byte[] data = new byte[byteSize];
+                    r.NextBytes(data);
+                    expected.Add(data);
+                    other.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+                }
+            }
+
+            column.InsertRangeFrom(13, other, 5, 50);
+
+            Assert.Equal(100, column.Count);
+
+            for (int i = 0; i < 13; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                if (existing[i] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(existing[i], actualByteList.ToArray());
+                }
+                
+            }
+
+            for (int i = 0; i < 50; i++)
+            {
+                var actual = column.GetValueAt(i + 13, default);
+                if (expected[i + 5] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(expected[i + 5], actualByteList.ToArray());
+                }
+            }
+
+            for (int i = 0; i < 37; i++)
+            {
+                var actual = column.GetValueAt(i + 63, default);
+                if (existing[i + 13] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(existing[i + 13], actualByteList.ToArray());
+                }
+            }
+        }
+
+        [Fact]
+        public void InsertRangeWitNonNullIntoNonEmptyColumnWithNull()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            Column other = new Column(GlobalMemoryManager.Instance);
+
+            List<byte[]?> existing = new List<byte[]?>();
+            List<byte[]?> expected = new List<byte[]?>();
+            Random r = new Random(123);
+
+            // Was 50
+            for (int i = 0; i < 50; i++)
+            {
+                var isNull = r.Next(2) == 0;
+
+                if (isNull)
+                {
+                    existing.Add(null);
+                    column.Add(NullValue.Instance);
+                }
+                else
+                {
+                    var byteSize = r.Next(20);
+                    byte[] data = new byte[byteSize];
+                    r.NextBytes(data);
+                    existing.Add(data);
+                    column.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+                }
+            }
+
+            for (int i = 0; i < 1000; i++)
+            {
+                var isNull = r.Next(2) == 0;
+
+                var byteSize = r.Next(20);
+                byte[] data = new byte[byteSize];
+                r.NextBytes(data);
+                expected.Add(data);
+                other.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+            }
+
+            column.InsertRangeFrom(13, other, 5, 50);
+
+            Assert.Equal(100, column.Count);
+
+            for (int i = 0; i < 13; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                if (existing[i] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(existing[i], actualByteList.ToArray());
+                }
+
+            }
+
+            for (int i = 0; i < 50; i++)
+            {
+                var actual = column.GetValueAt(i + 13, default);
+                if (expected[i + 5] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(expected[i + 5], actualByteList.ToArray());
+                }
+            }
+
+            for (int i = 0; i < 37; i++)
+            {
+                var actual = column.GetValueAt(i + 63, default);
+                if (existing[i + 13] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(existing[i + 13], actualByteList.ToArray());
+                }
+            }
+        }
+
+        [Fact]
+        public void InsertRangeWithNullIntoNonEmptyColumnWithNoNull()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            Column other = new Column(GlobalMemoryManager.Instance);
+
+            List<byte[]?> existing = new List<byte[]?>();
+            List<byte[]?> expected = new List<byte[]?>();
+            Random r = new Random(123);
+
+            // Was 50
+            for (int i = 0; i < 50; i++)
+            {
+                var isNull = r.Next(2) == 0;
+
+                var byteSize = r.Next(20);
+                byte[] data = new byte[byteSize];
+                r.NextBytes(data);
+                existing.Add(data);
+                column.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+            }
+
+            for (int i = 0; i < 1000; i++)
+            {
+                var isNull = r.Next(2) == 0;
+
+                if (isNull)
+                {
+                    expected.Add(null);
+                    other.Add(NullValue.Instance);
+                }
+                else
+                {
+                    var byteSize = r.Next(20);
+                    byte[] data = new byte[byteSize];
+                    r.NextBytes(data);
+                    expected.Add(data);
+                    other.Add(new ListValue(data.Select(x => (IDataValue)new Int64Value(x)).ToList()));
+                }
+            }
+
+            column.InsertRangeFrom(13, other, 5, 50);
+
+            Assert.Equal(100, column.Count);
+
+            for (int i = 0; i < 13; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                if (existing[i] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(existing[i], actualByteList.ToArray());
+                }
+
+            }
+
+            for (int i = 0; i < 50; i++)
+            {
+                var actual = column.GetValueAt(i + 13, default);
+                if (expected[i + 5] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(expected[i + 5], actualByteList.ToArray());
+                }
+            }
+
+            for (int i = 0; i < 37; i++)
+            {
+                var actual = column.GetValueAt(i + 63, default);
+                if (existing[i + 13] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    List<byte> actualByteList = new List<byte>();
+                    for (int k = 0; k < actual.AsList.Count; k++)
+                    {
+                        actualByteList.Add((byte)actual.AsList.GetAt(k).AsLong);
+                    }
+                    Assert.Equal(existing[i + 13], actualByteList.ToArray());
+                }
+            }
+        }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ListColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ListColumnTests.cs
@@ -1050,5 +1050,22 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
                 }
             }
         }
+
+        [Fact]
+        public void TestRemoveRangeNullLastBitmapSegment()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+
+            for (int i = 0; i < 63; i++)
+            {
+                column.Add(new ListValue(new Int64Value(i)));
+            }
+            column.Add(new ListValue(NullValue.Instance));
+            column.Add(NullValue.Instance);
+
+            column.RemoveRange(64, 1);
+
+            Assert.Equal(64, column.Count);
+        }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/MapColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/MapColumnTests.cs
@@ -226,5 +226,77 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
                 }
             }
         }
+
+        [Fact]
+        public void InsertRangeNonNull()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            Column other = new Column(GlobalMemoryManager.Instance);
+
+            List<SortedDictionary<string, string>?> otherList = new List<SortedDictionary<string, string>?>();
+            List<SortedDictionary<string, string>?> expected = new List<SortedDictionary<string, string>?>();
+            Random r = new Random(123);
+            for (int i = 0; i < 1000; i++)
+            {
+                var dictSize = r.Next(20);
+
+                SortedDictionary<string, string> rowexpected = new SortedDictionary<string, string>();
+                Dictionary<IDataValue, IDataValue> actual = new Dictionary<IDataValue, IDataValue>();
+                for (int k = 0; k < dictSize; k++)
+                {
+                    rowexpected.Add(k.ToString(), k.ToString());
+                    actual.Add(new StringValue(k.ToString()), new StringValue(k.ToString()));
+                }
+                expected.Add(rowexpected);
+                column.Add(new MapValue(actual));
+            }
+            for (int i = 0; i < 1000; i++)
+            {
+                var dictSize = r.Next(20);
+
+                SortedDictionary<string, string> rowexpected = new SortedDictionary<string, string>();
+                Dictionary<IDataValue, IDataValue> actual = new Dictionary<IDataValue, IDataValue>();
+                for (int k = 0; k < dictSize; k++)
+                {
+                    rowexpected.Add(k.ToString(), k.ToString());
+                    actual.Add(new StringValue(k.ToString()), new StringValue(k.ToString()));
+                }
+                otherList.Add(rowexpected);
+                other.Add(new MapValue(actual));
+            }
+
+            column.InsertRangeFrom(100, other, 100, 100);
+            expected.InsertRange(100, otherList.Skip(100).Take(100));
+
+            Assert.Equal(expected.Count(x => x == null), column.GetNullCount());
+            Assert.Equal(expected.Count, column.Count);
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                var actual = column.GetValueAt(i, default);
+                if (expected[i] == null)
+                {
+                    Assert.True(actual.IsNull);
+                }
+                else
+                {
+                    var dict = actual.AsMap;
+                    var dictLength = dict.GetLength();
+                    var expectedVal = expected[i]!;
+                    Assert.Equal(expectedVal.Count, dictLength);
+
+                    var expectedKeys = expectedVal.Keys.ToList();
+                    DataValueContainer dataValueContainer = new DataValueContainer();
+                    for (int k = 0; k < dictLength; k++)
+                    {
+                        dict.GetKeyAt(k, dataValueContainer);
+                        Assert.Equal(expectedKeys[k], dataValueContainer.AsString.ToString());
+
+                        dict.GetValueAt(k, dataValueContainer);
+                        Assert.Equal(expectedVal[expectedKeys[k]], dataValueContainer.AsString.ToString());
+                    }
+                }
+            }
+        }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
@@ -512,5 +512,60 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Assert.Equal("world", unionColumn.GetValueAt(2, default).AsString.ToString());
             Assert.Equal(3, unionColumn.GetValueAt(3, default).AsDecimal);
         }
+
+        [Fact]
+        public void InsertRangeFromOtherUnionColumnWithAvx()
+        {
+            UnionColumn unionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new Int64Value(1),
+                new DecimalValue(3)
+            };
+
+            UnionColumn otherUnionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new StringValue("1"),
+                new StringValue("2"),
+                new StringValue("3"),
+                new StringValue("4"),
+                new StringValue("5"),
+                new StringValue("6"),
+                new StringValue("7"),
+                new StringValue("8"),
+                new StringValue("9"),
+                new StringValue("10"),
+                new StringValue("11"),
+                new StringValue("12"),
+                new StringValue("13"),
+                new StringValue("14"),
+                new StringValue("15"),
+                new StringValue("16"),
+                new StringValue("17"),
+                new StringValue("18"),
+                new StringValue("19"),
+                new StringValue("20"),
+                new StringValue("21"),
+                new StringValue("22"),
+                new StringValue("23"),
+                new StringValue("24"),
+                new StringValue("25"),
+                new StringValue("26"),
+                new StringValue("27"),
+                new StringValue("28"),
+                new StringValue("29"),
+                new StringValue("30"),
+                new StringValue("31"),
+                new StringValue("32"),
+                new StringValue("33"),
+            };
+
+            unionColumn.InsertRangeFrom(1, otherUnionColumn, 0, 33, default);
+
+            Assert.Equal(4, unionColumn.Count);
+            Assert.Equal(1, unionColumn.GetValueAt(0, default).AsLong);
+            Assert.Equal("hello", unionColumn.GetValueAt(1, default).AsString.ToString());
+            Assert.Equal("world", unionColumn.GetValueAt(2, default).AsString.ToString());
+            Assert.Equal(3, unionColumn.GetValueAt(3, default).AsDecimal);
+        }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
@@ -561,11 +561,135 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             unionColumn.InsertRangeFrom(1, otherUnionColumn, 0, 33, default);
 
-            Assert.Equal(4, unionColumn.Count);
+            Assert.Equal(35, unionColumn.Count);
             Assert.Equal(1, unionColumn.GetValueAt(0, default).AsLong);
-            Assert.Equal("hello", unionColumn.GetValueAt(1, default).AsString.ToString());
-            Assert.Equal("world", unionColumn.GetValueAt(2, default).AsString.ToString());
-            Assert.Equal(3, unionColumn.GetValueAt(3, default).AsDecimal);
+            for (int i = 1; i <= 33; i++)
+            {
+                Assert.Equal(i.ToString(), unionColumn.GetValueAt(i, default).AsString.ToString());
+            }
+            Assert.Equal(3, unionColumn.GetValueAt(34, default).AsDecimal);
+        }
+
+        [Fact]
+        public void InsertRangeFromOtherUnionColumnWithAvxSubrange()
+        {
+            UnionColumn unionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new Int64Value(1),
+                new DecimalValue(3)
+            };
+
+            UnionColumn otherUnionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new StringValue("1"),
+                new StringValue("2"),
+                new StringValue("3"),
+                new StringValue("4"),
+                new StringValue("5"),
+                new StringValue("6"),
+                new StringValue("7"),
+                new StringValue("8"),
+                new StringValue("9"),
+                new StringValue("10"),
+                new StringValue("11"),
+                new StringValue("12"),
+                new StringValue("13"),
+                new StringValue("14"),
+                new StringValue("15"),
+                new StringValue("16"),
+                new StringValue("17"),
+                new StringValue("18"),
+                new StringValue("19"),
+                new StringValue("20"),
+                new StringValue("21"),
+                new StringValue("22"),
+                new StringValue("23"),
+                new StringValue("24"),
+                new StringValue("25"),
+                new StringValue("26"),
+                new StringValue("27"),
+                new StringValue("28"),
+                new StringValue("29"),
+                new StringValue("30"),
+                new StringValue("31"),
+                new StringValue("32"),
+                new StringValue("33"),
+            };
+
+            unionColumn.InsertRangeFrom(1, otherUnionColumn, 1, 31, default);
+
+            Assert.Equal(33, unionColumn.Count);
+            Assert.Equal(1, unionColumn.GetValueAt(0, default).AsLong);
+            for (int i = 2; i <= 32; i++)
+            {
+                Assert.Equal(i.ToString(), unionColumn.GetValueAt(i - 1, default).AsString.ToString());
+            }
+            Assert.Equal(3, unionColumn.GetValueAt(32, default).AsDecimal);
+        }
+
+        [Fact]
+        public void InsertRangeFromOtherUnionColumnWithAvxExistingDataInType()
+        {
+            UnionColumn unionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new Int64Value(1),
+                new DecimalValue(3),
+                new StringValue("1a"),
+                new StringValue("2a"),
+                new StringValue("3a"),
+                new StringValue("4a"),
+                new StringValue("5a"),
+                new StringValue("6a"),
+                new StringValue("7a"),
+                new StringValue("8a"),
+            };
+
+            UnionColumn otherUnionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new StringValue("1"),
+                new StringValue("2"),
+                new StringValue("3"),
+                new StringValue("4"),
+                new StringValue("5"),
+                new StringValue("6"),
+                new StringValue("7"),
+                new StringValue("8"),
+                new StringValue("9"),
+                new StringValue("10"),
+                new StringValue("11"),
+                new StringValue("12"),
+                new StringValue("13"),
+                new StringValue("14"),
+                new StringValue("15"),
+                new StringValue("16"),
+                new StringValue("17"),
+                new StringValue("18"),
+                new StringValue("19"),
+                new StringValue("20"),
+                new StringValue("21"),
+                new StringValue("22"),
+                new StringValue("23"),
+                new StringValue("24"),
+                new StringValue("25"),
+                new StringValue("26"),
+                new StringValue("27"),
+                new StringValue("28"),
+                new StringValue("29"),
+                new StringValue("30"),
+                new StringValue("31"),
+                new StringValue("32"),
+                new StringValue("33"),
+            };
+
+            unionColumn.InsertRangeFrom(1, otherUnionColumn, 1, 31, default);
+
+            Assert.Equal(33, unionColumn.Count);
+            Assert.Equal(1, unionColumn.GetValueAt(0, default).AsLong);
+            for (int i = 2; i <= 32; i++)
+            {
+                Assert.Equal(i.ToString(), unionColumn.GetValueAt(i - 1, default).AsString.ToString());
+            }
+            Assert.Equal(3, unionColumn.GetValueAt(32, default).AsDecimal);
         }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
@@ -764,5 +764,40 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Assert.Equal("7a", Assert.IsType<StringValue>(unionColumn.GetValueAt(39, default)).ToString());
             Assert.Equal("8a", Assert.IsType<StringValue>(unionColumn.GetValueAt(40, default)).ToString());
         }
+
+        [Fact]
+        public void TestInsertNullUnionColumn()
+        {
+            UnionColumn unionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new Int64Value(1),
+                new DecimalValue(3)
+            };
+
+            UnionColumn other = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                NullValue.Instance,
+                NullValue.Instance
+            };
+
+            unionColumn.InsertRangeFrom(2, other, 0, 2, default);
+
+            Assert.Equal(4, unionColumn.Count);
+            Assert.Equal(2, unionColumn.GetDataColumn(0).Count);
+        }
+
+        [Fact]
+        public void TestRemoveRangeWitNull()
+        {
+            UnionColumn column = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                NullValue.Instance,
+                NullValue.Instance
+            };
+
+            column.RemoveRange(0, 2);
+            Assert.Empty(column);
+            Assert.Equal(0, column.GetDataColumn(0).Count);
+        }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
@@ -750,11 +750,19 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             Assert.Equal(41, unionColumn.Count);
             Assert.Equal(1, unionColumn.GetValueAt(0, default).AsLong);
+            Assert.Equal(3, unionColumn.GetValueAt(1, default).AsDecimal);
+            Assert.Equal("1a", unionColumn.GetValueAt(2, default).AsString.ToString());
+            Assert.Equal("2a", unionColumn.GetValueAt(3, default).AsString.ToString());
+            Assert.Equal("3a", unionColumn.GetValueAt(4, default).AsString.ToString());
             for (int i = 2; i <= 32; i++)
             {
-                Assert.Equal(i.ToString(), unionColumn.GetValueAt(i - 1, default).AsString.ToString());
+                Assert.Equal(i.ToString(), unionColumn.GetValueAt(i + 3, default).AsString.ToString());
             }
-            Assert.Equal(3, unionColumn.GetValueAt(32, default).AsDecimal);
+            Assert.Equal("4a", Assert.IsType<StringValue>(unionColumn.GetValueAt(36, default)).ToString());
+            Assert.Equal("5a", Assert.IsType<StringValue>(unionColumn.GetValueAt(37, default)).ToString());
+            Assert.Equal("6a", Assert.IsType<StringValue>(unionColumn.GetValueAt(38, default)).ToString());
+            Assert.Equal("7a", Assert.IsType<StringValue>(unionColumn.GetValueAt(39, default)).ToString());
+            Assert.Equal("8a", Assert.IsType<StringValue>(unionColumn.GetValueAt(40, default)).ToString());
         }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
@@ -683,7 +683,72 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             unionColumn.InsertRangeFrom(1, otherUnionColumn, 1, 31, default);
 
-            Assert.Equal(33, unionColumn.Count);
+            Assert.Equal(41, unionColumn.Count);
+            Assert.Equal(1, unionColumn.GetValueAt(0, default).AsLong);
+            for (int i = 2; i <= 32; i++)
+            {
+                Assert.Equal(i.ToString(), unionColumn.GetValueAt(i - 1, default).AsString.ToString());
+            }
+            Assert.Equal(3, unionColumn.GetValueAt(32, default).AsDecimal);
+        }
+
+        [Fact]
+        public void InsertRangeFromOtherUnionColumnWithAvxExistingDataInTypeInMiddle()
+        {
+            UnionColumn unionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new Int64Value(1),
+                new DecimalValue(3),
+                new StringValue("1a"),
+                new StringValue("2a"),
+                new StringValue("3a"),
+                new StringValue("4a"),
+                new StringValue("5a"),
+                new StringValue("6a"),
+                new StringValue("7a"),
+                new StringValue("8a"),
+            };
+
+            UnionColumn otherUnionColumn = new UnionColumn(GlobalMemoryManager.Instance)
+            {
+                new StringValue("1"),
+                new StringValue("2"),
+                new StringValue("3"),
+                new StringValue("4"),
+                new StringValue("5"),
+                new StringValue("6"),
+                new StringValue("7"),
+                new StringValue("8"),
+                new StringValue("9"),
+                new StringValue("10"),
+                new StringValue("11"),
+                new StringValue("12"),
+                new StringValue("13"),
+                new StringValue("14"),
+                new StringValue("15"),
+                new StringValue("16"),
+                new StringValue("17"),
+                new StringValue("18"),
+                new StringValue("19"),
+                new StringValue("20"),
+                new StringValue("21"),
+                new StringValue("22"),
+                new StringValue("23"),
+                new StringValue("24"),
+                new StringValue("25"),
+                new StringValue("26"),
+                new StringValue("27"),
+                new StringValue("28"),
+                new StringValue("29"),
+                new StringValue("30"),
+                new StringValue("31"),
+                new StringValue("32"),
+                new StringValue("33"),
+            };
+
+            unionColumn.InsertRangeFrom(5, otherUnionColumn, 1, 31, default);
+
+            Assert.Equal(41, unionColumn.Count);
             Assert.Equal(1, unionColumn.GetValueAt(0, default).AsLong);
             for (int i = 2; i <= 32; i++)
             {

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -708,7 +708,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                     expected.Insert(index, val);
                 }
 
-                for (int i = 0; i < 1_000_000; i++)
+                for (int i = 0; i < 10_000; i++)
                 {
                     var start = r.Next(0, expected.Count);
                     var end = r.Next(start, expected.Count);
@@ -823,6 +823,296 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                 Assert.Equal(i + (i % 2), actual);
             }
             Assert.Equal(-1, list.FindNextTrueIndex(127));
+        }
+
+        [Fact]
+        public void TestInsertTrueInRangeStartEndInSameIndexStartMod0()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertTrueInRange(0, 5);
+            expected.InsertRange(0, Enumerable.Repeat(true, 5));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertTrueInRange(32, 7);
+            expected.InsertRange(32, Enumerable.Repeat(true, 7));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertTrueInRangeStartEndInSameIndexStartNotMod0()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertTrueInRange(3, 5);
+            expected.InsertRange(3, Enumerable.Repeat(true, 5));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertTrueInRange(39, 7);
+            expected.InsertRange(39, Enumerable.Repeat(true, 7));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertTrueInRangeStartEndInSameIndexBothMod0()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertTrueInRange(0, 32);
+            expected.InsertRange(0, Enumerable.Repeat(true, 32));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertTrueInRange(32, 32);
+            expected.InsertRange(32, Enumerable.Repeat(true, 32));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertTrueInRangeStartEndInDifferentIntegers()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertTrueInRange(5, 32);
+            expected.InsertRange(5, Enumerable.Repeat(true, 32));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertTrueInRange(67, 17);
+            expected.InsertRange(67, Enumerable.Repeat(true, 17));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertTrueInRangeStartEndInDifferentIntegersEndWithMod0()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertTrueInRange(5, 59);
+            expected.InsertRange(5, Enumerable.Repeat(true, 59));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertTrueInRange(67, 29);
+            expected.InsertRange(67, Enumerable.Repeat(true, 29));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertFalseInRangeStartEndInSameIndexStartMod0()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertFalseInRange(0, 5);
+            expected.InsertRange(0, Enumerable.Repeat(false, 5));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertFalseInRange(32, 7);
+            expected.InsertRange(32, Enumerable.Repeat(false, 7));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertFalseInRangeStartEndInSameIndexStartNotMod0()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertFalseInRange(3, 5);
+            expected.InsertRange(3, Enumerable.Repeat(false, 5));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertFalseInRange(39, 7);
+            expected.InsertRange(39, Enumerable.Repeat(false, 7));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertFalseInRangeStartEndInSameIndexBothMod0()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertFalseInRange(0, 32);
+            expected.InsertRange(0, Enumerable.Repeat(false, 32));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertFalseInRange(32, 32);
+            expected.InsertRange(32, Enumerable.Repeat(false, 32));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertFalseInRangeStartEndInDifferentIntegers()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertFalseInRange(5, 32);
+            expected.InsertRange(5, Enumerable.Repeat(false, 32));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertFalseInRange(67, 17);
+            expected.InsertRange(67, Enumerable.Repeat(false, 17));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+        }
+
+        [Fact]
+        public void TestInsertFalseInRangeStartEndInDifferentIntegersEndWithMod0()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+            List<bool> expected = new List<bool>();
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+                expected.Add(i % 2 == 0);
+            }
+
+            list.InsertFalseInRange(5, 59);
+            expected.InsertRange(5, Enumerable.Repeat(false, 59));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
+
+            list.InsertFalseInRange(67, 29);
+            expected.InsertRange(67, Enumerable.Repeat(false, 29));
+
+            for (int i = 0; i < expected.Count; i++)
+            {
+                Assert.Equal(expected[i], list.Get(i));
+            }
         }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BitmapListTests.cs
@@ -749,5 +749,80 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                 Assert.Equal(expectedCount, count);
             }
         }
+
+        [Fact]
+        public void TestFindNextFalseIndex()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 != 0);
+            }
+
+            // For loop that does the same thing
+            for (int i = 0; i < 127; i++)
+            {
+                var actual = list.FindNextFalseIndex(i);
+                Assert.Equal(i + i % 2, actual);
+            }
+            var last = list.FindNextFalseIndex(127);
+            Assert.Equal(-1, last);
+        }
+
+        [Fact]
+        public void TestFindNextFalseIndexStartWithTrue()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+            }
+
+            // For loop that does the same thing
+            for (int i = 0; i < 128; i++)
+            {
+                var actual = list.FindNextFalseIndex(i);
+                Assert.Equal(i + (i +1) % 2, actual);
+            }
+        }
+
+        [Fact]
+        public void TestFindNextTrueIndexStartWithFalse()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 != 0);
+            }
+
+            // For loop that does the same thing
+            for (int i = 1; i < 128; i++)
+            {
+                var actual = list.FindNextTrueIndex(i);
+                Assert.Equal(i + (i + 1) % 2, actual);
+            }
+        }
+
+        [Fact]
+        public void TestFindNextTrueIndexStartWithTrue()
+        {
+            var list = new BitmapList(GlobalMemoryManager.Instance);
+
+            for (int i = 0; i < 128; i++)
+            {
+                list.Add(i % 2 == 0);
+            }
+
+            // For loop that does the same thing
+            for (int i = 1; i < 127; i++)
+            {
+                var actual = list.FindNextTrueIndex(i);
+                Assert.Equal(i + (i % 2), actual);
+            }
+            Assert.Equal(-1, list.FindNextTrueIndex(127));
+        }
     }
 }


### PR DESCRIPTION
This implementation helps reduce time spent especially for list columns where alot of inserts where happening which caused many memcpy.
This instead allows one single memcpy to take place.