### PR TITLE
Bug fix: fix union deserialize special case with only null values

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ArrowToInternalVisitor.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ArrowToInternalVisitor.cs
@@ -200,6 +200,8 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
                 }
                 
                 columns.Add(_dataColumn ?? throw new InvalidOperationException("Internal column is null"));
+                // Reset null counter
+                _nullCount = 0;
             }
 
             _dataColumn = new UnionColumn(columns, typeMemory, offsetMemory, array.Length, preAllocatedMemoryManager);

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ArrowTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ArrowTests.cs
@@ -378,6 +378,39 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Assert.Equal(1, deserializedBatch.Columns[0].GetValueAt(2, default).AsLong);
             Assert.Equal("2", deserializedBatch.Columns[0].GetValueAt(3, default).ToString());
             Assert.Equal(2, deserializedBatch.Columns[0].GetValueAt(4, default).AsLong);
+
+            
+        }
+
+        [Fact]
+        public void UnionSerializeDeserializeWithOnlyNull()
+        {
+            Column column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new StringValue("1"));
+            column.Add(NullValue.Instance);
+            column.Add(new Int64Value(1));
+
+            Column toInsertInto = new Column(GlobalMemoryManager.Instance);
+
+            toInsertInto.InsertRangeFrom(0, column, 1, 1);
+
+            var recordBatch = EventArrowSerializer.BatchToArrow(new EventBatchData(
+            [
+                toInsertInto
+            ]), toInsertInto.Count);
+
+            MemoryStream memoryStream = new MemoryStream();
+            var writer = new ArrowStreamWriter(memoryStream, recordBatch.Schema, true);
+            writer.WriteRecordBatch(recordBatch);
+            writer.Dispose();
+            memoryStream.Position = 0;
+            var reader = new ArrowStreamReader(memoryStream, new Apache.Arrow.Memory.NativeMemoryAllocator(), true);
+            var deserializedRecordBatch = reader.ReadNextRecordBatch();
+            var deserializedBatch = EventArrowSerializer.ArrowToBatch(deserializedRecordBatch, GlobalMemoryManager.Instance);
+
+            // This threw an error since null count was incorrectly set on the union column from the null column inside
+            deserializedBatch.Columns[0].RemoveAt(0);
+            Assert.Empty(deserializedBatch);
         }
 
         [Fact]


### PR DESCRIPTION
When deserializing a union column with only null values the null counter from the inner null column was incorrectly used on the union column as well. This change resets the null count.