### PR TITLE
Add checks in tests that same data is not written multiple times

### DIFF
--- a/src/FlowtideDotNet.Storage/StateManager/IStorageMetadata.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/IStorageMetadata.cs
@@ -10,29 +10,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using FlowtideDotNet.Storage.FileCache;
-using FlowtideDotNet.Storage.Persistence.CacheStorage;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace FlowtideDotNet.AcceptanceTests.Internal
+namespace FlowtideDotNet.Storage.StateManager
 {
-    internal class TestStorageSession : FileCachePersistentSession
+    public interface IStorageMetadata
     {
-        private readonly TestStorage testStorage;
-
-        public TestStorageSession(FileCache fileCache, TestStorage testStorage) : base(fileCache)
-        {
-            this.testStorage = testStorage;
-        }
-
-        public override Task Write(long key, byte[] value)
-        {
-            testStorage.AddWrittenKey(key, value);
-            return base.Write(key, value);
-        }
+        bool Updated { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/StateManagerSyncClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/StateManagerSyncClient.cs
@@ -56,6 +56,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
 
         private ValueTask<IStateClient<V, TMetadata>> CreateStateClient<V, TMetadata>(string name, IStateSerializer<V> serializer)
             where V : ICacheObject
+            where TMetadata : IStorageMetadata
         {
             var combinedName = $"{m_name}_{name}";
             return stateManager.CreateClientAsync<V, TMetadata>(combinedName, new StateClientOptions<V>()

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
@@ -20,6 +20,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
 {
     internal class SyncStateClient<V, TMetadata> : StateClient, IStateClient<V, TMetadata>, ILruEvictHandler
         where V : ICacheObject
+        where TMetadata : IStorageMetadata
     {
         private bool disposedValue;
         private readonly StateManagerSync stateManager;
@@ -215,6 +216,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
                 m_fileCacheVersion.Clear();
             }
             
+            if (!metadata.CommitedOnce || (metadata.Metadata != null && metadata.Metadata.Updated)) 
             {
                 var previousCommitedOnce = metadata.CommitedOnce;
                 try
@@ -222,6 +224,11 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
                     metadata.CommitedOnce = true;
                     var bytes = StateClientMetadataSerializer.Serialize(metadata);
                     await session.Write(metadataId, bytes);
+                    if (metadata.Metadata != null)
+                    {
+                        metadata.Metadata.Updated = false;
+                    }
+                    
                 }
                 catch (Exception)
                 {

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/TemporarySyncStateClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/TemporarySyncStateClient.cs
@@ -20,6 +20,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
 {
     internal class TemporarySyncStateClient<V, TMetadata> : StateClient, IStateClient<V, TMetadata>, ILruEvictHandler
         where V : ICacheObject
+        where TMetadata : IStorageMetadata
     {
         private StateClientMetadata<TMetadata> metadata;
         private readonly SyncStateClient<V, TMetadata> baseClient;

--- a/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
@@ -215,6 +215,7 @@ namespace FlowtideDotNet.Storage.StateManager
 
         internal ValueTask<IStateClient<TValue, TMetadata>> CreateClientAsync<TValue, TMetadata>(string client, StateClientOptions<TValue> options)
             where TValue : ICacheObject
+            where TMetadata : IStorageMetadata
         {
             Debug.Assert(m_metadata != null);
             Debug.Assert(m_persistentStorage != null);

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.GenericWrite.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.GenericWrite.cs
@@ -87,7 +87,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                     // No lock required
                     newParentNode.children.InsertAt(0, leafNode.Id);
-                    m_stateClient.Metadata.Root = nextId;
+                    m_stateClient.Metadata = m_stateClient.Metadata.UpdateRoot(nextId);
 
                     var (newNode, _) = SplitLeafNode(newParentNode, 0, leafNode);
 
@@ -150,7 +150,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 var newParentNode = new InternalNode<K, V, TKeyContainer>(nextId, emptyKeys, m_options.MemoryAllocator);
                 // No lock requireds
                 newParentNode.children.InsertAt(0, internalNode.Id);
-                m_stateClient.Metadata.Root = nextId;
+                m_stateClient.Metadata = m_stateClient.Metadata.UpdateRoot(nextId);
 
                 var (newNode, _) = SplitInternalNode(newParentNode, 0, internalNode);
 
@@ -167,7 +167,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             }
             if (internalNode.children.Count == 1)
             {
-                m_stateClient.Metadata.Root = internalNode.children[0];
+                m_stateClient.Metadata = m_stateClient.Metadata.UpdateRoot(internalNode.children[0]);
                 m_stateClient.Delete(internalNode.Id);
             }
             else

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
@@ -53,13 +53,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 var emptyKeyContainer = m_options.KeySerializer.CreateEmpty();
                 var emptyValueContainer = m_options.ValueSerializer.CreateEmpty();
                 var root = new LeafNode<K, V, TKeyContainer, TValueContainer>(rootId, emptyKeyContainer, emptyValueContainer);
-                m_stateClient.Metadata = new BPlusTreeMetadata()
-                {
-                    Root = rootId,
-                    BucketLength = m_options.BucketSize.Value,
-                    Left = rootId,
-                    PageSizeBytes = m_options.PageSizeBytes.Value
-                };
+                m_stateClient.Metadata = BPlusTreeMetadata.Create(m_options.BucketSize.Value, rootId, rootId, m_options.PageSizeBytes.Value);
                 m_stateClient.AddOrUpdate(rootId, root);
             }
             return Task.CompletedTask;
@@ -204,13 +198,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             var emptyKeys = m_options.KeySerializer.CreateEmpty();
             var emptyValues = m_options.ValueSerializer.CreateEmpty();
             var root = new LeafNode<K, V, TKeyContainer, TValueContainer>(rootId, emptyKeys, emptyValues);
-            m_stateClient.Metadata = new BPlusTreeMetadata()
-            {
-                Root = rootId,
-                BucketLength = m_options.BucketSize.Value,
-                Left = rootId,
-                PageSizeBytes = m_options.PageSizeBytes.Value
-            };
+            m_stateClient.Metadata = BPlusTreeMetadata.Create(m_options.BucketSize.Value, rootId, rootId, m_options.PageSizeBytes.Value);
             m_stateClient.AddOrUpdate(rootId, root);
         }
     }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeMetadata.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeMetadata.cs
@@ -10,18 +10,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage.StateManager;
+using System.Text.Json.Serialization;
+
 namespace FlowtideDotNet.Storage.Tree.Internal
 {
-    internal class BPlusTreeMetadata
+    internal class BPlusTreeMetadata : IStorageMetadata
     {
-        public int BucketLength { get; set; }
-        public long Root { get; set; }
+        public static BPlusTreeMetadata Create(int bucketLength, long root, long left, int pageSizeBytes)
+        {
+            var newMetadata = new BPlusTreeMetadata(bucketLength, root, left, pageSizeBytes);
+            newMetadata.Updated = true;
+            return newMetadata;
+        }
+
+        /// <summary>
+        /// Constructor is used for serialization
+        /// </summary>
+        /// <param name="bucketLength"></param>
+        /// <param name="root"></param>
+        /// <param name="left"></param>
+        /// <param name="pageSizeBytes"></param>
+        [JsonConstructor]
+        public BPlusTreeMetadata(int bucketLength, long root, long left, int pageSizeBytes)
+        {
+            BucketLength = bucketLength;
+            Root = root;
+            Left = left;
+            PageSizeBytes = pageSizeBytes;
+            Updated = false;
+        }
+
+        public int BucketLength { get; }
+        public long Root { get; }
 
         /// <summary>
         /// Contains the id of the most left page.
         /// This is used to start an iterator.
         /// </summary>
-        public long Left { get; set; }
-        public int PageSizeBytes { get; set; }
+        public long Left { get; }
+        public int PageSizeBytes { get; }
+
+        [JsonIgnore]
+        public bool Updated { get; set; }
+
+        public BPlusTreeMetadata UpdateRoot(long newRoot)
+        {
+            var newMetadata = new BPlusTreeMetadata(BucketLength, newRoot, Left, PageSizeBytes);
+            newMetadata.Updated = true;
+            return newMetadata;
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/DatetimeFunctionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/DatetimeFunctionTests.cs
@@ -109,7 +109,9 @@ namespace FlowtideDotNet.AcceptanceTests
             SELECT
                 active
             FROM buffered
-            ");
+            ",
+            // Block-nested loop join can sometimes write the same data multiple times between checkpoints
+            ignoreSameDataCheck: true);
             await WaitForUpdate();
 
             var rows = GetActualRows();

--- a/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
@@ -34,7 +34,12 @@ namespace FlowtideDotNet.AcceptanceTests
         public IFunctionsRegister FunctionsRegister => flowtideTestStream.FunctionsRegister;
         public ISqlFunctionRegister SqlFunctionRegister => flowtideTestStream.SqlFunctionRegister;
 
-        protected Task StartStream(string sql, int parallelism = 1, StateSerializeOptions? stateSerializeOptions = default, int pageSize = 1024) => flowtideTestStream.StartStream(sql, parallelism, stateSerializeOptions, default, pageSize);
+        protected Task StartStream(
+            string sql, 
+            int parallelism = 1, 
+            StateSerializeOptions? stateSerializeOptions = default, 
+            int pageSize = 1024,
+            bool ignoreSameDataCheck = false) => flowtideTestStream.StartStream(sql, parallelism, stateSerializeOptions, default, pageSize, ignoreSameDataCheck);
 
         public List<FlxVector> GetActualRows() => flowtideTestStream.GetActualRowsAsVectors();
 

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -153,7 +153,8 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             int parallelism = 1, 
             StateSerializeOptions? stateSerializeOptions = default, 
             TimeSpan? timestampInterval = default,
-            int pageSize = 1024)
+            int pageSize = 1024,
+            bool ignoreSameDataCheck = false)
         {
             if (stateSerializeOptions == null)
             {
@@ -183,7 +184,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             });
 #endif
 
-            _persistentStorage = CreatePersistentStorage(testName);
+            _persistentStorage = CreatePersistentStorage(testName, ignoreSameDataCheck);
             _notificationReciever = new NotificationReciever(CheckpointComplete);
 
             flowtideBuilder
@@ -211,13 +212,13 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             await _stream.StartAsync();
         }
 
-        protected virtual IPersistentStorage CreatePersistentStorage(string testName)
+        protected virtual IPersistentStorage CreatePersistentStorage(string testName, bool ignoreSameDataCheck)
         {
             return new TestStorage(new Storage.FileCacheOptions()
             {
                 DirectoryPath = $"./data/tempFiles/{testName}/persist",
                 SegmentSize = 1024L * 1024 * 1024 * 64
-            }, true);
+            }, ignoreSameDataCheck, true);
         }
 
         private void OnDataUpdate(List<byte[]> actualData)

--- a/tests/FlowtideDotNet.Benchmarks/Stream/BenchmarkTestStream.cs
+++ b/tests/FlowtideDotNet.Benchmarks/Stream/BenchmarkTestStream.cs
@@ -54,7 +54,7 @@ namespace FlowtideDotNet.Benchmarks.Stream
             }
         }
 
-        protected override IPersistentStorage CreatePersistentStorage(string testName)
+        protected override IPersistentStorage CreatePersistentStorage(string testName, bool ignoreSameDataCheck)
         {
             return new FasterKvPersistentStorage(new FASTER.core.FasterKVSettings<long, FASTER.core.SpanByte>($"./data/tempFiles/{testName}/fasterkv", true));
         }


### PR DESCRIPTION
This check is between checkpoints and not only in a single checkpoint. This is to ensure that no uneccessary writes are being done to persistent storage.