### PR TITLE
Bug fix: fix so save page saves page correctly if resize is required

### DIFF
--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
@@ -54,7 +54,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             _previousValueSent = previousValueSent;
         }
 
-        public int Count => _eventBatch.Count;
+        public int Count => _weights.Count;
 
         public void Add(ColumnAggregateStateReference key)
         {

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreePageIterator.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreePageIterator.cs
@@ -90,6 +90,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             var byteSize = leaf.GetByteSize();
             if (leaf.keys.Count > 0 && checkForResize && tree.m_stateClient.Metadata!.PageSizeBytes < byteSize)
             {
+                tree.m_stateClient.AddOrUpdate(leaf.Id, leaf);
                 // Force a traversion of the tree to ensure that size is looked at for splits.
                 var traverseTask = tree.RMWNoResult(leaf.keys.Get(0), default, (input, current, found) =>
                 {

--- a/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
@@ -117,7 +117,7 @@ namespace FlowtideDotNet.AcceptanceTests
                     userkey, max(orderkey), max(orderkey)
                 FROM orders
                 GROUP BY userkey, orderkey
-                ");
+                ", ignoreSameDataCheck: true);
             await WaitForUpdate();
 
             for (int i = 0; i < 10; i++)


### PR DESCRIPTION
This is a bug that was introduced when reducing amount of page writes. save page with tree traversal did not save the page correctly.

This bug only affected the aggregate operator