### PR TITLE
Add stop stream command to more gracefully stop a stream

### DIFF
--- a/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
@@ -27,6 +27,8 @@ namespace FlowtideDotNet.Base.Engine
 
         public StreamStateValue State => streamContext.currentState;
 
+        public StreamStateValue WantedState => streamContext._wantedState;
+
         public StreamStatus Status => streamContext.GetStatus();
 
         public IStreamScheduler Scheduler => streamContext._streamScheduler;

--- a/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
@@ -112,5 +112,10 @@ namespace FlowtideDotNet.Base.Engine
         {
             return streamContext.GetGraph();
         }
+
+        public Task StopAsync()
+        {
+            return streamContext.StopAsync();
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
@@ -51,7 +51,7 @@ namespace FlowtideDotNet.Base.Engine
                 await StartAsync();
                 PeriodicTimer periodicTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(10));
                 int count = 0;
-                while (await periodicTimer.WaitForNextTickAsync())
+                while (await periodicTimer.WaitForNextTickAsync() && State != StreamStateValue.NotStarted)
                 {
                     await streamScheduler.Tick();
                     count++;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletedStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletedStreamState.cs
@@ -52,6 +52,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             return Task.CompletedTask;
         }
 
+        public override Task StopAsync()
+        {
+            throw new NotSupportedException("Stream already deleted");
+        }
+
         public override Task TriggerCheckpoint(bool isScheduled = false)
         {
             return Task.CompletedTask;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletingStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletingStreamState.cs
@@ -88,6 +88,8 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 await block.DeleteAsync();
             });
 
+            _context._stateManager.Dispose();
+
             await TransitionTo(StreamStateValue.Deleted);
         }
 
@@ -109,6 +111,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         public override Task DeleteAsync()
         {
             return Task.CompletedTask;
+        }
+
+        public override Task StopAsync()
+        {
+            throw new NotSupportedException("Stream is being deleted");
         }
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/NotStartedStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/NotStartedStreamState.cs
@@ -61,7 +61,14 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         public override Task StartAsync()
         {
+            Debug.Assert(_context != null);
+            _context._wantedState = StreamStateValue.Running;
             return TransitionTo(StreamStateValue.Starting);
+        }
+
+        public override Task StopAsync()
+        {
+            throw new NotImplementedException();
         }
 
         public override Task TriggerCheckpoint(bool isScheduled = false)

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
@@ -233,7 +233,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             lock (_context._checkpointLock)
             {
                 // If we are stopping, we should not do a checkpoint
-                if (_context._wantedState == StreamStateValue.Stopping)
+                if (_context._wantedState == StreamStateValue.NotStarted)
                 {
                     return Task.CompletedTask;
                 }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
@@ -305,7 +305,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         public override Task StopAsync()
         {
             Debug.Assert(_context != null, nameof(_context));
-            _context._wantedState = StreamStateValue.Stopping;
+            _context._wantedState = StreamStateValue.NotStarted;
             return Task.CompletedTask;
         }
     }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
@@ -301,5 +301,12 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 ingress.Value.DoLockingEvent(new InitWatermarksEvent());
             }
         }
+
+        public override Task StopAsync()
+        {
+            Debug.Assert(_context != null, nameof(_context));
+            _context._wantedState = StreamStateValue.Stopping;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -231,6 +231,8 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                     return TransitionTo(current, new DeletedStreamState(), oldState);
                 case StreamStateValue.Stopping:
                     return TransitionTo(current, new StoppingStreamState(), oldState);
+                case StreamStateValue.NotStarted:
+                    return TransitionTo(current, new NotStartedStreamState(), oldState);
             }
             return Task.CompletedTask;
         }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -29,13 +29,13 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 {
     public enum StreamStateValue
     {
-        NotStarted,
-        Starting,
-        Running,
-        Failure,
-        Deleting,
-        Deleted,
-        Stopping
+        NotStarted = 0,
+        Starting = 1,
+        Running = 2,
+        Failure = 3,
+        Deleting = 4,
+        Deleted = 5,
+        Stopping = 6
     }
 
     internal class StreamContext : IStreamTriggerCaller, IAsyncDisposable
@@ -145,6 +145,14 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                         break;
                 }
                 return new Measurement<float>(val, new KeyValuePair<string, object?>("stream", streamName));
+            });
+            _contextMeter.CreateObservableGauge<int>("flowtide_state", () =>
+            {
+                return new Measurement<int>((int)currentState, new KeyValuePair<string, object?>("stream", streamName));
+            });
+            _contextMeter.CreateObservableGauge<int>("flowtide_wanted_state", () =>
+            {
+                return new Measurement<int>((int)_wantedState, new KeyValuePair<string, object?>("stream", streamName));
             });
             if (loggerFactory == null)
             {

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamStateMachineState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamStateMachineState.cs
@@ -41,6 +41,8 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         public abstract Task DeleteAsync();
 
+        public abstract Task StopAsync();
+
         protected Task TransitionTo(StreamStateValue newState)
         {
             Debug.Assert(_context != null, nameof(_context));

--- a/src/FlowtideDotNet.Base/StopStreamCheckpoint.cs
+++ b/src/FlowtideDotNet.Base/StopStreamCheckpoint.cs
@@ -1,0 +1,27 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Base
+{
+    internal class StopStreamCheckpoint : Checkpoint
+    {
+        public StopStreamCheckpoint(long checkpointTime, long newTime) : base(checkpointTime, newTime)
+        {
+        }
+    }
+}

--- a/src/FlowtideDotNet.Base/Utils/Log.cs
+++ b/src/FlowtideDotNet.Base/Utils/Log.cs
@@ -171,5 +171,29 @@ namespace FlowtideDotNet.Base.Utils
           Level = LogLevel.Error,
           Message = "Stream error, stream: `{stream}`")]
         public static partial void StreamError(this ILogger logger, Exception? e, string stream);
+
+        [LoggerMessage(
+            EventId = 26,
+            Level = LogLevel.Information,
+            Message = "Stopping stream: `{stream}`")]
+        public static partial void StoppingStream(this ILogger logger, string stream);
+
+        [LoggerMessage(
+            EventId = 27,
+            Level = LogLevel.Information,
+            Message = "Stopped stream: `{stream}`")]
+        public static partial void StoppedStream(this ILogger logger, string stream);
+
+        [LoggerMessage(
+            EventId = 28,
+            Level = LogLevel.Information,
+            Message = "Starting shutdown checkpoint for stream `{stream}`.")]
+        public static partial void StartingShutdownCheckpoint(this ILogger logger, string stream);
+
+        [LoggerMessage(
+           EventId = 29,
+           Level = LogLevel.Information,
+           Message = "Shutdown checkpoint done in stream `{stream}`.")]
+        public static partial void ShutdownCheckpointDone(this ILogger logger, string stream);
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
@@ -206,6 +206,10 @@ namespace FlowtideDotNet.Base.Vertices.Ingress
 
             if (lockingEvent is ICheckpointEvent checkpoint)
             {
+                if (checkpoint is StopStreamCheckpoint)
+                {
+                    output.Stop();
+                }
                 var savedState = await OnCheckpoint(checkpoint.CheckpointTime);
                 checkpoint.AddState(Name, savedState);
                 await output.SendLockingEvent(lockingEvent);

--- a/src/FlowtideDotNet.DependencyInjection/Internal/StreamWorkerService.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Internal/StreamWorkerService.cs
@@ -30,7 +30,6 @@ namespace FlowtideDotNet.DependencyInjection.Internal
     {
         private readonly string name;
         private readonly IServiceProvider serviceProvider;
-        private Task? _streamTask;
         private Base.Engine.DataflowStream? _stream;
 
         public StreamWorkerService(string name, IServiceProvider serviceProvider)
@@ -66,7 +65,6 @@ namespace FlowtideDotNet.DependencyInjection.Internal
         {
             _stream = serviceProvider.GetRequiredKeyedService<Base.Engine.DataflowStream>(name);
             await _stream.RunAsync();
-
         }
     }
 }

--- a/src/FlowtideDotNet.DependencyInjection/Internal/StreamWorkerService.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Internal/StreamWorkerService.cs
@@ -26,10 +26,12 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.DependencyInjection.Internal
 {
-    internal class StreamWorkerService : BackgroundService
+    internal class StreamWorkerService : BackgroundService, IHostedLifecycleService
     {
         private readonly string name;
         private readonly IServiceProvider serviceProvider;
+        private Task? _streamTask;
+        private Base.Engine.DataflowStream? _stream;
 
         public StreamWorkerService(string name, IServiceProvider serviceProvider)
         {
@@ -37,10 +39,34 @@ namespace FlowtideDotNet.DependencyInjection.Internal
             this.serviceProvider = serviceProvider;
         }
 
+        public Task StartedAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task StartingAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task StoppedAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task StoppingAsync(CancellationToken cancellationToken)
+        {
+            if (_stream != null)
+            {
+                await _stream.StopAsync();
+            }
+        }
+
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            var stream = serviceProvider.GetRequiredKeyedService<Base.Engine.DataflowStream>(name);
-            await stream.RunAsync();
+            _stream = serviceProvider.GetRequiredKeyedService<Base.Engine.DataflowStream>(name);
+            await _stream.RunAsync();
+
         }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
@@ -41,6 +41,8 @@ namespace FlowtideDotNet.AcceptanceTests
             int pageSize = 1024,
             bool ignoreSameDataCheck = false) => flowtideTestStream.StartStream(sql, parallelism, stateSerializeOptions, default, pageSize, ignoreSameDataCheck);
 
+
+        protected Task StopStream() => flowtideTestStream.StopStream();
         public List<FlxVector> GetActualRows() => flowtideTestStream.GetActualRowsAsVectors();
 
         protected void AssertCurrentDataEqual<T>(IEnumerable<T> data)

--- a/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
@@ -13,6 +13,7 @@
 using FlexBuffers;
 using FlowtideDotNet.AcceptanceTests.Entities;
 using FlowtideDotNet.AcceptanceTests.Internal;
+using FlowtideDotNet.Base.Engine.Internal.StateMachine;
 using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Storage;
 using FlowtideDotNet.Substrait.Sql;
@@ -34,6 +35,8 @@ namespace FlowtideDotNet.AcceptanceTests
         public IFunctionsRegister FunctionsRegister => flowtideTestStream.FunctionsRegister;
         public ISqlFunctionRegister SqlFunctionRegister => flowtideTestStream.SqlFunctionRegister;
 
+        public StreamStateValue State => flowtideTestStream.State;
+
         protected Task StartStream(
             string sql, 
             int parallelism = 1, 
@@ -43,6 +46,9 @@ namespace FlowtideDotNet.AcceptanceTests
 
 
         protected Task StopStream() => flowtideTestStream.StopStream();
+
+        protected Task StartStream() => flowtideTestStream.StartStream();
+
         public List<FlxVector> GetActualRows() => flowtideTestStream.GetActualRowsAsVectors();
 
         protected void AssertCurrentDataEqual<T>(IEnumerable<T> data)

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -445,5 +445,10 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         {
             return _stream!.GetDiagnosticsGraph();
         }
+
+        public Task StopStream()
+        {
+            return _stream!.StopAsync();
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -14,6 +14,7 @@ using FastMember;
 using FlexBuffers;
 using FlowtideDotNet.AcceptanceTests.Entities;
 using FlowtideDotNet.Base.Engine;
+using FlowtideDotNet.Base.Engine.Internal.StateMachine;
 using FlowtideDotNet.Base.Metrics;
 using FlowtideDotNet.Core;
 using FlowtideDotNet.Core.Compute;
@@ -69,6 +70,8 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         public SqlPlanBuilder SqlPlanBuilder => sqlPlanBuilder;
 
         public int CachePageCount { get; set; } = 1000;
+
+        public StreamStateValue State => _stream!.State;
 
         public FlowtideTestStream(string testName)
         {
@@ -449,6 +452,11 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         public Task StopStream()
         {
             return _stream!.StopAsync();
+        }
+
+        public Task StartStream()
+        {
+            return _stream!.StartAsync();
         }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/StreamStateTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/StreamStateTests.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base.Engine.Internal.StateMachine;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,6 +37,33 @@ namespace FlowtideDotNet.AcceptanceTests
             await WaitForUpdate();
 
             await StopStream();
+
+            Assert.Equal(StreamStateValue.NotStarted, State);
+        }
+
+        [Fact]
+        public async Task TestStopStreamThenStart()
+        {
+            GenerateData();
+            await StartStream(@"
+            INSERT INTO output
+            SELECT userkey FROM users");
+
+            await WaitForUpdate();
+
+            await StopStream();
+
+            Assert.Equal(StreamStateValue.NotStarted, State);
+
+            GenerateData();
+
+            await StartStream();
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(Users.Select(x => new { x.UserKey }));
+
+            Assert.Equal(StreamStateValue.Running, State);
         }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/StreamStateTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/StreamStateTests.cs
@@ -1,0 +1,41 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace FlowtideDotNet.AcceptanceTests
+{
+    public class StreamStateTests : FlowtideAcceptanceBase
+    {
+        public StreamStateTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        public async Task TestStopStream()
+        {
+            GenerateData();
+            await StartStream(@"
+            INSERT INTO output
+            SELECT * FROM users");
+
+            await WaitForUpdate();
+
+            await StopStream();
+        }
+    }
+}


### PR DESCRIPTION
This is a required addition to more easily allow migration in say kubernetes between nodes.

The stop will first allow any ongoing checkpoint to finish, then start a stopping checkpoint, it will block all output from the ingress points. When it is finished it clears all memory and moves into the not started state.