### PR TITLE
Fix issue with watermark in multi input vertex

### DIFF
--- a/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
@@ -13,6 +13,7 @@
 using FlexBuffers;
 using FlowtideDotNet.AcceptanceTests.Entities;
 using FlowtideDotNet.AcceptanceTests.Internal;
+using FlowtideDotNet.Base;
 using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Storage;
 using FlowtideDotNet.Substrait.Sql;
@@ -33,6 +34,8 @@ namespace FlowtideDotNet.AcceptanceTests
         public IReadOnlyList<ProjectMember> ProjectMembers => flowtideTestStream.ProjectMembers;
         public IFunctionsRegister FunctionsRegister => flowtideTestStream.FunctionsRegister;
         public ISqlFunctionRegister SqlFunctionRegister => flowtideTestStream.SqlFunctionRegister;
+
+        public Watermark? LastWatermark => flowtideTestStream.LastWatermark;
 
         protected Task StartStream(
             string sql, 

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSink.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSink.cs
@@ -33,14 +33,17 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         private int crashOnCheckpointCount;
         private SortedDictionary<RowEvent, int> currentData;
         private bool watermarkRecieved = false;
+        private Action<Watermark> onWatermark;
         public MockDataSink(
             ExecutionDataflowBlockOptions executionDataflowBlockOptions, 
             Action<List<byte[]>> onDataChange,
-            int crashOnCheckpointCount) : base(executionDataflowBlockOptions)
+            int crashOnCheckpointCount,
+            Action<Watermark> onWatermark) : base(executionDataflowBlockOptions)
         {
             currentData = new SortedDictionary<RowEvent, int>(new BPlusTreeStreamEventComparer());
             this.onDataChange = onDataChange;
             this.crashOnCheckpointCount = crashOnCheckpointCount;
+            this.onWatermark = onWatermark;
         }
 
         public override string DisplayName => "Mock Data Sink";
@@ -64,6 +67,10 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         protected override Task OnWatermark(Watermark watermark)
         {
             watermarkRecieved = true;
+            if (onWatermark != null)
+            {
+                onWatermark(watermark);
+            }
             return base.OnWatermark(watermark);
         }
 

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/MockSinkFactory.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/MockSinkFactory.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base;
 using FlowtideDotNet.Base.Vertices.Egress;
 using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Core.Connectors;
@@ -26,17 +27,19 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
     internal class MockSinkFactory : RegexConnectorSinkFactory
     {
         private readonly Action<List<byte[]>> onDataUpdate;
+        private readonly Action<Watermark> onWatemrark;
         private readonly int egressCrashOnCheckpointCount;
 
-        public MockSinkFactory(string regexPattern, Action<List<byte[]>> onDataUpdate, int egressCrashOnCheckpointCount) : base(regexPattern)
+        public MockSinkFactory(string regexPattern, Action<List<byte[]>> onDataUpdate, int egressCrashOnCheckpointCount, Action<Watermark> onwatermark) : base(regexPattern)
         {
             this.onDataUpdate = onDataUpdate;
             this.egressCrashOnCheckpointCount = egressCrashOnCheckpointCount;
+            this.onWatemrark = onwatermark;
         }
 
         public override IStreamEgressVertex CreateSink(WriteRelation writeRelation, IFunctionsRegister functionsRegister, ExecutionDataflowBlockOptions dataflowBlockOptions)
         {
-            return new MockDataSink(dataflowBlockOptions, onDataUpdate, egressCrashOnCheckpointCount);
+            return new MockDataSink(dataflowBlockOptions, onDataUpdate, egressCrashOnCheckpointCount, onWatemrark);
         }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -515,10 +515,26 @@ namespace FlowtideDotNet.AcceptanceTests
                 ", pageSize: 8);
             await WaitForUpdate();
 
+            Assert.NotNull(LastWatermark);
+            Assert.Equal(1000, LastWatermark.Watermarks["projects"]);
+            Assert.Equal(-1, LastWatermark.Watermarks["users"]);
+            Assert.Equal(-1, LastWatermark.Watermarks["projectmembers"]);
+
             GenerateUsers(1000);
             await WaitForUpdate();
+
+            Assert.NotNull(LastWatermark);
+            Assert.Equal(1000, LastWatermark.Watermarks["projects"]);
+            Assert.Equal(1000, LastWatermark.Watermarks["users"]);
+            Assert.Equal(-1, LastWatermark.Watermarks["projectmembers"]);
+
             GenerateProjectMembers(1000);
             await WaitForUpdate();
+
+            Assert.NotNull(LastWatermark);
+            Assert.Equal(1000, LastWatermark.Watermarks["projects"]);
+            Assert.Equal(1000, LastWatermark.Watermarks["users"]);
+            Assert.Equal(1000, LastWatermark.Watermarks["projectmembers"]);
 
             var expected = from user in Users
                            join projectmember in ProjectMembers on user.UserKey equals projectmember.UserKey into gj

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -264,11 +264,18 @@ namespace FlowtideDotNet.AcceptanceTests
                 ON o.userkey = u.userkey");
             await WaitForUpdate();
 
+            Assert.NotNull(LastWatermark);
+            Assert.Equal(1000, LastWatermark.Watermarks["users"]);
+            Assert.Equal(1000, LastWatermark.Watermarks["orders"]);
             await Crash();
 
             GenerateData();
 
             await WaitForUpdate();
+
+            Assert.NotNull(LastWatermark);
+            Assert.Equal(2000, LastWatermark.Watermarks["users"]);
+            Assert.Equal(2000, LastWatermark.Watermarks["orders"]);
 
             AssertCurrentDataEqual(Orders.Join(Users, x => x.UserKey, x => x.UserKey, (l, r) => new { l.OrderKey, r.FirstName, r.LastName }));
         }


### PR DESCRIPTION
The change to try and wait to output watermarks caused a bug where the watermark info was not updated correctly