### PR TITLE
Fix bug where a temporary tree fails fetching metadata after a crash

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnComparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnComparer.cs
@@ -53,7 +53,7 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
                 key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
                 var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
 
-                if (low != 0)
+                if (low < 0)
                 {
                     return low;
                 }


### PR DESCRIPTION
The fix is to create a new metadata since the tree is temporary