### PR TITLE
Remove metadata write when fetching a state client

### DIFF
--- a/src/FlowtideDotNet.Storage/StateManager/Internal/StateClientMetadata.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/StateClientMetadata.cs
@@ -15,5 +15,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
     internal class StateClientMetadata<T>
     {
         public T? Metadata { get; set; }
+
+        public bool CommitedOnce { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/StateClientMetadata.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/StateClientMetadata.cs
@@ -16,6 +16,10 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
     {
         public T? Metadata { get; set; }
 
+        /// <summary>
+        /// Used to track if the state has been commited at least once, if it is true, it is known that data can be fetched from persitent storage.
+        /// A temporary tree will always have this set to false.
+        /// </summary>
         public bool CommitedOnce { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
@@ -213,7 +213,7 @@ namespace FlowtideDotNet.Storage.StateManager
             m_metadata.PageCommitsAtLastCompaction = m_metadata.PageCommits;
         }
 
-        internal async ValueTask<IStateClient<TValue, TMetadata>> CreateClientAsync<TValue, TMetadata>(string client, StateClientOptions<TValue> options)
+        internal ValueTask<IStateClient<TValue, TMetadata>> CreateClientAsync<TValue, TMetadata>(string client, StateClientOptions<TValue> options)
             where TValue : ICacheObject
         {
             Debug.Assert(m_metadata != null);
@@ -224,7 +224,7 @@ namespace FlowtideDotNet.Storage.StateManager
             if (_stateClients.TryGetValue(client, out var cachedClient))
             {
                 Monitor.Exit(m_lock);
-                return (cachedClient as SyncStateClient<TValue, TMetadata>)!;
+                return ValueTask.FromResult<IStateClient<TValue, TMetadata>>((cachedClient as SyncStateClient<TValue, TMetadata>)!);
             }
             if (m_metadata.ClientMetadataLocations.TryGetValue(client, out var location))
             {
@@ -238,7 +238,7 @@ namespace FlowtideDotNet.Storage.StateManager
                     {
                         _stateClients.Add(client, stateClient);
                     }
-                    return stateClient;
+                    return ValueTask.FromResult<IStateClient<TValue, TMetadata>>(stateClient);
                 }
                 else
                 {
@@ -258,7 +258,7 @@ namespace FlowtideDotNet.Storage.StateManager
                     var session = m_persistentStorage.CreateSession();
                     var stateClient = new SyncStateClient<TValue, TMetadata>(this, client, clientMetadataPageId, clientMetadata, session, options, m_fileCacheOptions, meter, this.options.UseReadCache, this.options.DefaultBPlusTreePageSize, this.options.DefaultBPlusTreePageSizeBytes);
                     _stateClients.Add(client, stateClient);
-                    return stateClient;
+                    return ValueTask.FromResult<IStateClient<TValue, TMetadata>>(stateClient);
                 }
             }
         }

--- a/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
@@ -253,7 +253,6 @@ namespace FlowtideDotNet.Storage.StateManager
                 m_metadata.ClientMetadataLocations.Add(client, clientMetadataPageId);
                 Monitor.Exit(m_lock);
 
-                //await m_persistentStorage.Write(clientMetadataPageId, StateClientMetadataSerializer.Serialize(clientMetadata));
                 lock (m_lock)
                 {
                     var session = m_persistentStorage.CreateSession();

--- a/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
@@ -253,7 +253,7 @@ namespace FlowtideDotNet.Storage.StateManager
                 m_metadata.ClientMetadataLocations.Add(client, clientMetadataPageId);
                 Monitor.Exit(m_lock);
 
-                await m_persistentStorage.Write(clientMetadataPageId, StateClientMetadataSerializer.Serialize(clientMetadata));
+                //await m_persistentStorage.Write(clientMetadataPageId, StateClientMetadataSerializer.Serialize(clientMetadata));
                 lock (m_lock)
                 {
                     var session = m_persistentStorage.CreateSession();


### PR DESCRIPTION
This removes double writes the first time of the stream for metadata. Also follows the rule that one page key should only be handled by one session. Also removes temporary tree storing their metadata in persistent storage.