### PR TITLE
Reenable the append tree and change metrics to use the append tree

### DIFF
--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricGatherer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricGatherer.cs
@@ -110,6 +110,7 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
                     _meterListener.RecordObservableInstruments();
                     await series.Lock();
                     await StoreMeasurements(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), series);
+                    await series.Prune(DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(5)).ToUnixTimeMilliseconds());
                 }
                 catch (Exception)
                 {

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricOptions.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricOptions.cs
@@ -20,5 +20,11 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
         /// Time between capturing the values to time series.
         /// </summary>
         public TimeSpan CaptureRate { get; set; }
+
+        /// <summary>
+        /// Set the max lifetime metrics should be kept, if null metrics will be kept forever.
+        /// Default is 1 day
+        /// </summary>
+        public TimeSpan? MaxLifetime { get; set; } = TimeSpan.FromDays(1);
     }
 }

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricSeries.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricSeries.cs
@@ -57,7 +57,7 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             _stateManager = new StateManagerSync<object>(new StateManagerOptions()
             {
                 MinCachePageCount = 0,
-                CachePageCount = 0,
+                CachePageCount = 1000,
             }, NullLogger.Instance, new System.Diagnostics.Metrics.Meter(string.Empty), string.Empty);
 
             await _stateManager.InitializeAsync();
@@ -97,7 +97,7 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
                     Comparer = new TimestampComparer(),
                     KeySerializer = _keySerializer!,
                     ValueSerializer = _valueSerializer!,
-                    BucketSize = 4,
+                    BucketSize = 1024,
                     UseByteBasedPageSizes = false,
                     PageSizeBytes = 32 * 1024,
                     MemoryAllocator = GlobalMemoryManager.Instance

--- a/src/FlowtideDotNet.Storage/AppendTree/IAppendTree.cs
+++ b/src/FlowtideDotNet.Storage/AppendTree/IAppendTree.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Storage.AppendTree;
+using FlowtideDotNet.Storage.Tree;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,13 +20,14 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Storage
 {
-    public interface IAppendTree<K, V>
+    public interface IAppendTree<K, V, TKeyContainer, TValueContainer>
+        where TKeyContainer : IKeyContainer<K>
     {
         ValueTask Append(in K key, in V value);
         ValueTask Commit();
         ValueTask Prune(K key);
         internal Task<string> Print();
-        IAppendTreeIterator<K, V> CreateIterator();
+        IAppendTreeIterator<K, V, TKeyContainer> CreateIterator();
         ValueTask Clear();
     }
 }

--- a/src/FlowtideDotNet.Storage/AppendTree/IAppendTreeIterator.cs
+++ b/src/FlowtideDotNet.Storage/AppendTree/IAppendTreeIterator.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage.Tree;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,8 +19,9 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Storage.AppendTree
 {
-    public interface IAppendTreeIterator<K, V> : IAsyncEnumerable<KeyValuePair<K, V>>
+    public interface IAppendTreeIterator<K, V, TKeyContainer> : IAsyncEnumerable<KeyValuePair<K, V>>, IDisposable
+        where TKeyContainer: IKeyContainer<K>
     {
-        ValueTask Seek(in K key, in IComparer<K>? searchComparer = null);
+        ValueTask Seek(in K key, in IBplusTreeComparer<K, TKeyContainer>? searchComparer = null);
     }
 }

--- a/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTree.Insertion.cs
+++ b/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTree.Insertion.cs
@@ -1,165 +1,178 @@
-﻿//// Licensed under the Apache License, Version 2.0 (the "License")
-//// you may not use this file except in compliance with the License.
-//// You may obtain a copy of the License at
-////
-////     http://www.apache.org/licenses/LICENSE-2.0
-////  
-//// Unless required by applicable law or agreed to in writing, software
-//// distributed under the License is distributed on an "AS IS" BASIS,
-//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//// See the License for the specific language governing permissions and
-//// limitations under the License.
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-//using FlowtideDotNet.Storage.Tree;
-//using FlowtideDotNet.Storage.Tree.Internal;
-//using System;
-//using System.Collections.Generic;
-//using System.Diagnostics;
-//using System.Linq;
-//using System.Reflection;
-//using System.Runtime.CompilerServices;
-//using System.Text;
-//using System.Threading.Tasks;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
 
-//namespace FlowtideDotNet.Storage.AppendTree.Internal
-//{
-//    internal partial class AppendTree<K, V>
-//    {
-//        public ValueTask Append(in K key, in V value)
-//        {
-//            if (m_rightNode == null)
-//            {
-//                var rightNodeTask = m_stateClient.GetValue(m_stateClient.Metadata!.Right, "");
-//                if (rightNodeTask.IsCompletedSuccessfully)
-//                {
-//                    m_rightNode = (rightNodeTask.Result as LeafNode<K, V>)!;
-//                }
-//                else
-//                {
-//                    return Append_AwaitGetRightNode(rightNodeTask, key, value);
-//                }
-//            }
-            
-//            return Append_AfterFetchRightNode(key, value);
-//        }
+namespace FlowtideDotNet.Storage.AppendTree.Internal
+{
+    internal partial class AppendTree<K, V, TKeyContainer, TValueContainer>
+    {
+        public ValueTask Append(in K key, in V value)
+        {
+            return Append_AfterFetchRightNode(key, value);
+        }
 
-//        private async ValueTask Append_AwaitGetRightNode(ValueTask<IBPlusTreeNode?> rightNodeTask, K key, V value)
-//        {
-//            var rightNode = await rightNodeTask;
-//            m_rightNode = (rightNode as LeafNode<K, V>)!;
-//            await Append_AfterFetchRightNode(key, value);
-//        }
+        private async ValueTask Append_AwaitGetRightNode(ValueTask<IBPlusTreeNode?> rightNodeTask, K key, V value)
+        {
+            var rightNode = await rightNodeTask;
+            m_rightNode = (rightNode as LeafNode<K, V, TKeyContainer, TValueContainer>)!;
+            await Append_AfterFetchRightNode(key, value);
+        }
 
-//        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//        private ValueTask Append_AfterFetchRightNode(in K key, in V value)
-//        {
-//            if (m_rightNode!.keys.Count > 0 && m_keyComparer.Compare(m_rightNode!.keys[m_rightNode.keys.Count -1], key) >= 0)
-//            {
-//                throw new InvalidOperationException("Key must be greater than the last key in the right node.");
-//            } 
-//            if (m_rightNode!.keys.Count < m_bucketSize)
-//            {
-//                // Locking is done insert of insert at.
-//                m_rightNode.InsertAt(key, value, m_rightNode.keys.Count);
-//                return ValueTask.CompletedTask;
-//            }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ValueTask Append_AfterFetchRightNode(in K key, in V value)
+        {
+            if (m_rightNode!.keys.Count > 0 && m_keyComparer.CompareTo(m_rightNode!.keys.Get(m_rightNode.keys.Count - 1), key) >= 0)
+            {
+                throw new InvalidOperationException("Key must be greater than the last key in the right node.");
+            }
+            if (m_rightNode!.keys.Count < m_bucketSize)
+            {
+                // Locking is done insert of insert at.
+                m_rightNode.InsertAt(key, value, m_rightNode.keys.Count);
+                return ValueTask.CompletedTask;
+            }
 
-//            // Append from the top
-//            return AppendFullLeaf(key, value);
-//        }
+            // Append from the top
+            return AppendFullLeaf(key, value);
+        }
 
-//        private ValueTask AppendFullLeaf(in K key, in V value)
-//        {
-//            Debug.Assert(m_rightNode != null);
-//            var newRightNode = new LeafNode<K, V>(m_stateClient.GetNewPageId());
-//            newRightNode.InsertAt(key, value, 0);
-//            m_rightNode.EnterWriteLock();
-//            m_rightNode.next = newRightNode.Id;
-//            m_rightNode.ExitWriteLock();
-//            m_stateClient.AddOrUpdate(m_rightNode.Id, m_rightNode);
+        private async ValueTask AppendFullLeaf(K key, V value)
+        {
+            Debug.Assert(m_rightNode != null);
+            var emptyKeys = m_options.KeySerializer.CreateEmpty();
+            var emptyValues = m_options.ValueSerializer.CreateEmpty();
+            var newRightNode = new LeafNode<K, V, TKeyContainer, TValueContainer>(m_stateClient.GetNewPageId(), emptyKeys, emptyValues);
+            newRightNode.InsertAt(key, value, 0);
+            m_rightNode.EnterWriteLock();
+            m_rightNode.next = newRightNode.Id;
+            m_rightNode.ExitWriteLock();
+            m_stateClient.AddOrUpdate(m_rightNode.Id, m_rightNode);
 
-//            var parentKey = m_rightNode.keys[m_rightNode.keys.Count - 1];
+            var parentKey = m_rightNode.keys.Get(m_rightNode.keys.Count - 1);
 
-//            var node = (BaseNode<K>)m_rightNode;
-//            var newNode = (BaseNode<K>)newRightNode;
+            var node = (BaseNode<K, TKeyContainer>)m_rightNode;
+            var newNode = (BaseNode<K, TKeyContainer>)newRightNode;
 
-//            m_rightNode = newRightNode;
-//            m_stateClient.Metadata!.Right = newRightNode.Id;
+            // Set right node returns the previous node
+            SetRightNode(newRightNode);
 
-//            bool updatedParent = true;
-//            // Iterate over the internal nodes but not the root node since that requires special handling.
-//            for (int i = m_rightInternalNodes.Count -1; i > 0; i--)
-//            {
-//                var internalNode = m_rightInternalNodes[i];
-//                if (internalNode.keys.Count < m_bucketSize)
-//                {
-//                    internalNode.EnterWriteLock();
-//                    internalNode.keys.Add(parentKey);
-//                    internalNode.children.Add(newNode.Id);
-//                    internalNode.ExitWriteLock();
-//                    updatedParent = false;
-//                    break;
-//                }
-//                else
-//                {
-//                    // Create an internal node that has no keys and only one child
-//                    var newInternalNode = new InternalNode<K, V>(m_stateClient.GetNewPageId());
-//                    newInternalNode.children.Add(newNode.Id);
+            bool updatedParent = true;
+            // Iterate over the internal nodes but not the root node since that requires special handling.
+            for (int i = m_rightInternalNodes.Count - 1; i > 0; i--)
+            {
+                var internalNodeId = m_rightInternalNodes[i];
+                var internalNode = (await GetChildNode(internalNodeId) as InternalNode<K, V, TKeyContainer>)!;
+                if (internalNode.keys.Count < m_bucketSize)
+                {
+                    internalNode.EnterWriteLock();
+                    internalNode.keys.Add(parentKey);
+                    internalNode.children.Add(newNode.Id);
+                    internalNode.ExitWriteLock();
+                    var isFull = m_stateClient.AddOrUpdate(internalNode.Id, internalNode);
+                    if (isFull)
+                    {
+                        await m_stateClient.WaitForNotFullAsync();
+                    }
+                    internalNode.Return();
+                    updatedParent = false;
+                    break;
+                }
+                else
+                {
+                    // Create an internal node that has no keys and only one child
+                    var newInternalNode = new InternalNode<K, V, TKeyContainer>(m_stateClient.GetNewPageId(), m_options.KeySerializer.CreateEmpty(), m_options.MemoryAllocator);
+                    newInternalNode.children.Add(newNode.Id);
 
-//                    // Replace the most right node at this level
-//                    m_rightInternalNodes[i] = newInternalNode;
-//                    m_stateClient.AddOrUpdate(internalNode.Id, internalNode);
-//                    m_stateClient.AddOrUpdate(newInternalNode.Id, newInternalNode);
-//                    node = internalNode;
-//                    newNode = newInternalNode;
-//                    updatedParent = true;
-//                }
-//            }
+                    // Replace the most right node at this level
+                    m_rightInternalNodes[i] = newInternalNode.Id;
+                    m_stateClient.AddOrUpdate(internalNode.Id, internalNode);
+                    m_stateClient.AddOrUpdate(newInternalNode.Id, newInternalNode);
+                    if (node.Id != m_rightNode.Id)
+                    {
+                        // If the node is not the most right node, return it
+                        node.Return();
+                    }
+                    node = internalNode;
+                    newNode = newInternalNode;
+                    updatedParent = true;
+                }
+            }
 
-//            if (m_rightInternalNodes.Count > 0 && updatedParent)
-//            {
-//                // Handle the root node
-//                var rootNode = m_rightInternalNodes[0];
-//                if (rootNode.keys.Count < m_bucketSize)
-//                {
-//                    rootNode.EnterWriteLock();
-//                    rootNode.keys.Add(parentKey);
-//                    rootNode.children.Add(newNode.Id);
-//                    rootNode.ExitWriteLock();
-//                }
-//                else
-//                {
-//                    // Create a new root node
-//                    var newRoot = new InternalNode<K, V>(m_stateClient.GetNewPageId());
-//                    var intermediateNode = new InternalNode<K, V>(m_stateClient.GetNewPageId());
-//                    intermediateNode.children.Add(newNode.Id);
-//                    m_rightInternalNodes[0] = intermediateNode;
-                    
-//                    newRoot.keys.Add(parentKey);
-//                    newRoot.children.Add(rootNode.Id);
-//                    newRoot.children.Add(intermediateNode.Id);
+            if (node.Id != m_rightNode.Id)
+            {
+                node.Return();
+            }
 
-//                    m_rightInternalNodes.Insert(0, newRoot);
-                    
-//                    m_stateClient.Metadata!.Root = newRoot.Id;
-//                    m_stateClient.AddOrUpdate(rootNode.Id, rootNode);
-//                    m_stateClient.AddOrUpdate(newRoot.Id, newRoot);
-//                    m_stateClient.AddOrUpdate(intermediateNode.Id, intermediateNode);
-//                }
-//            }
-//            else if (m_rightInternalNodes.Count == 0)
-//            {
-//                // Create new root node
-//                var newRootNode = new InternalNode<K, V>(m_stateClient.GetNewPageId());
-//                newRootNode.keys.Add(parentKey);
-//                newRootNode.children.Add(node.Id);
-//                newRootNode.children.Add(newNode.Id);
+            if (m_rightInternalNodes.Count > 0 && updatedParent)
+            {
+                // Handle the root node
+                var rootNodeId = m_rightInternalNodes[0];
+                var rootNode = (await GetChildNode(rootNodeId) as InternalNode<K, V, TKeyContainer>)!;
+                if (rootNode.keys.Count < m_bucketSize)
+                {
+                    rootNode.EnterWriteLock();
+                    rootNode.keys.Add(parentKey);
+                    rootNode.children.Add(newNode.Id);
+                    rootNode.ExitWriteLock();
+                    var isFull = m_stateClient.AddOrUpdate(rootNode.Id, rootNode);
+                    if (isFull)
+                    {
+                        await m_stateClient.WaitForNotFullAsync();
+                    }
+                    rootNode.Return();
+                }
+                else
+                {
+                    // Create a new root node
+                    var newRoot = new InternalNode<K, V, TKeyContainer>(m_stateClient.GetNewPageId(), m_options.KeySerializer.CreateEmpty(), m_options.MemoryAllocator);
+                    var intermediateNode = new InternalNode<K, V, TKeyContainer>(m_stateClient.GetNewPageId(), m_options.KeySerializer.CreateEmpty(), m_options.MemoryAllocator);
+                    intermediateNode.children.Add(newNode.Id);
+                    m_rightInternalNodes[0] = intermediateNode.Id;
 
-//                m_stateClient.Metadata!.Root = newRootNode.Id;
-//                m_stateClient.AddOrUpdate(newRootNode.Id, newRootNode);
-//                m_rightInternalNodes.Add(newRootNode);
-//            }
-//            return ValueTask.CompletedTask;
-//        }
-//    }
-//}
+                    newRoot.keys.Add(parentKey);
+                    newRoot.children.Add(rootNode.Id);
+                    newRoot.children.Add(intermediateNode.Id);
+
+                    m_rightInternalNodes.Insert(0, newRoot.Id);
+
+                    m_stateClient.Metadata!.Root = newRoot.Id;
+                    m_stateClient.AddOrUpdate(rootNode.Id, rootNode);
+                    m_stateClient.AddOrUpdate(newRoot.Id, newRoot);
+                    m_stateClient.AddOrUpdate(intermediateNode.Id, intermediateNode);
+                    rootNode.Return();
+                }
+            }
+            else if (m_rightInternalNodes.Count == 0)
+            {
+                // Create new root node
+                var newRootNode = new InternalNode<K, V, TKeyContainer>(m_stateClient.GetNewPageId(), m_options.KeySerializer.CreateEmpty(), m_options.MemoryAllocator);
+                newRootNode.keys.Add(parentKey);
+                newRootNode.children.Add(node.Id);
+                newRootNode.children.Add(newNode.Id);
+
+                m_stateClient.Metadata!.Root = newRootNode.Id;
+                m_stateClient.AddOrUpdate(newRootNode.Id, newRootNode);
+                m_rightInternalNodes.Add(newRootNode.Id);
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTree.Pruning.cs
+++ b/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTree.Pruning.cs
@@ -1,222 +1,229 @@
-﻿//// Licensed under the Apache License, Version 2.0 (the "License")
-//// you may not use this file except in compliance with the License.
-//// You may obtain a copy of the License at
-////
-////     http://www.apache.org/licenses/LICENSE-2.0
-////  
-//// Unless required by applicable law or agreed to in writing, software
-//// distributed under the License is distributed on an "AS IS" BASIS,
-//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//// See the License for the specific language governing permissions and
-//// limitations under the License.
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-//using FlowtideDotNet.Storage.Tree.Internal;
-//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
+using FlowtideDotNet.Storage.Tree.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-//namespace FlowtideDotNet.Storage.AppendTree.Internal
-//{
-//    internal partial class AppendTree<K, V>
-//    {
-//        /// <summary>
-//        /// Prunes the tree until this key.
-//        /// </summary>
-//        /// <param name="key"></param>
-//        /// <returns></returns>
-//        public async ValueTask Prune(K key)
-//        {
-//            var rootNode = await GetChildNode(m_stateClient.Metadata!.Root);
+namespace FlowtideDotNet.Storage.AppendTree.Internal
+{
+    internal partial class AppendTree<K, V, TKeyContainer, TValueContainer>
+    {
+        /// <summary>
+        /// Prunes the tree until this key.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public async ValueTask Prune(K key)
+        {
+            var rootNode = await GetChildNode(m_stateClient.Metadata!.Root);
 
-//            await Prune_AfterGetRoot(rootNode, key);
-//        }
+            await Prune_AfterGetRoot(rootNode, key);
+        }
 
-//        /// <summary>
-//        /// Prunes the tree of data that is before the key.
-//        /// It only prunes if an entire leaf node can be removed. This is done because it then does not need to load the data into RAM
-//        /// to iterate over the leaf node which could contain alot of data.
-//        /// </summary>
-//        /// <param name="rootNode"></param>
-//        /// <param name="key"></param>
-//        /// <returns></returns>
-//        private async ValueTask Prune_AfterGetRoot(IBPlusTreeNode? rootNode, K key)
-//        {
-//            // We only prune if entire l
-//            if (rootNode is LeafNode<K, V> leafNode)
-//            {
-//                leafNode.EnterWriteLock();
-//                var index = leafNode.keys.BinarySearch(key, m_keyComparer);
-//                if (index < 0)
-//                {
-//                    index = ~index;
-//                }
-//                leafNode.keys.RemoveRange(0, index);
-//                leafNode.values.RemoveRange(0, index);
-//                leafNode.ExitWriteLock();
-//            }
-//            else if (rootNode is InternalNode<K, V> internalNode)
-//            {
-//                int i = await TryPruneInternalNode(internalNode, key, 0, false);
-//                if (i > 0)
-//                {
-//                    internalNode.EnterWriteLock();
-//                    internalNode.keys.RemoveRange(0, i);
-//                    internalNode.children.RemoveRange(0, i);
-//                    internalNode.ExitWriteLock();
-//                }
-//                if (internalNode.children.Count == 0)
-//                {
-//                    var newRoot = new LeafNode<K, V>(m_stateClient.GetNewPageId());
-//                    m_stateClient.Metadata!.Root = newRoot.Id;
-//                    m_stateClient.Delete(internalNode.Id);
-//                    m_stateClient.AddOrUpdate(newRoot.Id, newRoot);
-//                }
-//                else if (internalNode.children.Count == 1)
-//                {
-//                    m_stateClient.Metadata!.Root = internalNode.children[0];
-//                    m_stateClient.Delete(internalNode.Id);
-//                    m_rightInternalNodes.RemoveAt(0);
-//                    var newRootId = internalNode.children[0];
-//                    while (true)
-//                    {
-//                        // Loop to clean up any single child internal nodes
-//                        var newRoot = await GetChildNode(newRootId);
-//                        if (newRoot is InternalNode<K, V> newRootInternal &&
-//                            newRootInternal.children.Count == 1)
-//                        {
-//                            newRootId = newRootInternal.children[0];
-//                            m_stateClient.Metadata!.Root = newRootId;
-//                            m_stateClient.Delete(newRootInternal.Id);
-//                            m_rightInternalNodes.RemoveAt(0);
-//                        }
-//                        else
-//                        {
-//                            break;
-//                        }
-//                    }
-//                }
-//                else
-//                {
-//                    m_stateClient.AddOrUpdate(internalNode.Id, internalNode);
-//                }
-//            }
-//        }
+        /// <summary>
+        /// Prunes the tree of data that is before the key.
+        /// It only prunes if an entire leaf node can be removed. This is done because it then does not need to load the data into RAM
+        /// to iterate over the leaf node which could contain alot of data.
+        /// </summary>
+        /// <param name="rootNode"></param>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        private async ValueTask Prune_AfterGetRoot(IBPlusTreeNode? rootNode, K key)
+        {
+            // We only prune if entire l
+            if (rootNode is LeafNode<K, V, TKeyContainer, TValueContainer> leafNode)
+            {
+                leafNode.EnterWriteLock();
+                var index = m_keyComparer.FindIndex(key, leafNode.keys);
+                if (index < 0)
+                {
+                    index = ~index;
+                }
+                leafNode.keys.RemoveRange(0, index);
+                leafNode.values.RemoveRange(0, index);
+                leafNode.ExitWriteLock();
+            }
+            else if (rootNode is InternalNode<K, V, TKeyContainer> internalNode)
+            {
+                int i = await TryPruneInternalNode(internalNode, key, 0, false);
+                if (i > 0)
+                {
+                    internalNode.EnterWriteLock();
+                    internalNode.keys.RemoveRange(0, i);
+                    internalNode.children.RemoveRange(0, i);
+                    internalNode.ExitWriteLock();
+                }
+                if (internalNode.children.Count == 0)
+                {
+                    var newRoot = new LeafNode<K, V, TKeyContainer, TValueContainer>(m_stateClient.GetNewPageId(), m_options.KeySerializer.CreateEmpty(), m_options.ValueSerializer.CreateEmpty());
+                    m_stateClient.Metadata!.Root = newRoot.Id;
+                    m_stateClient.Delete(internalNode.Id);
+                    m_stateClient.AddOrUpdate(newRoot.Id, newRoot);
+                }
+                else if (internalNode.children.Count == 1)
+                {
+                    m_stateClient.Metadata!.Root = internalNode.children[0];
+                    m_stateClient.Delete(internalNode.Id);
+                    m_rightInternalNodes.RemoveAt(0);
+                    var newRootId = internalNode.children[0];
+                    while (true)
+                    {
+                        // Loop to clean up any single child internal nodes
+                        var newRoot = await GetChildNode(newRootId);
+                        if (newRoot is InternalNode<K, V, TKeyContainer> newRootInternal &&
+                            newRootInternal.children.Count == 1)
+                        {
+                            newRootId = newRootInternal.children[0];
+                            m_stateClient.Metadata!.Root = newRootId;
+                            m_stateClient.Delete(newRootInternal.Id);
+                            m_rightInternalNodes.RemoveAt(0);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    m_stateClient.AddOrUpdate(internalNode.Id, internalNode);
+                }
+            }
+            if (rootNode != null)
+            {
+                ReturnNode(rootNode);
+            }
+        }
 
-//        private async Task<int> TryPruneInternalNode(InternalNode<K, V> internalNode, K key, int depth, bool pruneAll)
-//        {
-//            // Check if we are at the depth that all children are leaf nodes
-//            if (depth == m_rightInternalNodes.Count - 1)
-//            {
-//                int i = 0;
-//                if (pruneAll)
-//                {
-//                    for (; i < internalNode.children.Count; i++)
-//                    {
-//                        m_stateClient.Delete(internalNode.children[i]);
-//                    }
-//                    return i;
-//                }
-//                else
-//                {
-//                    for (; i < internalNode.keys.Count; i++)
-//                    {
-//                        if (m_keyComparer.Compare(internalNode.keys[i], key) <= 0)
-//                        {
-//                            m_stateClient.Delete(internalNode.children[i]);
-//                        }
-//                        else
-//                        {
-//                            break;
-//                        }
-//                    }
-//                    return i;
-//                }
-//            }
-//            else
-//            {
-//                int i = 0;
-//                for (; i < internalNode.children.Count; i++)
-//                {
-//                    var childNode = await GetChildNode(internalNode.children[i]);
-//                    if (pruneAll)
-//                    {
-//                        await Prune_internalNode(childNode, key, depth + 1, pruneAll);
-//                        continue;
-//                    }
-//                    // Check if all leafs can be pruned in this tree
-//                    if (i < internalNode.keys.Count &&
-//                        m_keyComparer.Compare(internalNode.keys[i], key) <= 0)
-//                    {
-//                        await Prune_internalNode(childNode, key, depth + 1, true);
-//                    }
-//                    else
-//                    {
-//                        if (!await Prune_internalNode(childNode, key, depth + 1, false))
-//                        {
-//                            break;
-//                        }
-//                    }
-//                }
-//                return i;
-//            }
-//        }
+        private async Task<int> TryPruneInternalNode(InternalNode<K, V, TKeyContainer> internalNode, K key, int depth, bool pruneAll)
+        {
+            // Check if we are at the depth that all children are leaf nodes
+            if (depth == m_rightInternalNodes.Count - 1)
+            {
+                int i = 0;
+                if (pruneAll)
+                {
+                    for (; i < internalNode.children.Count; i++)
+                    {
+                        m_stateClient.Delete(internalNode.children[i]);
+                    }
+                    return i;
+                }
+                else
+                {
+                    for (; i < internalNode.keys.Count; i++)
+                    {
+                        if (m_keyComparer.CompareTo(internalNode.keys.Get(i), key) <= 0)
+                        {
+                            m_stateClient.Delete(internalNode.children[i]);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    return i;
+                }
+            }
+            else
+            {
+                int i = 0;
+                for (; i < internalNode.children.Count; i++)
+                {
+                    var childNode = await GetChildNode(internalNode.children[i]);
+                    if (pruneAll)
+                    {
+                        await Prune_internalNode(childNode, key, depth + 1, pruneAll);
+                        ReturnNode(childNode);
+                        continue;
+                    }
+                    // Check if all leafs can be pruned in this tree
+                    if (i < internalNode.keys.Count &&
+                        m_keyComparer.CompareTo(internalNode.keys.Get(i), key) <= 0)
+                    {
+                        await Prune_internalNode(childNode, key, depth + 1, true);
+                    }
+                    else
+                    {
+                        if (!await Prune_internalNode(childNode, key, depth + 1, false))
+                        {
+                            ReturnNode(childNode);
+                            break;
+                        }
+                    }
+                    ReturnNode(childNode);
+                }
+                return i;
+            }
+        }
 
-//        /// <summary>
-//        /// Returns true if the node is pruned completely
-//        /// </summary>
-//        /// <param name="node"></param>
-//        /// <param name="key"></param>
-//        /// <returns></returns>
-//        private async ValueTask<bool> Prune_internalNode(IBPlusTreeNode? node, K key, int depth, bool pruneAll)
-//        {
-//            if (node is LeafNode<K, V> leafNode)
-//            {
-//                // This code should not be reached, but it is here for completeness, if one wants to prune inside of a leaf node
-//                leafNode.EnterWriteLock();
-//                var index = leafNode.keys.BinarySearch(key, m_keyComparer);
-//                if (index < 0)
-//                {
-//                    index = ~index;
-//                }
-//                leafNode.keys.RemoveRange(0, index);
-//                leafNode.values.RemoveRange(0, index);
-//                leafNode.ExitWriteLock();
+        /// <summary>
+        /// Returns true if the node is pruned completely
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        private async ValueTask<bool> Prune_internalNode(IBPlusTreeNode? node, K key, int depth, bool pruneAll)
+        {
+            if (node is LeafNode<K, V, TKeyContainer, TValueContainer> leafNode)
+            {
+                // This code should not be reached, but it is here for completeness, if one wants to prune inside of a leaf node
+                leafNode.EnterWriteLock();
+                var index = m_keyComparer.FindIndex(key, leafNode.keys);
+                if (index < 0)
+                {
+                    index = ~index;
+                }
+                leafNode.keys.RemoveRange(0, index);
+                leafNode.values.RemoveRange(0, index);
+                leafNode.ExitWriteLock();
 
-//                if (leafNode.keys.Count == 0)
-//                {
-//                    m_stateClient.Delete(leafNode.Id);
-//                    return true;
-//                }
-//                else
-//                {
-//                    m_stateClient.AddOrUpdate(leafNode.Id, leafNode);
-//                }
-//                return false;
-//            }
-//            else if (node is InternalNode<K, V> internalNode)
-//            {
-//                int i = await TryPruneInternalNode(internalNode, key, depth, pruneAll);
-//                if (i > 0)
-//                {
-//                    internalNode.EnterWriteLock();
-//                    internalNode.keys.RemoveRange(0, Math.Min(i, internalNode.keys.Count));
-//                    internalNode.children.RemoveRange(0, i);
-//                    internalNode.ExitWriteLock();
-//                }
-//                if (internalNode.children.Count == 0)
-//                {
-//                    m_stateClient.Delete(internalNode.Id);
-//                    return true;
-//                }
-//                else
-//                {
-//                    m_stateClient.AddOrUpdate(internalNode.Id, internalNode);
-//                }
-//                return false;
-//            }
-//            throw new NotImplementedException();
-//        }
-//    }
-//}
+                if (leafNode.keys.Count == 0)
+                {
+                    m_stateClient.Delete(leafNode.Id);
+                    return true;
+                }
+                else
+                {
+                    m_stateClient.AddOrUpdate(leafNode.Id, leafNode);
+                }
+                return false;
+            }
+            else if (node is InternalNode<K, V, TKeyContainer> internalNode)
+            {
+                int i = await TryPruneInternalNode(internalNode, key, depth, pruneAll);
+                if (i > 0)
+                {
+                    internalNode.EnterWriteLock();
+                    internalNode.keys.RemoveRange(0, Math.Min(i, internalNode.keys.Count));
+                    internalNode.children.RemoveRange(0, i);
+                    internalNode.ExitWriteLock();
+                }
+                if (internalNode.children.Count == 0)
+                {
+                    m_stateClient.Delete(internalNode.Id);
+                    return true;
+                }
+                else
+                {
+                    m_stateClient.AddOrUpdate(internalNode.Id, internalNode);
+                }
+                return false;
+            }
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTree.Searching.cs
+++ b/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTree.Searching.cs
@@ -1,91 +1,102 @@
-﻿//// Licensed under the Apache License, Version 2.0 (the "License")
-//// you may not use this file except in compliance with the License.
-//// You may obtain a copy of the License at
-////
-////     http://www.apache.org/licenses/LICENSE-2.0
-////  
-//// Unless required by applicable law or agreed to in writing, software
-//// distributed under the License is distributed on an "AS IS" BASIS,
-//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//// See the License for the specific language governing permissions and
-//// limitations under the License.
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-//using FlowtideDotNet.Storage.Tree.Internal;
-//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Runtime.CompilerServices;
-//using System.Text;
-//using System.Threading.Tasks;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
 
-//namespace FlowtideDotNet.Storage.AppendTree.Internal
-//{
-//    /// <summary>
-//    /// Contains the logic for searching the AppendTree.
-//    /// </summary>
-//    /// <typeparam name="K"></typeparam>
-//    /// <typeparam name="V"></typeparam>
-//    internal partial class AppendTree<K, V>
-//    {
+namespace FlowtideDotNet.Storage.AppendTree.Internal
+{
+    /// <summary>
+    /// Contains the logic for searching the AppendTree.
+    /// </summary>
+    /// <typeparam name="K"></typeparam>
+    /// <typeparam name="V"></typeparam>
+    internal partial class AppendTree<K, V, TKeyContainer, TValueContainer>
+    {
 
-//        internal ValueTask<LeafNode<K, V>> FindLeafNode(in K key, in IComparer<K> searchComparer)
-//        {
-//            var rootTask = m_stateClient.GetValue(m_stateClient.Metadata!.Root, "SearchRoot");
+        internal ValueTask<LeafNode<K, V, TKeyContainer, TValueContainer>> FindLeafNode(in K key, in IBplusTreeComparer<K, TKeyContainer> searchComparer)
+        {
+            Debug.Assert(m_rightNode != null);
+            // Check if the most right node contains the data, if so no need to search the tree
+            if (searchComparer.CompareTo(m_rightNode.keys.Get(0), key) <= 0)
+            {
+                return new ValueTask<LeafNode<K, V, TKeyContainer, TValueContainer>>(m_rightNode);
+            }
+            // Might be better here to start a search with the most right internal nodes, since they are more likely to be in the cache
 
-//            if (!rootTask.IsCompletedSuccessfully)
-//            {
-//                return FindLeafNode_Slow(key, searchComparer, rootTask);
-//            }
+            var rootTask = GetChildNode(m_stateClient.Metadata!.Root);
 
-//            return SearchLeafNodeForRead_AfterTask(key, rootTask.Result!, searchComparer);
-//        }
+            if (!rootTask.IsCompletedSuccessfully)
+            {
+                return FindLeafNode_Slow(key, searchComparer, rootTask);
+            }
 
-//        private async ValueTask<LeafNode<K, V>> FindLeafNode_Slow(K key, IComparer<K> searchComparer, ValueTask<IBPlusTreeNode?> task)
-//        {
-//            var root = await task;
-//            return await SearchLeafNodeForRead_AfterTask(key, root!, searchComparer);
-//        }
+            return SearchLeafNodeForRead_AfterTask(key, rootTask.Result!, searchComparer);
+        }
 
-//        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//        private ValueTask<LeafNode<K, V>> SearchLeafNodeForRead_AfterTask(in K key, in IBPlusTreeNode node, in IComparer<K> searchComparer)
-//        {
-//            if (node is LeafNode<K, V> leaf)
-//            {
-//                return new ValueTask<LeafNode<K, V>>(leaf);
-//            }
-//            else if (node is InternalNode<K, V> parentNode)
-//            {
-//                return SearchLeafNodeForReadInternal(key, parentNode, searchComparer);
-//            }
-//            throw new NotImplementedException();
-//        }
+        private async ValueTask<LeafNode<K, V, TKeyContainer, TValueContainer>> FindLeafNode_Slow(K key, IBplusTreeComparer<K, TKeyContainer> searchComparer, ValueTask<IBPlusTreeNode?> task)
+        {
+            var root = await task;
+            return await SearchLeafNodeForRead_AfterTask(key, root!, searchComparer);
+        }
 
-//        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//        private ValueTask<LeafNode<K, V>> SearchLeafNodeForReadInternal(in K key, in InternalNode<K, V> node, in IComparer<K> searchComparer)
-//        {
-//            // Must enter lock before accessing keys and children.
-//            node.EnterWriteLock();
-//            var index = node.keys.BinarySearch(key, searchComparer);
-//            if (index < 0)
-//            {
-//                index = ~index;
-//            }
-//            var child = node.children[index];
-//            node.ExitWriteLock();
-//            var childNodeTask = m_stateClient.GetValue(child, "SearchLeafNodeForReadInternal");
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ValueTask<LeafNode<K, V, TKeyContainer, TValueContainer>> SearchLeafNodeForRead_AfterTask(in K key, in IBPlusTreeNode node, in IBplusTreeComparer<K, TKeyContainer> searchComparer)
+        {
+            if (node is LeafNode<K, V, TKeyContainer, TValueContainer> leaf)
+            {
+                return new ValueTask<LeafNode<K, V, TKeyContainer, TValueContainer>>(leaf);
+            }
+            else if (node is InternalNode<K, V, TKeyContainer> parentNode)
+            {
+                return SearchLeafNodeForReadInternal(key, parentNode, searchComparer);
+            }
+            throw new NotImplementedException();
+        }
 
-//            if (!childNodeTask.IsCompletedSuccessfully)
-//            {
-//                return SearchLeafNodeForReadInternal_Slow(key, searchComparer, childNodeTask);
-//            }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ValueTask<LeafNode<K, V, TKeyContainer, TValueContainer>> SearchLeafNodeForReadInternal(in K key, in InternalNode<K, V, TKeyContainer> node, in IBplusTreeComparer<K, TKeyContainer> searchComparer)
+        {
+            // Must enter lock before accessing keys and children.
+            node.EnterWriteLock();
+            var index = searchComparer.FindIndex(key, node.keys);
+            if (index < 0)
+            {
+                index = ~index;
+            }
+            var child = node.children[index];
+            node.ExitWriteLock();
+            node.Return();
+            var childNodeTask = GetChildNode(child);
 
-//            return SearchLeafNodeForRead_AfterTask(key, childNodeTask.Result!, searchComparer);
-//        }
+            if (!childNodeTask.IsCompletedSuccessfully)
+            {
+                return SearchLeafNodeForReadInternal_Slow(key, searchComparer, childNodeTask);
+            }
 
-//        private async ValueTask<LeafNode<K, V>> SearchLeafNodeForReadInternal_Slow(K key, IComparer<K> searchComparer, ValueTask<IBPlusTreeNode?> task)
-//        {
-//            var childNode = await task;
-//            return await SearchLeafNodeForRead_AfterTask(key, childNode!, searchComparer);
-//        }
-//    }
-//}
+            return SearchLeafNodeForRead_AfterTask(key, childNodeTask.Result!, searchComparer);
+        }
+
+        private async ValueTask<LeafNode<K, V, TKeyContainer, TValueContainer>> SearchLeafNodeForReadInternal_Slow(K key, IBplusTreeComparer<K, TKeyContainer> searchComparer, ValueTask<IBPlusTreeNode?> task)
+        {
+            var childNode = await task;
+            return await SearchLeafNodeForRead_AfterTask(key, childNode!, searchComparer);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTree.cs
+++ b/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTree.cs
@@ -10,138 +10,159 @@
 //// See the License for the specific language governing permissions and
 //// limitations under the License.
 
-//using FlowtideDotNet.Storage.StateManager.Internal;
-//using FlowtideDotNet.Storage.Tree.Internal;
-//using FlowtideDotNet.Storage.Tree;
-//using System;
-//using System.Collections.Generic;
-//using System.Diagnostics;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
+using FlowtideDotNet.Storage.StateManager.Internal;
+using FlowtideDotNet.Storage.Tree.Internal;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-//namespace FlowtideDotNet.Storage.AppendTree.Internal
-//{
-//    internal partial class AppendTree<K, V> : IAppendTree<K, V>
-//    {
-//        internal readonly IStateClient<IBPlusTreeNode, AppendTreeMetadata> m_stateClient;
-//        private readonly BPlusTreeOptions<K, V> m_options;
-//        internal IComparer<K> m_keyComparer;
-//        private LeafNode<K, V>? m_rightNode;
-//        private readonly int m_bucketSize;
-//        private readonly List<InternalNode<K, V>> m_rightInternalNodes;
+namespace FlowtideDotNet.Storage.AppendTree.Internal
+{
+    internal partial class AppendTree<K, V, TKeyContainer, TValueContainer> : IAppendTree<K, V, TKeyContainer, TValueContainer>
+        where TKeyContainer : IKeyContainer<K>
+        where TValueContainer : IValueContainer<V>
+    {
+        internal readonly IStateClient<IBPlusTreeNode, AppendTreeMetadata> m_stateClient;
+        private readonly BPlusTreeOptions<K, V, TKeyContainer, TValueContainer> m_options;
+        internal IBplusTreeComparer<K, TKeyContainer> m_keyComparer;
+        private LeafNode<K, V, TKeyContainer, TValueContainer>? m_rightNode;
+        private readonly int m_bucketSize;
+        private List<long> m_rightInternalNodes;
 
-//        public AppendTree(IStateClient<IBPlusTreeNode, AppendTreeMetadata> stateClient, BPlusTreeOptions<K, V> options)
-//        {
-//            Debug.Assert(options.BucketSize.HasValue);
-//            this.m_stateClient = stateClient;
-//            this.m_options = options;
-//            m_bucketSize = options.BucketSize.Value;
-//            this.m_keyComparer = options.Comparer;
-//            m_rightInternalNodes = new List<InternalNode<K, V>>();
-//        }
+        public AppendTree(IStateClient<IBPlusTreeNode, AppendTreeMetadata> stateClient, BPlusTreeOptions<K, V, TKeyContainer, TValueContainer> options)
+        {
+            Debug.Assert(options.BucketSize.HasValue);
+            this.m_stateClient = stateClient;
+            this.m_options = options;
+            m_bucketSize = options.BucketSize.Value;
+            this.m_keyComparer = options.Comparer;
+            m_rightInternalNodes = new List<long>();
+        }
 
-//        public async Task InitializeAsync()
-//        {
-//            Debug.Assert(m_options.BucketSize.HasValue);
-//            if (m_stateClient.Metadata == null)
-//            {
-//                var rootId = m_stateClient.GetNewPageId();
-//                var root = new LeafNode<K, V>(rootId);
-//                m_stateClient.Metadata = new AppendTreeMetadata()
-//                {
-//                    Root = rootId,
-//                    BucketLength = m_options.BucketSize.Value,
-//                    Left = rootId,
-//                    Right = rootId
-//                };
-//                m_stateClient.AddOrUpdate(rootId, root);
-//                m_rightNode = root;
-//            }
-//            else
-//            {
-//                // Fill up the right internal nodes
-//                m_rightInternalNodes.Clear();
-//                await CreateInternalNodesList(m_stateClient.Metadata.Root);
-//            }
-//        }
+        public async Task InitializeAsync()
+        {
+            Debug.Assert(m_options.BucketSize.HasValue);
+            if (m_stateClient.Metadata == null)
+            {
+                var rootId = m_stateClient.GetNewPageId();
+                var emptyKeys = m_options.KeySerializer.CreateEmpty();
+                var emptyValues = m_options.ValueSerializer.CreateEmpty();
+                var root = new LeafNode<K, V, TKeyContainer, TValueContainer>(rootId, emptyKeys, emptyValues);
+                m_stateClient.Metadata = new AppendTreeMetadata()
+                {
+                    Root = rootId,
+                    BucketLength = m_options.BucketSize.Value,
+                    Left = rootId,
+                    Right = rootId
+                };
+                m_stateClient.AddOrUpdate(rootId, root);
+                m_rightNode = root;
+                m_rightNode.TryRent();
+            }
+            else
+            {
+                m_rightNode = (await m_stateClient.GetValue(m_stateClient.Metadata.Right, "")) as LeafNode<K, V, TKeyContainer, TValueContainer>;
+                m_rightNode!.TryRent();
+                m_rightInternalNodes.Clear();
+                await CreateInternalNodesList(m_stateClient.Metadata.Root);
+            }
+        }
 
-//        private async ValueTask CreateInternalNodesList(long id)
-//        {
-//            if (m_stateClient.Metadata!.Right == id)
-//            {
-//                return;
-//            }
-//            var node = await GetChildNode(id);
+        internal void ReturnNode(IBPlusTreeNode? node)
+        {
+            if (node != null && node.Id != m_rightNode!.Id)
+            {
+                node.Return();
+            }
+        }
 
-//            if (node is InternalNode<K, V> internalNode)
-//            {
-//                m_rightInternalNodes.Add(internalNode);
-//                await CreateInternalNodesList(internalNode.children[internalNode.children.Count - 1]);
-//            }
-//        }
+        private async ValueTask CreateInternalNodesList(long id)
+        {
+            if (m_stateClient.Metadata!.Right == id)
+            {
+                return;
+            }
+            var node = await GetChildNode(id);
 
-//        public ValueTask Commit()
-//        {
-//            if (m_rightNode != null)
-//            {
-//                m_stateClient.AddOrUpdate(m_rightNode.Id, m_rightNode);
-//            }
-//            return m_stateClient.Commit();
-//        }
+            if (node is InternalNode<K, V, TKeyContainer> internalNode)
+            {
+                m_rightInternalNodes.Add(internalNode.Id);
+                await CreateInternalNodesList(internalNode.children[internalNode.children.Count - 1]);
+            }
+        }
 
-//        public async Task<string> Print()
-//        {
-//            Debug.Assert(m_stateClient.Metadata != null);
-//            var root = (BaseNode<K>)(await GetChildNode(m_stateClient.Metadata.Root))!;
 
-//            var builder = new StringBuilder();
-//            builder.AppendLine("digraph g {");
-//            builder.AppendLine("splines=line");
-//            builder.AppendLine("node [shape = none,height=.1];");
-//            await root.Print(builder, async (id) => (BaseNode<K>)(await GetChildNode(id))!);
-//            builder.AppendLine("}");
-//            return builder.ToString();
-//        }
+        private void SetRightNode(LeafNode<K, V, TKeyContainer, TValueContainer> node)
+        {
+            node.TryRent();
+            var previous = m_rightNode;
+            m_rightNode = node;
+            m_stateClient.Metadata!.Right = node.Id;
+            // The previous right node is returned in the insertion loop
+        }
 
-//        public IAppendTreeIterator<K, V> CreateIterator()
-//        {
-//            return new AppendTreeIterator<K, V>(this);
-//        }
+        public ValueTask Commit()
+        {
+            if (m_rightNode != null)
+            {
+                m_stateClient.AddOrUpdate(m_rightNode.Id, m_rightNode);
+            }
+            return m_stateClient.Commit();
+        }
 
-//        internal async ValueTask<IBPlusTreeNode?> GetChildNode(long id)
-//        {
-//            // Must always check if it is the right node since it is not commited to state before full.
-//            if (id == m_stateClient.Metadata!.Right)
-//            {
-//                if (m_rightNode == null)
-//                {
-//                    m_rightNode = (await m_stateClient.GetValue(id, "")) as LeafNode<K, V>;
-//                }
-//                return m_rightNode!;
-//            }
-//            return await m_stateClient.GetValue(id, "");
-//        }
+        public async Task<string> Print()
+        {
+            Debug.Assert(m_stateClient.Metadata != null);
+            var root = (BaseNode<K, TKeyContainer>)(await GetChildNode(m_stateClient.Metadata.Root))!;
 
-//        public async ValueTask Clear()
-//        {
-//            Debug.Assert(m_options.BucketSize.HasValue);
-//            // Clear the current state from the state storage
-//            await m_stateClient.Reset(true);
+            var builder = new StringBuilder();
+            builder.AppendLine("digraph g {");
+            builder.AppendLine("splines=line");
+            builder.AppendLine("node [shape = none,height=.1];");
+            await root.Print(builder, async (id) => (BaseNode<K, TKeyContainer>)(await GetChildNode(id))!);
+            builder.AppendLine("}");
+            return builder.ToString();
+        }
 
-//            // Create a new root leaf
-//            var rootId = m_stateClient.GetNewPageId();
-//            var root = new LeafNode<K, V>(rootId);
-//            m_stateClient.Metadata = new AppendTreeMetadata()
-//            {
-//                Root = rootId,
-//                BucketLength = m_options.BucketSize.Value,
-//                Left = rootId,
-//                Right = rootId
-//            };
-//            m_rightNode = root;
-//            m_rightInternalNodes.Clear();
-//            m_stateClient.AddOrUpdate(rootId, root);
-//        }
-//    }
-//}
+        public IAppendTreeIterator<K, V, TKeyContainer> CreateIterator()
+        {
+            return new AppendTreeIterator<K, V, TKeyContainer, TValueContainer>(this);
+        }
+
+        internal async ValueTask<IBPlusTreeNode?> GetChildNode(long id)
+        {
+            // Must always check if it is the right node since it is not commited to state before full.
+            if (id == m_stateClient.Metadata!.Right)
+            {
+                return m_rightNode!;
+            }
+            return await m_stateClient.GetValue(id, "");
+        }
+
+        public async ValueTask Clear()
+        {
+            Debug.Assert(m_options.BucketSize.HasValue);
+            // Clear the current state from the state storage
+            await m_stateClient.Reset(true);
+
+            // Create a new root leaf
+            var rootId = m_stateClient.GetNewPageId();
+            var emptyKeys = m_options.KeySerializer.CreateEmpty();
+            var emptyValues = m_options.ValueSerializer.CreateEmpty();
+            var root = new LeafNode<K, V, TKeyContainer, TValueContainer>(rootId, emptyKeys, emptyValues);
+            m_stateClient.Metadata = new AppendTreeMetadata()
+            {
+                Root = rootId,
+                BucketLength = m_options.BucketSize.Value,
+                Left = rootId,
+                Right = rootId
+            };
+            m_rightNode = root;
+            m_stateClient.AddOrUpdate(rootId, root);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTreeIterator.cs
+++ b/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTreeIterator.cs
@@ -1,127 +1,141 @@
-﻿//// Licensed under the Apache License, Version 2.0 (the "License")
-//// you may not use this file except in compliance with the License.
-//// You may obtain a copy of the License at
-////
-////     http://www.apache.org/licenses/LICENSE-2.0
-////  
-//// Unless required by applicable law or agreed to in writing, software
-//// distributed under the License is distributed on an "AS IS" BASIS,
-//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//// See the License for the specific language governing permissions and
-//// limitations under the License.
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-//using FlowtideDotNet.Storage.Tree;
-//using FlowtideDotNet.Storage.Tree.Internal;
-//using System;
-//using System.Collections.Generic;
-//using System.Diagnostics;
-//using System.Linq;
-//using System.Reflection;
-//using System.Text;
-//using System.Threading.Tasks;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
 
-//namespace FlowtideDotNet.Storage.AppendTree.Internal
-//{
-//    internal class AppendTreeIterator<K, V> : IAppendTreeIterator<K, V>
-//    {
-//        private sealed class Enumerator : IAsyncEnumerator<KeyValuePair<K, V>>
-//        {
-//            private readonly AppendTree<K, V> _tree;
-//            private LeafNode<K, V> _node;
-//            private int _index;
-//            private bool _started;
+namespace FlowtideDotNet.Storage.AppendTree.Internal
+{
+    internal class AppendTreeIterator<K, V, TKeyContainer, TValueContainer> : IAppendTreeIterator<K, V, TKeyContainer>
+        where TKeyContainer : IKeyContainer<K>
+        where TValueContainer : IValueContainer<V>
+    {
+        private sealed class Enumerator : IAsyncEnumerator<KeyValuePair<K, V>>
+        {
+            private readonly AppendTree<K, V, TKeyContainer, TValueContainer> _tree;
+            private LeafNode<K, V, TKeyContainer, TValueContainer> _node;
+            private int _index;
+            private bool _started;
 
-//            public Enumerator(AppendTree<K, V> tree, LeafNode<K, V> node, int index)
-//            {
-//                _tree = tree;
-//                _node = node;
-//                _index = index;
-//                _started = false;
-//            }
-//            public KeyValuePair<K, V> Current => GetCurrent();
+            public Enumerator(AppendTree<K, V, TKeyContainer, TValueContainer> tree, LeafNode<K, V, TKeyContainer, TValueContainer> node, int index)
+            {
+                _tree = tree;
+                _node = node;
+                _index = index;
+                _started = false;
+            }
+            public KeyValuePair<K, V> Current => GetCurrent();
 
-//            private KeyValuePair<K, V> GetCurrent()
-//            {
-//                _node.EnterWriteLock();
-//                var result = new KeyValuePair<K, V>(_node.keys[_index], _node.values[_index]);
-//                _node.ExitWriteLock();
-//                return result;
-//            }
+            private KeyValuePair<K, V> GetCurrent()
+            {
+                _node.EnterWriteLock();
+                var result = new KeyValuePair<K, V>(_node.keys.Get(_index), _node.values.Get(_index));
+                _node.ExitWriteLock();
+                return result;
+            }
 
-//            public ValueTask DisposeAsync()
-//            {
-//                return ValueTask.CompletedTask;
-//            }
+            public ValueTask DisposeAsync()
+            {
+                if (_node.Id != _tree.m_stateClient.Metadata!.Right)
+                {
+                    _node.Return();
+                }
+                return ValueTask.CompletedTask;
+            }
 
-//            public ValueTask<bool> MoveNextAsync()
-//            {
-//                if (!_started)
-//                {
-//                    _started = true;
-//                }
-//                else
-//                {
-//                    _index++;
-//                }
-//                if (_node.keys.Count <= _index && _node.next == 0)
-//                {
-//                    return ValueTask.FromResult(false);
-//                }
-//                else if (_node.next != 0 && _node.keys.Count == _index)
-//                {
-//                    return FetchNewPage();
-//                }
-//                return ValueTask.FromResult(true);
-//            }
+            public ValueTask<bool> MoveNextAsync()
+            {
+                if (!_started)
+                {
+                    _started = true;
+                }
+                else
+                {
+                    _index++;
+                }
+                if (_node.keys.Count <= _index && _node.next == 0)
+                {
+                    return ValueTask.FromResult(false);
+                }
+                else if (_node.next != 0 && _node.keys.Count == _index)
+                {
+                    return FetchNewPage();
+                }
+                return ValueTask.FromResult(true);
+            }
 
-//            private async ValueTask<bool> FetchNewPage()
-//            {
-//                _node = ((await _tree.GetChildNode(_node.next)) as LeafNode<K, V>)!;
-//                _index = 0;
-//                if (_node.keys.Count == 0)
-//                {
-//                    return false;
-//                }
-//                return true;
-//            }
-//        }
+            private async ValueTask<bool> FetchNewPage()
+            {
+                if (_node.Id != _tree.m_stateClient.Metadata!.Right)
+                {
+                    _node.Return();
+                }
+                _node = ((await _tree.GetChildNode(_node.next)) as LeafNode<K, V, TKeyContainer, TValueContainer>)!;
+                _index = 0;
+                if (_node.keys.Count == 0)
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
 
-//        private readonly AppendTree<K, V> _tree;
-//        private LeafNode<K, V>? _node;
-//        private int? _index;
+        private readonly AppendTree<K, V, TKeyContainer, TValueContainer> _tree;
+        private LeafNode<K, V, TKeyContainer, TValueContainer>? _node;
+        private int? _index;
 
-//        public AppendTreeIterator(AppendTree<K, V> tree)
-//        {
-//            _tree = tree;
-//        }
+        public AppendTreeIterator(AppendTree<K, V, TKeyContainer, TValueContainer> tree)
+        {
+            _tree = tree;
+        }
 
-//        public IAsyncEnumerator<KeyValuePair<K, V>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-//        {
-//            if (_node == null || _index == null)
-//            {
-//                throw new NotSupportedException("You must call seek before iterating");
-//            }
-//            return new Enumerator(_tree, _node, _index.Value);
-//        }
+        public IAsyncEnumerator<KeyValuePair<K, V>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (_node == null || _index == null)
+            {
+                throw new NotSupportedException("You must call seek before iterating");
+            }
+            return new Enumerator(_tree, _node, _index.Value);
+        }
 
-//        public ValueTask Seek(in K key, in IComparer<K>? searchComparer = null)
-//        {
-//            // Do async seek directly right now
-//            return Seek_Slow(key, searchComparer);
-//        }
+        public ValueTask Seek(in K key, in IBplusTreeComparer<K, TKeyContainer>? searchComparer = null)
+        {
+            // Do async seek directly right now
+            var comparer = searchComparer == null ? _tree.m_keyComparer : searchComparer;
+            return Seek_Slow(key, comparer);
+        }
 
-//        private async ValueTask Seek_Slow(K key, IComparer<K>? searchComparer)
-//        {
-//            var comparer = searchComparer == null ? _tree.m_keyComparer : searchComparer;
-//            _node = await _tree.FindLeafNode(key, comparer);
-//            _node.EnterWriteLock();
-//            var i = _node.keys.BinarySearch(key, searchComparer);
-//            _node.ExitWriteLock();
-//            if (i < 0)
-//            {
-//                i = ~i;
-//            }
-//            _index = i;
-//        }
-//    }
-//}
+        private async ValueTask Seek_Slow(K key, IBplusTreeComparer<K, TKeyContainer> searchComparer)
+        {
+            _node = await _tree.FindLeafNode(key, searchComparer);
+            _node.EnterWriteLock();
+            var i = searchComparer.FindIndex(key, _node.keys);
+            _node.ExitWriteLock();
+            if (i < 0)
+            {
+                i = ~i;
+            }
+            _index = i;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTreeMetadata.cs
+++ b/src/FlowtideDotNet.Storage/AppendTree/Internal/AppendTreeMetadata.cs
@@ -10,25 +10,29 @@
 //// See the License for the specific language governing permissions and
 //// limitations under the License.
 
-//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
+using FlowtideDotNet.Storage.StateManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-//namespace FlowtideDotNet.Storage.AppendTree.Internal
-//{
-//    internal class AppendTreeMetadata
-//    {
-//        public int BucketLength { get; set; }
-//        public long Root { get; set; }
+namespace FlowtideDotNet.Storage.AppendTree.Internal
+{
+    internal class AppendTreeMetadata : IStorageMetadata
+    {
+        public int BucketLength { get; set; }
+        public long Root { get; set; }
 
-//        /// <summary>
-//        /// Contains the id of the most left page.
-//        /// This is used to start an iterator.
-//        /// </summary>
-//        public long Left { get; set; }
+        /// <summary>
+        /// Contains the id of the most left page.
+        /// This is used to start an iterator.
+        /// </summary>
+        public long Left { get; set; }
 
-//        public long Right { get; set; }
-//    }
-//}
+        public long Right { get; set; }
+
+        public int Depth { get; set; }
+        public bool Updated { get; set; }
+    }
+}

--- a/src/FlowtideDotNet.Storage/StateManager/IStateManagerClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/IStateManagerClient.cs
@@ -25,6 +25,11 @@ namespace FlowtideDotNet.Storage.StateManager
             where TKeyContainer: IKeyContainer<K>
             where TValueContainer: IValueContainer<V>;
 
+        ValueTask<IAppendTree<K, V, TKeyContainer, TValueContainer>> GetOrCreateAppendTree<K, V, TKeyContainer, TValueContainer>(string name, BPlusTreeOptions<K, V, TKeyContainer, TValueContainer> options)
+            where TKeyContainer : IKeyContainer<K>
+            where TValueContainer : IValueContainer<V>;
+
+
         IStateManagerClient GetChildManager(string name);
     }
 }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
@@ -284,11 +284,12 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
                     var sw = ValueStopwatch.StartNew();
                     var bytes = m_fileCache.Read(key);
                     var value = options.ValueSerializer.Deserialize(new ByteMemoryOwner(bytes), bytes.Length, stateManager.SerializeOptions);
-                    stateManager.AddOrUpdate(key, value, this);
                     if (!value.TryRent())
                     {
                         throw new InvalidOperationException("Could not rent value when fetched from storage.");
                     }
+                    stateManager.AddOrUpdate(key, value, this);
+                    
                     if (m_temporaryReadMsHistogram != null)
                     {
                         m_temporaryReadMsHistogram.Record((float)sw.GetElapsedTime().TotalMilliseconds, tagList);

--- a/tests/FlowtideDotNet.Storage.Tests/Append/AppendTreeTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/Append/AppendTreeTests.cs
@@ -1,249 +1,252 @@
-﻿//// Licensed under the Apache License, Version 2.0 (the "License")
-//// you may not use this file except in compliance with the License.
-//// You may obtain a copy of the License at
-////
-////     http://www.apache.org/licenses/LICENSE-2.0
-////  
-//// Unless required by applicable law or agreed to in writing, software
-//// distributed under the License is distributed on an "AS IS" BASIS,
-//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//// See the License for the specific language governing permissions and
-//// limitations under the License.
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-//using FASTER.core;
-//using FlowtideDotNet.Storage.AppendTree.Internal;
-//using FlowtideDotNet.Storage.Comparers;
-//using FlowtideDotNet.Storage.Persistence.CacheStorage;
-//using FlowtideDotNet.Storage.Persistence.FasterStorage;
-//using FlowtideDotNet.Storage.Serializers;
-//using FlowtideDotNet.Storage.StateManager;
-//using Microsoft.Extensions.Logging.Abstractions;
-//using System;
-//using System.Collections.Generic;
-//using System.Diagnostics.Metrics;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
+using FASTER.core;
+using FlowtideDotNet.Storage.AppendTree.Internal;
+using FlowtideDotNet.Storage.Comparers;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Persistence.CacheStorage;
+using FlowtideDotNet.Storage.Persistence.FasterStorage;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-//namespace FlowtideDotNet.Storage.Tests.Append
-//{
-//    public class AppendTreeTests : IDisposable
-//    {
-//        StateManager.StateManagerSync? stateManager;
+namespace FlowtideDotNet.Storage.Tests.Append
+{
+    public class AppendTreeTests : IDisposable
+    {
+        StateManager.StateManagerSync? stateManager;
 
-//        public void Dispose()
-//        {
-//            if (stateManager != null)
-//            {
-//                stateManager.Dispose();
-//            }
-//        }
+        public void Dispose()
+        {
+            if (stateManager != null)
+            {
+                stateManager.Dispose();
+            }
+        }
 
-//        private async Task<IAppendTree<long, long>> CreateTree(int bucketSize = 8, string path = "./data/temp", bool deleteOnClose = true, int cachePageCount = 1000000)
-//        {
-//            stateManager = new StateManager.StateManagerSync<object>(new StateManagerOptions()
-//            {
-//                CachePageCount = cachePageCount,
-//                PersistentStorage = new FasterKvPersistentStorage(new FasterKVSettings<long, SpanByte>(path, deleteOnClose))
-//            }, new NullLogger<StateManagerSync>(), new Meter($"storage"), "storage");
-//            await stateManager.InitializeAsync();
+        private async Task<IAppendTree<long, long, ListKeyContainer<long>, ListValueContainer<long>>> CreateTree(int bucketSize = 8, string path = "./data/temp", bool deleteOnClose = true, int cachePageCount = 1000000)
+        {
+            stateManager = new StateManager.StateManagerSync<object>(new StateManagerOptions()
+            {
+                CachePageCount = cachePageCount,
+                PersistentStorage = new FasterKvPersistentStorage(new FasterKVSettings<long, SpanByte>(path, deleteOnClose))
+            }, new NullLogger<StateManagerSync>(), new Meter($"storage"), "storage");
+            await stateManager.InitializeAsync();
 
-//            var nodeClient = stateManager.GetOrCreateClient("node1");
-//            var tree = await nodeClient.GetOrCreateAppendTree<long, long>("tree", new Tree.BPlusTreeOptions<long, long>()
-//            {
-//                BucketSize = bucketSize,
-//                Comparer = new LongComparer(),
-//                KeySerializer = new LongSerializer(),
-//                ValueSerializer = new LongSerializer()
-//            });
-//            return tree;
-//        }
+            var nodeClient = stateManager.GetOrCreateClient("node1");
+            var tree = await nodeClient.GetOrCreateAppendTree("tree", new Tree.BPlusTreeOptions<long, long, ListKeyContainer<long>, ListValueContainer<long>>()
+            {
+                BucketSize = bucketSize,
+                Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
+                KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
+                ValueSerializer = new ValueListSerializer<long>(new LongSerializer()),
+                MemoryAllocator = GlobalMemoryManager.Instance
+            });
+            return tree;
+        }
 
-//        [Fact]
-//        public async Task TestNewRootFromLeaf()
-//        {
-//            var tree = await CreateTree(1);
+        [Fact]
+        public async Task TestNewRootFromLeaf()
+        {
+            var tree = await CreateTree(1);
 
-//            await tree.Append(1, 1);
-//            await tree.Append(2, 2);
+            await tree.Append(1, 1);
+            await tree.Append(2, 2);
 
-//            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            // Check the graph
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJyskM2KwyAUhfeBvMPF9bSp_dl0oi8SujDxJhFERYVZlL57NakDocximFko3nM8ng-lmrxwM0xwr6vgtDIYWN7ryliJ0IVZOAQGxhr8mFFNc2R7evtc_UunRY86-W0bRa8ReuslekYOBAbUuox0HYMTgzJTtnkbfVoSnPWRkTErTZRZ4rScikmL2eRQs1RxXihOf6d4r0xRb7_SVcPIcVO_TbwRkeVjyHU8wI7DMp3ICnr-B9Djr0FfiZ9B6TfoOYG-iLcydIM1IXqhTGSj0AHzC4-6egIAAP__AwD4E7Oj",
-//                graph);
-//        }
+            // Check the graph
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJyskM2KwyAUhfeBvMPF9bSp_dl0oi8SujDxJhFERYVZlL57NakDocximFko3nM8ng-lmrxwM0xwr6vgtDIYWN7ryliJ0IVZOAQGxhr8mFFNc2R7evtc_UunRY86-W0bRa8ReuslekYOBAbUuox0HYMTgzJTtnkbfVoSnPWRkTErTZRZ4rScikmL2eRQs1RxXihOf6d4r0xRb7_SVcPIcVO_TbwRkeVjyHU8wI7DMp3ICnr-B9Djr0FfiZ9B6TfoOYG-iLcydIM1IXqhTGSj0AHzC4-6egIAAP__AwD4E7Oj",
+                graph);
+        }
 
-//        [Fact]
-//        public async Task PruneFrom2LevelTo1Level()
-//        {
-//            var tree = await CreateTree(1);
+        [Fact]
+        public async Task PruneFrom2LevelTo1Level()
+        {
+            var tree = await CreateTree(1);
 
-//            await tree.Append(1, 1);
-//            await tree.Append(2, 2);
+            await tree.Append(1, 1);
+            await tree.Append(2, 2);
 
-//            await tree.Prune(2);
+            await tree.Prune(2);
 
-//            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            // Check the graph
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJxUjsEKwyAMhu-FvkPwPNa17Db1RcoOtmYqiIoKPYy9-6Jlhx0S8uf7fxLtTFbJgoH3OJTkXcAiWh-HEDXCWqxKCAJCDHix6Iyt4jo_Hye_r15t6IlzXtXmEbaYNWbBbgx29P4n51OWpHYXTMOS10yl5cIn6jRBirkK9qJojgdZg2AL-Tqeuvsv0VdTPytl--gzDl8AAAD__wMA3OtCLQ==",
-//                graph);
-//        }
+            // Check the graph
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJxUjsEKwyAMhu-FvkPwPNa17Db1RcoOtmYqiIoKPYy9-6Jlhx0S8uf7fxLtTFbJgoH3OJTkXcAiWh-HEDXCWqxKCAJCDHix6Iyt4jo_Hye_r15t6IlzXtXmEbaYNWbBbgx29P4n51OWpHYXTMOS10yl5cIn6jRBirkK9qJojgdZg2AL-Tqeuvsv0VdTPytl--gzDl8AAAD__wMA3OtCLQ==",
+                graph);
+        }
 
-//        [Fact]
-//        public async Task TestNewRootFromInternalNode()
-//        {
-//            var tree = await CreateTree(1);
+        [Fact]
+        public async Task TestNewRootFromInternalNode()
+        {
+            var tree = await CreateTree(1);
 
-//            await tree.Append(1, 1);
-//            await tree.Append(2, 2);
-//            await tree.Append(3, 3);
-//            await tree.Append(4, 4);
+            await tree.Append(1, 1);
+            await tree.Append(2, 2);
+            await tree.Append(3, 3);
+            await tree.Append(4, 4);
 
-//            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJy0ks1ugzAMx-9IvIOV8zbKRyntCC-CdgiQAlKUoCTSDtPefeEjrbJqrdDoIVHsvx3_ZLvpW0mGDlr48j01sJ5Thcfb97hoKJSqIwMFDFxw-tLRvu00fgs_3mf9UDJSUWb0PNekYhQqIRsqMdohqClj1gxnUw2k7nk7ykWupTkNDEJqjM6jJ9DN6Coi-7JiaMVgTAqmUkVhKfbPoQjXUcT_p7gtaVKl-DShHKPIKe9m3BChqTHodN7BawGTFaMZNNkANFoNGj0CDS-giQFdiF03lLXgSkvSc43PhCl6-SFxQtN7oQenK_ulK9lzlihet0TpBrOJV88mvjebzGlXurTruAFoshp0yfgb9LoCR7tE6S_3g824hmbmh2_f-wEAAP__AwDXnZbc",
-//                graph);
-//        }
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJy0ks1ugzAMx-9IvIOV8zbKRyntCC-CdgiQAlKUoCTSDtPefeEjrbJqrdDoIVHsvx3_ZLvpW0mGDlr48j01sJ5Thcfb97hoKJSqIwMFDFxw-tLRvu00fgs_3mf9UDJSUWb0PNekYhQqIRsqMdohqClj1gxnUw2k7nk7ykWupTkNDEJqjM6jJ9DN6Coi-7JiaMVgTAqmUkVhKfbPoQjXUcT_p7gtaVKl-DShHKPIKe9m3BChqTHodN7BawGTFaMZNNkANFoNGj0CDS-giQFdiF03lLXgSkvSc43PhCl6-SFxQtN7oQenK_ulK9lzlihet0TpBrOJV88mvjebzGlXurTruAFoshp0yfgb9LoCR7tE6S_3g824hmbmh2_f-wEAAP__AwDXnZbc",
+                graph);
+        }
 
-//        [Fact]
-//        public async Task PruneFrom3LevelTo1Level()
-//        {
-//            var tree = await CreateTree(1);
+        [Fact]
+        public async Task PruneFrom3LevelTo1Level()
+        {
+            var tree = await CreateTree(1);
 
-//            await tree.Append(1, 1);
-//            await tree.Append(2, 2);
-//            await tree.Append(3, 3);
-//            await tree.Append(4, 4);
+            await tree.Append(1, 1);
+            await tree.Append(2, 2);
+            await tree.Append(3, 3);
+            await tree.Append(4, 4);
 
-//            var beforePruneGraph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var beforePruneGraph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            await tree.Prune(3);
+            await tree.Prune(3);
 
-//            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJxUjsEKwyAMhu-FvkPwPNZ17DKmvkjZwdZMBVFRoYexd1-07LBDQv58_0-inckqWTDwHoeSvAtYROvjEKJGWIpVCUFAiAFPFp2xVZzn5-Pg98WrFT1xzqtaPcIas8Ys2IXBht7_5HzIktTmgmlY8pqptLzxiTpNkGKugr0omuNO1iDYlXwdT939l-irqZ-Vsn30GYcvAAAA__8DAOCQQjY=",
-//                graph);
-//        }
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJxUjsEKwyAMhu-FvkPwPNZ17DKmvkjZwdZMBVFRoYexd1-07LBDQv58_0-inckqWTDwHoeSvAtYROvjEKJGWIpVCUFAiAFPFp2xVZzn5-Pg98WrFT1xzqtaPcIas8Ys2IXBht7_5HzIktTmgmlY8pqptLzxiTpNkGKugr0omuNO1iDYlXwdT939l-irqZ-Vsn30GYcvAAAA__8DAOCQQjY=",
+                graph);
+        }
 
-//        [Fact]
-//        public async Task PruneFrom4LevelTo2Level()
-//        {
-//            var tree = await CreateTree(1);
+        [Fact]
+        public async Task PruneFrom4LevelTo2Level()
+        {
+            var tree = await CreateTree(1);
 
-//            await tree.Append(1, 1);
-//            await tree.Append(2, 2);
-//            await tree.Append(3, 3);
-//            await tree.Append(4, 4);
-//            await tree.Append(5, 5);
-//            await tree.Append(6, 6);
-//            await tree.Append(7, 7);
-//            await tree.Append(8, 8);
+            await tree.Append(1, 1);
+            await tree.Append(2, 2);
+            await tree.Append(3, 3);
+            await tree.Append(4, 4);
+            await tree.Append(5, 5);
+            await tree.Append(6, 6);
+            await tree.Append(7, 7);
+            await tree.Append(8, 8);
 
-//            var beforePruneGraph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var beforePruneGraph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJy0ltGOqyAQhu-b9B2I17unjija3eqLNHtBK1UTgkZJ9mKz777QSittgiFHLzTCDM6Xf_4AZVP1tKtRhX62m6HjjWBDrt_bjWhLho5DTTuGciRawd5q1lS1zP_B1-ctDtGR0xPjKuFwkPTEGTq1fcn6PAgDdGacmyHchkNHz42odLg4yF49JeraXubBRc_sZKmnith8mSCY4E4v2l1LFYXBSNehiPwoknUowI8C_z_Fa0m1tG-_VarIg8gqb694IQquwgQflxC9F-g6wsENNF4ANPIGjeZA4Q4aK9CR2J5Gx3MrBtnTRsj8QvnA7n-IrVTiSk0tVZJRlWwdE2E_E5EFeoO9e4Ndvcksucgo134B0NgbNJ4DfVhgb0xEnqYdzthbqRDOueiRm5lqEFlypaNcgNexF_GzF8A6GIknRriAexJv9yQu9wBYjVPNH1mX2C6JNyuZZZ0Y9b5hKuqngMPBKmolJ85kbMsDRh6yjqNST0ctcAd4rTnbpdTZJWJLZk4aWODWVGTerOMKB-vEC3rfMtRPgTmTTJL1YfHYFScBfRX53W7-AAAA__8DAHNTYsU=",
-//                beforePruneGraph);
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJy0ltGOqyAQhu-b9B2I17unjija3eqLNHtBK1UTgkZJ9mKz777QSittgiFHLzTCDM6Xf_4AZVP1tKtRhX62m6HjjWBDrt_bjWhLho5DTTuGciRawd5q1lS1zP_B1-ctDtGR0xPjKuFwkPTEGTq1fcn6PAgDdGacmyHchkNHz42odLg4yF49JeraXubBRc_sZKmnith8mSCY4E4v2l1LFYXBSNehiPwoknUowI8C_z_Fa0m1tG-_VarIg8gqb694IQquwgQflxC9F-g6wsENNF4ANPIGjeZA4Q4aK9CR2J5Gx3MrBtnTRsj8QvnA7n-IrVTiSk0tVZJRlWwdE2E_E5EFeoO9e4Ndvcksucgo134B0NgbNJ4DfVhgb0xEnqYdzthbqRDOueiRm5lqEFlypaNcgNexF_GzF8A6GIknRriAexJv9yQu9wBYjVPNH1mX2C6JNyuZZZ0Y9b5hKuqngMPBKmolJ85kbMsDRh6yjqNST0ctcAd4rTnbpdTZJWJLZk4aWODWVGTerOMKB-vEC3rfMtRPgTmTTJL1YfHYFScBfRX53W7-AAAA__8DAHNTYsU=",
+                beforePruneGraph);
 
-//            await tree.Prune(1);
+            await tree.Prune(1);
 
-//            var prune1Graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var prune1Graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJy0Vl1vgyAUfW_S_0B43qb4gXar_pFmD7RSNSFokGQPy_77oJVW2gVDpg9-cM-Fezz3BKzaWpC-ATX43m6GnrWcDoW-bze8qyg4DA3pKSgA7zh9aWhbN7J4Q58fVxxFB0aOlKmE_V6SI6Pg2ImKigKGEJwoY2aIrsOhJ6eW1xou91KoqwJ9J2QBzzoSyEqHysS8GRAZMNCTgkupsjQ0snVYRH4s0hVY_Fko-X-h529TU0X3pVJ5ASOrvD3jiRG8fDt8P4fgtQSXUQLHcKLC6BbGEBxOHR-kIC2XxZmwgd5WyKwVUrWCfubrdDb26yxeQPDYW_DYJXhuyYVHuXYLEE28iSZzRO8W2Bln4Iewwxk7KxWFcy665-amGoosubJRLhSvYy_sZy-E1qGRetIIF3BP6u2e1OUehKzGqeaPXJfYA7E3VzzLdWLU2y6oWD8ADgcr1EpOncmxLQ8y8uB1HJV5OmqBI_G55myXMmeXsC2ZOWnQAj8RZe7NdZzh4Drxgt63DOsHYM4kk2R9WNx3xQkQK-Bnu_kFAAD__wMAXSsYgA==",
-//                prune1Graph);
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJy0Vl1vgyAUfW_S_0B43qb4gXar_pFmD7RSNSFokGQPy_77oJVW2gVDpg9-cM-Fezz3BKzaWpC-ATX43m6GnrWcDoW-bze8qyg4DA3pKSgA7zh9aWhbN7J4Q58fVxxFB0aOlKmE_V6SI6Pg2ImKigKGEJwoY2aIrsOhJ6eW1xou91KoqwJ9J2QBzzoSyEqHysS8GRAZMNCTgkupsjQ0snVYRH4s0hVY_Fko-X-h529TU0X3pVJ5ASOrvD3jiRG8fDt8P4fgtQSXUQLHcKLC6BbGEBxOHR-kIC2XxZmwgd5WyKwVUrWCfubrdDb26yxeQPDYW_DYJXhuyYVHuXYLEE28iSZzRO8W2Bln4Iewwxk7KxWFcy665-amGoosubJRLhSvYy_sZy-E1qGRetIIF3BP6u2e1OUehKzGqeaPXJfYA7E3VzzLdWLU2y6oWD8ADgcr1EpOncmxLQ8y8uB1HJV5OmqBI_G55myXMmeXsC2ZOWnQAj8RZe7NdZzh4Drxgt63DOsHYM4kk2R9WNx3xQkQK-Bnu_kFAAD__wMAXSsYgA==",
+                prune1Graph);
 
-//            await tree.Prune(2);
+            await tree.Prune(2);
 
-//            var prune2Graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var prune2Graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJy0ldFugyAUhu-b9B0I19vqqYptV3yRZhe0UjUhaJBkF8vefdBKJ-1iQ6YXGuE_eD7O-QNFXSrWVqhEX8tF14pa8o7a93Ihm4KjQ1exliOKZCP5S8XrstL0DT7erzqsD4IduTAB-71mR8HRsVEFVxRHGJ24EG4I12HXslMtSyvne63MU6C2UZris51Z6cJO5Yn7ciI4cWUXrS6p8txhZDNQ_JloM89247Dtkv9TPKY0S1XzaUIlxWsvvb_igQhfCoN35wi95ugyIvgKup0ANAkGTZ6Bwg10a0B7Yn8aHU6N7LRitdT0zETHb3_YeqEQjcVmXlk2LhusvfmsLxfE89iLhNkLYB6MNBAjmsA9abB70jH3AHiNM83vWZMJWEkwK3nKOjBqcnNfdC-MONioXnA6Ghz75QFXHjKPo7JAR6UTdCkL7lI22iXilyx1JZvgTss3waz9ihHWgRfsueWo74RnJhkE28vi91QcCLERvpeLHwAAAP__AwD5Mqbw",
-//                prune2Graph);
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJy0ldFugyAUhu-b9B0I19vqqYptV3yRZhe0UjUhaJBkF8vefdBKJ-1iQ6YXGuE_eD7O-QNFXSrWVqhEX8tF14pa8o7a93Ihm4KjQ1exliOKZCP5S8XrstL0DT7erzqsD4IduTAB-71mR8HRsVEFVxRHGJ24EG4I12HXslMtSyvne63MU6C2UZris51Z6cJO5Yn7ciI4cWUXrS6p8txhZDNQ_JloM89247Dtkv9TPKY0S1XzaUIlxWsvvb_igQhfCoN35wi95ugyIvgKup0ANAkGTZ6Bwg10a0B7Yn8aHU6N7LRitdT0zETHb3_YeqEQjcVmXlk2LhusvfmsLxfE89iLhNkLYB6MNBAjmsA9abB70jH3AHiNM83vWZMJWEkwK3nKOjBqcnNfdC-MONioXnA6Ghz75QFXHjKPo7JAR6UTdCkL7lI22iXilyx1JZvgTss3waz9ihHWgRfsueWo74RnJhkE28vi91QcCLERvpeLHwAAAP__AwD5Mqbw",
+                prune2Graph);
 
-//            await tree.Prune(3);
+            await tree.Prune(3);
 
-//            var prune3Graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var prune3Graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJy8VMtugzAQvCPxD5bPbcEkPNLG_pGoBwccQLIMsi31UPXfa0gc4aQisgo5gPDMrnfYHW3V1pL2DajBdxionreCKTy8w0B0FQMH1dCeAQxEJ9hLw9q60fgNfX6ceZQcOD0ybgL2e02PnIFjJysmMYwhKBnn9ojOR9XTshX1QJO9luapQN9JjeFpQCJdDRDZ2i9LIktGQ1I0liLEyshXUPFnoeJZhXb_L3TfRJMquy8TKjBMnPJuxp0iOP47fD_F4JWA8bSDF3hnYHSFkalxKDuhtKSt0PhEuWLXK3LnisJegRIHzw0-wpt1zJX5mQuhdWSknjLiBSyRelsinbMEQs7gzPAvWrcLaM28tWYPtU6Mur26L74lZhxsWCc4nQ3euO1Btj3ZOo7KPR2VLjCl3HtK-eyUMrdlqW3ZAiueFN5aLxkzWideGPaWVX1DPDLJJDhztuKE2BjiJwx-AQAA__8DADcHXJQ=",
-//                prune3Graph);
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJy8VMtugzAQvCPxD5bPbcEkPNLG_pGoBwccQLIMsi31UPXfa0gc4aQisgo5gPDMrnfYHW3V1pL2DajBdxionreCKTy8w0B0FQMH1dCeAQxEJ9hLw9q60fgNfX6ceZQcOD0ybgL2e02PnIFjJysmMYwhKBnn9ojOR9XTshX1QJO9luapQN9JjeFpQCJdDRDZ2i9LIktGQ1I0liLEyshXUPFnoeJZhXb_L3TfRJMquy8TKjBMnPJuxp0iOP47fD_F4JWA8bSDF3hnYHSFkalxKDuhtKSt0PhEuWLXK3LnisJegRIHzw0-wpt1zJX5mQuhdWSknjLiBSyRelsinbMEQs7gzPAvWrcLaM28tWYPtU6Mur26L74lZhxsWCc4nQ3euO1Btj3ZOo7KPR2VLjCl3HtK-eyUMrdlqW3ZAiueFN5aLxkzWideGPaWVX1DPDLJJDhztuKE2BjiJwx-AQAA__8DADcHXJQ=",
+                prune3Graph);
 
-//            await tree.Prune(4);
+            await tree.Prune(4);
 
-//            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJy0ks9qhDAQxu-C7zDk3FbT1Vha44tID1HjHwiJJIEeSt-9sW52111wkboHg5NvJvPjm2mGTrOxhw6-w8CMYpDc0OkMA6kaDqXp2ciBglSSP_V86HpLX_Dnx6zjQylYxYVLyHPLKsGhUrrhmqIYQc2F8CGeQzOyepDdJBe51e5rYFTaUtRON5FtpquC-D8vYi9GU1H016ooThj4MRjpRoz4_xi3PV2pVl8uVVL0uui_rLhBQrM16L2N4bmAOYzRkTXZgZVsZiV3WfGZNXGsnvpKgLJW0ljNBmlpy4Th51eSZXK6mnxY2oO9PeQxG5Vt3Kh0hyllm6eUrU6JLC1LvWXZDqxvm1mPFSusF7uQnTYqvRbuLclFMnGv_ITBLwAAAP__AwAjSpua",
-//                graph);
-//        }
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJy0ks9qhDAQxu-C7zDk3FbT1Vha44tID1HjHwiJJIEeSt-9sW52111wkboHg5NvJvPjm2mGTrOxhw6-w8CMYpDc0OkMA6kaDqXp2ciBglSSP_V86HpLX_Dnx6zjQylYxYVLyHPLKsGhUrrhmqIYQc2F8CGeQzOyepDdJBe51e5rYFTaUtRON5FtpquC-D8vYi9GU1H016ooThj4MRjpRoz4_xi3PV2pVl8uVVL0uui_rLhBQrM16L2N4bmAOYzRkTXZgZVsZiV3WfGZNXGsnvpKgLJW0ljNBmlpy4Th51eSZXK6mnxY2oO9PeQxG5Vt3Kh0hyllm6eUrU6JLC1LvWXZDqxvm1mPFSusF7uQnTYqvRbuLclFMnGv_ITBLwAAAP__AwAjSpua",
+                graph);
+        }
 
-//        [Fact]
-//        public async Task TestCommit()
-//        {
-//            if (Directory.Exists("./data/temp/testcommit"))
-//            {
-//                Directory.Delete("./data/temp/testcommit", true);
-//            }
-            
-//            var tree = await CreateTree(1, "./data/temp/testcommit", false);
+        [Fact]
+        public async Task TestCommit()
+        {
+            if (Directory.Exists("./data/temp/testcommit"))
+            {
+                Directory.Delete("./data/temp/testcommit", true);
+            }
 
-//            await tree.Append(1, 1);
-//            await tree.Append(2, 2);
+            var tree = await CreateTree(1, "./data/temp/testcommit", false);
 
-//            await tree.Commit();
-//            await stateManager!.CheckpointAsync();
-//            stateManager!.Dispose();
-//            tree = await CreateTree(1, "./data/temp/testcommit", false);
+            await tree.Append(1, 1);
+            await tree.Append(2, 2);
 
-//            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
+            await tree.Commit();
+            await stateManager!.CheckpointAsync();
+            stateManager!.Dispose();
+            tree = await CreateTree(1, "./data/temp/testcommit", false);
 
-//            // Check the graph
-//            Assert.Equal(
-//                "https://kroki.io/graphviz/svg/eJyskM2KwyAUhfeBvMPF9bSp_dl0oi8SujDxJhFERYVZlL57NakDocximFko3nM8ng-lmrxwM0xwr6vgtDIYWN7ryliJ0IVZOAQGxhr8mFFNc2R7evtc_UunRY86-W0bRa8ReuslekYOBAbUuox0HYMTgzJTtnkbfVoSnPWRkTErTZRZ4rScikmL2eRQs1RxXihOf6d4r0xRb7_SVcPIcVO_TbwRkeVjyHU8wI7DMp3ICnr-B9Djr0FfiZ9B6TfoOYG-iLcydIM1IXqhTGSj0AHzC4-6egIAAP__AwD4E7Oj",
-//                graph);
-//        }
+            var graph = KrokiUrlBuilder.ToKrokiUrl(await tree.Print());
 
-//        [Fact]
-//        public async Task InsertOutOfOrder()
-//        {
-//            var tree = await CreateTree(1);
+            // Check the graph
+            Assert.Equal(
+                "https://kroki.io/graphviz/svg/eJyskM2KwyAUhfeBvMPF9bSp_dl0oi8SujDxJhFERYVZlL57NakDocximFko3nM8ng-lmrxwM0xwr6vgtDIYWN7ryliJ0IVZOAQGxhr8mFFNc2R7evtc_UunRY86-W0bRa8ReuslekYOBAbUuox0HYMTgzJTtnkbfVoSnPWRkTErTZRZ4rScikmL2eRQs1RxXihOf6d4r0xRb7_SVcPIcVO_TbwRkeVjyHU8wI7DMp3ICnr-B9Djr0FfiZ9B6TfoOYG-iLcydIM1IXqhTGSj0AHzC4-6egIAAP__AwD4E7Oj",
+                graph);
+        }
 
-//            await tree.Append(2, 2);
+        [Fact]
+        public async Task InsertOutOfOrder()
+        {
+            var tree = await CreateTree(1);
 
-//            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-//            {
-//                await tree.Append(1, 1);
-//            });
-//            Assert.Equal("Key must be greater than the last key in the right node.", ex.Message);
-//        }
+            await tree.Append(2, 2);
 
-//        [Fact]
-//        public async Task TestIterator()
-//        {
-//            var tree = await CreateTree(2);
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await tree.Append(1, 1);
+            });
+            Assert.Equal("Key must be greater than the last key in the right node.", ex.Message);
+        }
 
-//            for (int i = 0; i < 10; i++)
-//            {
-//                await tree.Append(i, i);
-//            }
+        [Fact]
+        public async Task TestIterator()
+        {
+            var tree = await CreateTree(2);
 
-//            var iterator = tree.CreateIterator();
-//            await iterator.Seek(0);
+            for (int i = 0; i < 10; i++)
+            {
+                await tree.Append(i, i);
+            }
 
-//            int counter = 0;
-//            await foreach(var kv in iterator)
-//            {
-//                Assert.Equal(counter, kv.Key);
-//                Assert.Equal(counter, kv.Value);
-//                counter++;
-//            }
-//        }
-//    }
-//}
+            var iterator = tree.CreateIterator();
+            await iterator.Seek(0);
+
+            int counter = 0;
+            await foreach (var kv in iterator)
+            {
+                Assert.Equal(counter, kv.Key);
+                Assert.Equal(counter, kv.Value);
+                counter++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The append tree is a special case of the B+ tree which fills a page completely and instead of splitting it creates a new page on the right.

This means that page will be packed exactly to the limit which helps reduce the amount of pages.
Searching is still as quick as the B+ tree.

It is possible to prune from the left of the tree where entire leaf pages are removed if all values in the leaf page are in the pruning range. This allows pruning to be done without loading the actual leaf page from persistent or temporary disk storage.