### PR TITLE
Change serializers and storage interfaces to use IBufferWriter<byte> and ReadOnlyMemory<byte>

### DIFF
--- a/docs/docs/statepersistence.md
+++ b/docs/docs/statepersistence.md
@@ -196,24 +196,18 @@ A data page is fetched using the following logic:
 ## Compression
 
 It is possible to compress pages in the state.
-This is done by providing two functions to state serialize options, a compress function and a decompress function.
+The option that exist today is to compress pages with Zstd. Most storage backends add zstd compression by default to save on network throughput and storage size.
 
-Example using ZLib compression:
+To set compression, it is set under add storage:
 
 ```csharp
-builder.WithStateOptions(() => new StateManagerOptions()
-{
+builder.AddStorage(b => {
     ...
-    SerializeOptions = new StateSerializeOptions()
-    {
-        CompressFunc = (stream) =>
-        {
-            return new System.IO.Compression.ZLibStream(stream, CompressionMode.Compress);
-        },
-        DecompressFunc = (stream) =>
-        {
-            return new System.IO.Compression.ZLibStream(stream, CompressionMode.Decompress);
-        }
-    }
-})
+    
+    // Use zstd page compression
+    b.ZstdPageCompression();
+    
+    // Use no compression even if the storage medium added compression
+    b.NoCompression();
+});
 ```

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricSeries.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/MetricSeries.cs
@@ -68,7 +68,7 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             _client = await _stateManager.CreateClientAsync<IBPlusTreeNode, AppendTreeMetadata>(string.Empty, new FlowtideDotNet.Storage.StateManager.Internal.StateClientOptions<IBPlusTreeNode>()
             {
                 ValueSerializer = new BPlusTreeSerializer<long, double, TimestampKeyContainer, DoubleValueContainer>(_keySerializer, _valueSerializer, GlobalMemoryManager.Instance),
-            });
+            }, GlobalMemoryManager.Instance);
         }
 
         public async Task Prune(long timestamp)

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueSerializer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueSerializer.cs
@@ -15,6 +15,8 @@ using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
+using System.Buffers;
+using System.Buffers.Binary;
 
 namespace FlowtideDotNet.AspNetCore.TimeSeries
 {
@@ -53,10 +55,13 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in DoubleValueContainer values)
+        public void Serialize(in IBufferWriter<byte> writer, in DoubleValueContainer values)
         {
             var mem = values._list.SlicedMemory;
-            writer.Write(mem.Length);
+            var headerSpan = writer.GetSpan(4);
+            BinaryPrimitives.WriteInt32LittleEndian(headerSpan, mem.Length);
+            writer.Advance(4);
+            //writer.Write(mem.Length);
             writer.Write(mem.Span);
         }
     }

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueSerializer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueSerializer.cs
@@ -39,14 +39,19 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             return new DoubleValueContainer(memoryAllocator);
         }
 
-        public DoubleValueContainer Deserialize(in BinaryReader reader)
+        public DoubleValueContainer Deserialize(ref SequenceReader<byte> reader)
         {
-            var count = reader.ReadInt32();
-            var memory = reader.ReadBytes(count);
-
+            if (!reader.TryReadLittleEndian(out int count))
+            {
+                throw new InvalidOperationException("Failed to read count");
+            }
             var nativeMemory = memoryAllocator.Allocate(count, 64);
 
-            memory.CopyTo(nativeMemory.Memory.Span);
+            if (!reader.TryCopyTo(nativeMemory.Memory.Span.Slice(0, count)))
+            {
+                throw new InvalidOperationException("Failed to read bytes");
+            }
+            reader.Advance(count);
             return new DoubleValueContainer(new PrimitiveList<double>(nativeMemory, count / 8, memoryAllocator));   
         }
 

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeySerializer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeySerializer.cs
@@ -14,6 +14,8 @@ using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
+using System.Buffers;
+using System.Buffers.Binary;
 
 namespace FlowtideDotNet.AspNetCore.TimeSeries
 {
@@ -52,10 +54,13 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in TimestampKeyContainer values)
+        public void Serialize(in IBufferWriter<byte> writer, in TimestampKeyContainer values)
         {
             var mem = values._list.SlicedMemory;
-            writer.Write(mem.Length);
+            var headerSpan = writer.GetSpan(4);
+            BinaryPrimitives.WriteInt32LittleEndian(headerSpan, mem.Length);
+            writer.Advance(4);
+            //writer.Write(mem.Length);
             writer.Write(mem.Span);
         }
     }

--- a/src/FlowtideDotNet.Connector.Sharepoint/Internal/SharepointSource.cs
+++ b/src/FlowtideDotNet.Connector.Sharepoint/Internal/SharepointSource.cs
@@ -101,12 +101,16 @@ namespace FlowtideDotNet.Connector.Sharepoint.Internal
             }
             catch(Exception e)
             {
-                Logger.LogError(e, "Error fetching delta");
                 if (e is TaskCanceledException || e is OperationCanceledException)
                 {
-                    throw new InvalidOperationException("Error fetching delta, task was cancelled.", e);
+                    Logger.LogWarning(e, "Error fetching delta, task was cancelled. Waiting 120 seconds before retrying.");
+                    await Task.Delay(TimeSpan.FromSeconds(120));
                 }
-                throw;
+                else
+                {
+                    Logger.LogError(e, "Error fetching delta");
+                    throw;
+                }
             }
             finally
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -1052,7 +1052,15 @@ namespace FlowtideDotNet.Core.ColumnStore
             if (_type != ArrowTypeId.Union)
             {
                 // Union does not have a validity bitmap in apache arrow
-                dataWriter.WriteArrowBuffer(_validityList!.MemorySlice.Span);
+                if (_nullCounter == 0)
+                {
+                    // write an empty buffer if there is no null values
+                    dataWriter.WriteArrowBuffer(Span<byte>.Empty);
+                }
+                else
+                {
+                    dataWriter.WriteArrowBuffer(_validityList!.MemorySlice.Span);
+                }
             }
 
             _dataColumn!.WriteDataToBuffer(ref dataWriter);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -806,7 +806,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
         public SerializationEstimation GetSerializationEstimate()
         {
-            int bodyLength = Count * sizeof(int);
+            int bodyLength = Count * 5;
             int fieldCount = 1;
             int bufferCount = 2;
             for (int i = 0; i < _valueColumns.Count; i++)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -806,6 +806,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
         public SerializationEstimation GetSerializationEstimate()
         {
+            // Start with the size of the type list and the offsets type list is 1 byte per element and offsets is 4 bytes per element
             int bodyLength = Count * 5;
             int fieldCount = 1;
             int bufferCount = 2;

--- a/src/FlowtideDotNet.Core/ColumnStore/Serialization/EventBatchBPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Serialization/EventBatchBPlusTreeSerializer.cs
@@ -26,16 +26,12 @@ namespace FlowtideDotNet.Core.ColumnStore.Serialization
     {
         private readonly EventBatchSerializer _batchSerializer;
         private readonly object _lock = new object();
-        private IBatchCompressor _batchCompressor;
-        private IBatchDecompressor _batchDecompressor;
 
         
 
         public EventBatchBPlusTreeSerializer()
         {
             _batchSerializer = new EventBatchSerializer();
-            _batchCompressor = new BatchCompressor();
-            _batchDecompressor = new BatchDecompressor();
         }
 
         public EventBatchDeserializeResult Deserialize(ref SequenceReader<byte> reader, IMemoryAllocator memoryAllocator)

--- a/src/FlowtideDotNet.Core/ColumnStore/Serialization/EventBatchBPlusTreeSerializer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Serialization/EventBatchBPlusTreeSerializer.cs
@@ -1,0 +1,103 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZstdSharp;
+
+namespace FlowtideDotNet.Core.ColumnStore.Serialization
+{
+    public class EventBatchBPlusTreeSerializer
+    {
+        private readonly EventBatchSerializer _batchSerializer;
+        private readonly object _lock = new object();
+        private IBatchCompressor _batchCompressor;
+        private IBatchDecompressor _batchDecompressor;
+
+        
+
+        public EventBatchBPlusTreeSerializer()
+        {
+            _batchSerializer = new EventBatchSerializer();
+            _batchCompressor = new BatchCompressor();
+            _batchDecompressor = new BatchDecompressor();
+        }
+
+        public EventBatchDeserializeResult Deserialize(ref SequenceReader<byte> reader, IMemoryAllocator memoryAllocator)
+        {
+            var deserializer = new EventBatchDeserializer(memoryAllocator);
+            return deserializer.DeserializeBatch(ref reader);
+        }
+
+        public void Serialize(IBufferWriter<byte> bufferWriter, EventBatchData eventBatch, int count)
+        {
+            lock (_lock)
+            {
+                _batchSerializer.SerializeEventBatch(bufferWriter, eventBatch, count);
+            }
+        }
+
+        public Task CheckpointAsync(IBPlusTreeSerializerCheckpointContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task InitializeAsync(IBPlusTreeSerializerInitializeContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        private class BatchCompressor : IBatchCompressor
+        {
+            private Compressor _compressor;
+
+            public BatchCompressor()
+            {
+                _compressor = new Compressor();
+            }
+
+            public void ColumnChange(int columnIndex)
+            {
+            }
+
+            public int Wrap(ReadOnlySpan<byte> input, Span<byte> output)
+            {
+                return _compressor.Wrap(input, output);
+            }
+        }
+
+        private class BatchDecompressor : IBatchDecompressor
+        {
+            private Decompressor _decompressor;
+
+            public BatchDecompressor()
+            {
+                _decompressor = new Decompressor();
+            }
+
+            public void ColumnChange(int columnIndex)
+            {
+            }
+
+            public int Unwrap(ReadOnlySpan<byte> input, Span<byte> output)
+            {
+                return _decompressor.Unwrap(input, output);
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/ColumnStore/Serialization/EventBatchDeserializeResult.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Serialization/EventBatchDeserializeResult.cs
@@ -10,21 +10,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using FlowtideDotNet.Storage.StateManager.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace FlowtideDotNet.Storage.Persistence
+namespace FlowtideDotNet.Core.ColumnStore.Serialization
 {
-    public interface IPersistentStorageSession : IDisposable
+    public struct EventBatchDeserializeResult
     {
-        ValueTask<T> Read<T>(long key, IStateSerializer<T> stateSerializer)
-            where T : ICacheObject;
+        public EventBatchDeserializeResult(EventBatchData eventBatch, int count)
+        {
+            EventBatch = eventBatch;
+            Count = count;
+        }
 
-        ValueTask<ReadOnlyMemory<byte>> Read(long key);
-
-        Task Write(long key, SerializableObject value);
-
-        Task Delete(long key);
-
-        Task Commit();
+        public EventBatchData EventBatch { get; }
+        public int Count { get; }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnStoreSerializer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnStoreSerializer.cs
@@ -58,9 +58,10 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             return new ColumnKeyStorageContainer(recordBatch.ColumnCount, eventBatch, recordBatch.Length);
         }
 
-        public void Serialize(in BinaryWriter writer, in ColumnKeyStorageContainer values)
+        public void Serialize(in IBufferWriter<byte> writer, in ColumnKeyStorageContainer values)
         {
             var recordBatch = EventArrowSerializer.BatchToArrow(values._data, values.Count);
+            
             var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);
             batchWriter.WriteRecordBatch(recordBatch);
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnStoreSerializer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnStoreSerializer.cs
@@ -30,14 +30,16 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
     {
         private readonly int columnCount;
         private readonly IMemoryAllocator memoryAllocator;
-        private readonly EventBatchSerializer _batchSerializer;
+        private readonly EventBatchBPlusTreeSerializer _batchSerializer;
+        
 
         public ColumnStoreSerializer(int columnCount, IMemoryAllocator memoryAllocator)
         {
             this.columnCount = columnCount;
             this.memoryAllocator = memoryAllocator;
-            _batchSerializer = new EventBatchSerializer();
+            _batchSerializer = new EventBatchBPlusTreeSerializer();
         }
+
         public ColumnKeyStorageContainer CreateEmpty()
         {
             return new ColumnKeyStorageContainer(columnCount, memoryAllocator);
@@ -50,22 +52,15 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             return fieldInfo!;
         }
 
-        public ColumnKeyStorageContainer Deserialize(in BinaryReader reader)
+        public ColumnKeyStorageContainer Deserialize(ref SequenceReader<byte> reader)
         {
-            using var arrowReader = new ArrowStreamReader(reader.BaseStream, new Apache.Arrow.Memory.NativeMemoryAllocator(), true);
-            var recordBatch = arrowReader.ReadNextRecordBatch();
-
-            var eventBatch = EventArrowSerializer.ArrowToBatch(recordBatch, memoryAllocator);
-
-            return new ColumnKeyStorageContainer(recordBatch.ColumnCount, eventBatch, recordBatch.Length);
+            var batchResult = _batchSerializer.Deserialize(ref reader, memoryAllocator);
+            return new ColumnKeyStorageContainer(batchResult.EventBatch.Columns.Count, batchResult.EventBatch, batchResult.Count);
         }
 
         public void Serialize(in IBufferWriter<byte> writer, in ColumnKeyStorageContainer values)
         {
-            var recordBatch = EventArrowSerializer.BatchToArrow(values._data, values.Count);
-            
-            var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);
-            batchWriter.WriteRecordBatch(recordBatch);
+            _batchSerializer.Serialize(writer, values._data, values.Count);
         }
 
         public Task CheckpointAsync(IBPlusTreeSerializerCheckpointContext context)

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnValueSerializer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnValueSerializer.cs
@@ -13,6 +13,7 @@
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -51,7 +52,7 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in ColumnValueStorageContainer values)
+        public void Serialize(in IBufferWriter<byte> writer, in ColumnValueStorageContainer values)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnValueSerializer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnValueSerializer.cs
@@ -42,7 +42,7 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             return new ColumnValueStorageContainer(_columnCount, _memoryAllocator);
         }
 
-        public ColumnValueStorageContainer Deserialize(in BinaryReader reader)
+        public ColumnValueStorageContainer Deserialize(ref SequenceReader<byte> reader)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
@@ -268,9 +268,8 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
 
         public Span<byte> Get(in int index)
         {
-            var offset = _offsets.Get(index);
-            return AccessSpan.Slice(offset, _offsets.Get(index + 1) - offset);
-            
+                var offset = _offsets.Get(index);
+                return AccessSpan.Slice(offset, _offsets.Get(index + 1) - offset);
         }
 
         public Memory<byte> GetMemory(in int index)

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageSerializer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageSerializer.cs
@@ -18,6 +18,7 @@ using FlowtideDotNet.Core.Operators.Normalization;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -61,7 +62,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in ListAggKeyStorageContainer values)
+        public void Serialize(in IBufferWriter<byte> writer, in ListAggKeyStorageContainer values)
         {
             var recordBatch = EventArrowSerializer.BatchToArrow(values._data, values.Count);
             var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);

--- a/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
+++ b/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
@@ -20,10 +20,6 @@ using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
-using FlowtideDotNet.Core.Compute;
-using FlowtideDotNet.Core.Compute.Internal;
-using System.Diagnostics;
-using FlowtideDotNet.Core.Connectors;
 using Microsoft.Extensions.Options;
 using FlowtideDotNet.Base;
 

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeySerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeySerializer.cs
@@ -22,6 +22,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using FlowtideDotNet.Storage.Memory;
+using System.Buffers;
 
 namespace FlowtideDotNet.Core.Operators.Aggregate.Column
 {
@@ -57,7 +58,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             return new AggregateKeyStorageContainer(recordBatch.ColumnCount, eventBatch, recordBatch.Length);
         }
 
-        public void Serialize(in BinaryWriter writer, in AggregateKeyStorageContainer values)
+        public void Serialize(in IBufferWriter<byte> writer, in AggregateKeyStorageContainer values)
         {
             var recordBatch = EventArrowSerializer.BatchToArrow(values._data, values.Count);
             var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueSerializer.cs
@@ -31,11 +31,13 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
     {
         private readonly int measureCount;
         private readonly IMemoryAllocator memoryAllocator;
+        private readonly EventBatchBPlusTreeSerializer _batchSerializer;
 
         public ColumnAggregateValueSerializer(int measureCount, IMemoryAllocator memoryAllocator)
         {
             this.measureCount = measureCount;
             this.memoryAllocator = memoryAllocator;
+            _batchSerializer = new EventBatchBPlusTreeSerializer();
         }
 
         public Task CheckpointAsync(IBPlusTreeSerializerCheckpointContext context)
@@ -48,27 +50,36 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             return new ColumnAggregateValueContainer(measureCount, memoryAllocator);
         }
 
-        public ColumnAggregateValueContainer Deserialize(in BinaryReader reader)
+        public ColumnAggregateValueContainer Deserialize(ref SequenceReader<byte> reader)
         {
-            var previousValueLength = reader.ReadInt32();
-            var previousValueMemory = reader.ReadBytes(previousValueLength);
+            if (!reader.TryReadLittleEndian(out int previousValueLength))
+            {
+                throw new InvalidOperationException("Failed to read previous value length");
+            }
             var previousValueNativeMemory = memoryAllocator.Allocate(previousValueLength, 64);
+            var slice = previousValueNativeMemory.Memory.Span.Slice(0, previousValueLength);
+            if (!reader.TryCopyTo(slice))
+            {
+                throw new InvalidOperationException("Failed to read previous value");
+            }
+            reader.Advance(previousValueLength);
 
-            previousValueMemory.CopyTo(previousValueNativeMemory.Memory.Span);
-
-            var weightLength = reader.ReadInt32();
-            var weightMemory = reader.ReadBytes(weightLength);
+            if (!reader.TryReadLittleEndian(out int weightLength))
+            {
+                throw new InvalidOperationException("Failed to read weight length");
+            }
             var weightNativeMemory = memoryAllocator.Allocate(weightLength, 64);
-            weightMemory.CopyTo(weightNativeMemory.Memory.Span);
+            if (!reader.TryCopyTo(weightNativeMemory.Memory.Span.Slice(0, weightLength)))
+            {
+                throw new InvalidOperationException("Failed to read weight");
+            }
+            reader.Advance(weightLength);
 
-            using var arrowReader = new ArrowStreamReader(reader.BaseStream, new Apache.Arrow.Memory.NativeMemoryAllocator(), true);
-            var recordBatch = arrowReader.ReadNextRecordBatch();
+            var eventBatchResult = _batchSerializer.Deserialize(ref reader, memoryAllocator);
+            var previousValueList = new PrimitiveList<bool>(previousValueNativeMemory, eventBatchResult.Count, memoryAllocator);
+            var weightsList = new PrimitiveList<int>(weightNativeMemory, eventBatchResult.Count, memoryAllocator);
 
-            var eventBatch = EventArrowSerializer.ArrowToBatch(recordBatch, memoryAllocator);
-            var previousValueList = new PrimitiveList<bool>(previousValueNativeMemory, recordBatch.Length, memoryAllocator);
-            var weightsList = new PrimitiveList<int>(weightNativeMemory, recordBatch.Length, memoryAllocator);
-
-            return new ColumnAggregateValueContainer(measureCount, eventBatch, weightsList, previousValueList);
+            return new ColumnAggregateValueContainer(measureCount, eventBatchResult.EventBatch, weightsList, previousValueList);
         }
 
         public Task InitializeAsync(IBPlusTreeSerializerInitializeContext context)
@@ -82,18 +93,16 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             var lengthSpan = writer.GetSpan(4);
             BinaryPrimitives.WriteInt32LittleEndian(lengthSpan, previousValueMemory.Length);
             writer.Advance(4);
-            //writer.Write(previousValueMemory.Length);
+
             writer.Write(previousValueMemory.Span);
             var weightMemory = values._weights.SlicedMemory;
             lengthSpan = writer.GetSpan(4);
             BinaryPrimitives.WriteInt32LittleEndian(lengthSpan, weightMemory.Length);
             writer.Advance(4);
-            //writer.Write(weightMemory.Length);
+
             writer.Write(weightMemory.Span);
 
-            var recordBatch = EventArrowSerializer.BatchToArrow(values._eventBatch, values._weights.Count);
-            var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);
-            batchWriter.WriteRecordBatch(recordBatch);
+            _batchSerializer.Serialize(writer, values._eventBatch, values._weights.Count);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsSerializer.cs
@@ -13,6 +13,8 @@
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -58,12 +60,17 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in JoinWeightsValueContainer values)
+        public void Serialize(in IBufferWriter<byte> writer, in JoinWeightsValueContainer values)
         {
             var memory = values.Memory;
 
-            writer.Write(values.Count);
-            writer.Write(memory.Length);
+            var headerSpan = writer.GetSpan(8);
+            BinaryPrimitives.WriteInt32LittleEndian(headerSpan, values.Count);
+            BinaryPrimitives.WriteInt32LittleEndian(headerSpan.Slice(4), memory.Length);
+            writer.Advance(8);
+
+            //writer.Write(values.Count);
+            //writer.Write(memory.Length);
             writer.Write(memory.Span);
         }
     }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorageSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorageSerializer.cs
@@ -16,6 +16,7 @@ using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -59,7 +60,7 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in NormalizeKeyStorage values)
+        public void Serialize(in IBufferWriter<byte> writer, in NormalizeKeyStorage values)
         {
             var recordBatch = EventArrowSerializer.BatchToArrow(values._data, values.Count);
             var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueSerializer.cs
@@ -16,6 +16,7 @@ using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -59,7 +60,7 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in NormalizeValueStorage values)
+        public void Serialize(in IBufferWriter<byte> writer, in NormalizeValueStorage values)
         {
             var recordBatch = EventArrowSerializer.BatchToArrow(values._data, values.Count);
             var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueSerializer.cs
@@ -28,11 +28,13 @@ namespace FlowtideDotNet.Core.Operators.Normalization
     {
         private readonly List<int> _columnsToStore;
         private readonly IMemoryAllocator _memoryAllocator;
+        private readonly EventBatchBPlusTreeSerializer _batchSerializer;
 
         public NormalizeValueSerializer(List<int> columnsToStore, IMemoryAllocator memoryAllocator)
         {
             _columnsToStore = columnsToStore;
             _memoryAllocator = memoryAllocator;
+            _batchSerializer = new EventBatchBPlusTreeSerializer();
         }
 
         public Task CheckpointAsync(IBPlusTreeSerializerCheckpointContext context)
@@ -45,14 +47,10 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             return new NormalizeValueStorage(_columnsToStore, _memoryAllocator);    
         }
 
-        public NormalizeValueStorage Deserialize(in BinaryReader reader)
+        public NormalizeValueStorage Deserialize(ref SequenceReader<byte> reader)
         {
-            using var arrowReader = new ArrowStreamReader(reader.BaseStream, new Apache.Arrow.Memory.NativeMemoryAllocator(), true);
-            var recordBatch = arrowReader.ReadNextRecordBatch();
-
-            var eventBatch = EventArrowSerializer.ArrowToBatch(recordBatch, _memoryAllocator);
-
-            return new NormalizeValueStorage(_columnsToStore, eventBatch, recordBatch.Length);
+            var batchResult = _batchSerializer.Deserialize(ref reader, _memoryAllocator);
+            return new NormalizeValueStorage(_columnsToStore, batchResult.EventBatch, batchResult.Count);
         }
 
         public Task InitializeAsync(IBPlusTreeSerializerInitializeContext context)
@@ -62,9 +60,7 @@ namespace FlowtideDotNet.Core.Operators.Normalization
 
         public void Serialize(in IBufferWriter<byte> writer, in NormalizeValueStorage values)
         {
-            var recordBatch = EventArrowSerializer.BatchToArrow(values._data, values.Count);
-            var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);
-            batchWriter.WriteRecordBatch(recordBatch);
+            _batchSerializer.Serialize(writer, values._data, values.Count);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedKeyStorageSerializer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedKeyStorageSerializer.cs
@@ -17,6 +17,7 @@ using FlowtideDotNet.Core.Operators.Normalization;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -60,7 +61,7 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in ModifiedKeyStorage values)
+        public void Serialize(in IBufferWriter<byte> writer, in ModifiedKeyStorage values)
         {
             var recordBatch = EventArrowSerializer.BatchToArrow(values._data, values.Count);
             var batchWriter = new ArrowStreamWriter(writer.BaseStream, recordBatch.Schema, true);

--- a/src/FlowtideDotNet.Core/Sinks/Console/ConsoleSink.cs
+++ b/src/FlowtideDotNet.Core/Sinks/Console/ConsoleSink.cs
@@ -28,7 +28,7 @@ namespace FlowtideDotNet.Core.Sinks
     internal class ConsoleSink : EgressVertex<StreamEventBatch, object>
     {
         private readonly WriteRelation writeRelation;
-        private IBPlusTree<ColumnRowReference, int, ColumnKeyStorageContainer, ListValueContainer<int>>? _tree;
+        private IBPlusTree<ColumnRowReference, int, ColumnKeyStorageContainer, PrimitiveListValueContainer<int>>? _tree;
         private bool m_initialDataSent;
 
         public ConsoleSink(WriteRelation writeRelation, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionDataflowBlockOptions)
@@ -50,13 +50,13 @@ namespace FlowtideDotNet.Core.Sinks
 
         protected override async Task InitializeOrRestore(long restoreTime, object? state, IStateManagerClient stateManagerClient)
         {
-            _tree = await stateManagerClient.GetOrCreateTree("tree", new BPlusTreeOptions<ColumnRowReference, int, ColumnKeyStorageContainer, ListValueContainer<int>>()
+            _tree = await stateManagerClient.GetOrCreateTree("tree", new BPlusTreeOptions<ColumnRowReference, int, ColumnKeyStorageContainer, PrimitiveListValueContainer<int>>()
             {
                 Comparer = new ColumnComparer(writeRelation.OutputLength),
                 KeySerializer = new ColumnStoreSerializer(writeRelation.OutputLength, MemoryAllocator),
                 MemoryAllocator = MemoryAllocator,
                 UseByteBasedPageSizes = true,
-                ValueSerializer = new ValueListSerializer<int>(new IntSerializer())
+                ValueSerializer = new PrimitiveListValueContainerSerializer<int>(MemoryAllocator)
             });
         }
 

--- a/src/FlowtideDotNet.DependencyInjection/Extensions/FlowtideStorageExtensions.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Extensions/FlowtideStorageExtensions.cs
@@ -34,7 +34,7 @@ namespace FlowtideDotNet.DependencyInjection
             FileCacheOptions fileCacheOptions = new FileCacheOptions();
             options?.Invoke(fileCacheOptions);
             storageBuilder.SetPersistentStorage(new FileCachePersistentStorage(fileCacheOptions));
-            storageBuilder.ZLibCompression();
+            storageBuilder.ZstdPageCompression();
             return storageBuilder;
         }
 
@@ -51,7 +51,7 @@ namespace FlowtideDotNet.DependencyInjection
                 MemorySize = 1024 * 1024 * 32,
                 PageSize = 1024 * 1024 * 16
             }));
-            storageBuilder.ZLibCompression();
+            storageBuilder.ZstdPageCompression();
             return storageBuilder;
         }
         
@@ -91,23 +91,18 @@ namespace FlowtideDotNet.DependencyInjection
                     }
                 );
             });
-            storageBuilder.ZLibCompression();
+            storageBuilder.ZstdPageCompression();
 
             return storageBuilder;
         }
 
-        public static IFlowtideStorageBuilder ZLibCompression(this IFlowtideStorageBuilder storageBuilder)
+        public static IFlowtideStorageBuilder ZstdPageCompression(this IFlowtideStorageBuilder storageBuilder, int compressionLevel = 3)
         {
             return storageBuilder.SetCompressionFunction(new StateSerializeOptions()
             {
-                CompressFunc = (stream) =>
-                {
-                    return new ZLibStream(stream, CompressionMode.Compress);
-                },
-                DecompressFunc = (stream) =>
-                {
-                    return new ZLibStream(stream, CompressionMode.Decompress);
-                }
+                CompressionMethod = CompressionMethod.Page,
+                CompressionType = CompressionType.Zstd,
+                ComressionLevel = compressionLevel
             });
         }
 

--- a/src/FlowtideDotNet.DependencyInjection/Extensions/FlowtideStorageExtensions.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Extensions/FlowtideStorageExtensions.cs
@@ -98,7 +98,7 @@ namespace FlowtideDotNet.DependencyInjection
 
         public static IFlowtideStorageBuilder ZstdPageCompression(this IFlowtideStorageBuilder storageBuilder, int compressionLevel = 3)
         {
-            return storageBuilder.SetCompressionFunction(new StateSerializeOptions()
+            return storageBuilder.SetCompression(new StateSerializeOptions()
             {
                 CompressionMethod = CompressionMethod.Page,
                 CompressionType = CompressionType.Zstd,
@@ -108,7 +108,7 @@ namespace FlowtideDotNet.DependencyInjection
 
         public static IFlowtideStorageBuilder NoCompression(this IFlowtideStorageBuilder storageBuilder)
         {
-            return storageBuilder.SetCompressionFunction(new FlowtideDotNet.Storage.StateSerializeOptions());
+            return storageBuilder.SetCompression(new FlowtideDotNet.Storage.StateSerializeOptions());
         }
     }
 }

--- a/src/FlowtideDotNet.DependencyInjection/IFlowtideStorageBuilder.cs
+++ b/src/FlowtideDotNet.DependencyInjection/IFlowtideStorageBuilder.cs
@@ -38,7 +38,7 @@ namespace FlowtideDotNet.DependencyInjection
 
         IFlowtideStorageBuilder SetPersistentStorage(Func<IServiceProvider, IPersistentStorage> func);
 
-        IFlowtideStorageBuilder SetCompressionFunction(StateSerializeOptions serializeOptions);
+        IFlowtideStorageBuilder SetCompression(StateSerializeOptions serializeOptions);
 
         IServiceCollection ServiceCollection { get; }
 

--- a/src/FlowtideDotNet.DependencyInjection/Internal/FlowtideStorageBuilder.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Internal/FlowtideStorageBuilder.cs
@@ -28,7 +28,7 @@ namespace FlowtideDotNet.DependencyInjection.Internal
             this.services = services;
         }
 
-        public IFlowtideStorageBuilder SetCompressionFunction(StateSerializeOptions serializeOptions)
+        public IFlowtideStorageBuilder SetCompression(StateSerializeOptions serializeOptions)
         {
             services.AddKeyedSingleton(name, serializeOptions);
             return this;

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorage.cs
@@ -196,15 +196,21 @@ namespace FlowtideDotNet.Storage.SqlServer
             _stream.Reset();
         }
 
-        public bool TryGetValue(long key, [NotNullWhen(true)] out byte[]? value)
+        public bool TryGetValue(long key, [NotNullWhen(true)] out ReadOnlyMemory<byte>? value)
         {
 #if DEBUG_WRITE
             _debugWriter!.WriteCall([key]);
 #endif
 
             Debug.Assert(_storageRepository != null, "Stream repository should be initialized");
-            value = _storageRepository.Read(key);
-            return value != null;
+            var bytes = _storageRepository.Read(key);
+            if (bytes != null)
+            {
+                value = bytes;
+                return true;
+            }
+            value = null;
+            return false;
         }
 
         public ValueTask Write(long key, byte[] value)

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/FileCacheBufferWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/FileCacheBufferWriter.cs
@@ -30,6 +30,8 @@ namespace FlowtideDotNet.Storage.FileCache.Internal
 
         public Memory<byte> Memory => SliceMemory();
 
+        public int Position => _position;
+
         private Memory<byte> SliceMemory()
         {
             var alignedLength = (_position + sectorSize - 1) / sectorSize * sectorSize;
@@ -51,13 +53,11 @@ namespace FlowtideDotNet.Storage.FileCache.Internal
             var alignedLength = (estimatedSize + sectorSize - 1) / sectorSize * sectorSize;
             if (_memory == null)
             {
-
                 _memory = memoryAllocator.Allocate(alignedLength, sectorSize);
             }
             else if (_memory.Memory.Length < alignedLength)
             {
-                _memory.Dispose();
-                _memory = memoryAllocator.Allocate(alignedLength, sectorSize);
+                _memory = memoryAllocator.Realloc(_memory, alignedLength, sectorSize);
             }
             _position = 0;
         }
@@ -81,7 +81,7 @@ namespace FlowtideDotNet.Storage.FileCache.Internal
             var alignedLength = (newLength + sectorSize - 1) / sectorSize * sectorSize;
             if (_memory.Memory.Length < alignedLength)
             {
-                _memory = memoryAllocator.Allocate(alignedLength,  sectorSize);
+                _memory = memoryAllocator.Realloc(_memory, alignedLength,  sectorSize);
             }
             return _memory.Memory.Slice(_position);
         }

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/FileCacheBufferWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/FileCacheBufferWriter.cs
@@ -1,0 +1,94 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Memory;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage.FileCache.Internal
+{
+    internal class FileCacheBufferWriter : IBufferWriter<byte>, IDisposable
+    {
+        private readonly IMemoryAllocator memoryAllocator;
+        private readonly int sectorSize;
+        private IMemoryOwner<byte>? _memory;
+        private int _position;
+
+        public Memory<byte> Memory => SliceMemory();
+
+        private Memory<byte> SliceMemory()
+        {
+            var alignedLength = (_position + sectorSize - 1) / sectorSize * sectorSize;
+            return _memory?.Memory.Slice(0, alignedLength) ?? Memory<byte>.Empty;
+        }
+
+        public FileCacheBufferWriter(IMemoryAllocator memoryAllocator, int sectorSize)
+        {
+            this.memoryAllocator = memoryAllocator;
+            this.sectorSize = sectorSize;
+        }
+        public void Advance(int count)
+        {
+            _position += count;
+        }
+
+        public void Reset(int estimatedSize)
+        {
+            var alignedLength = (estimatedSize + sectorSize - 1) / sectorSize * sectorSize;
+            if (_memory == null)
+            {
+
+                _memory = memoryAllocator.Allocate(alignedLength, sectorSize);
+            }
+            else if (_memory.Memory.Length < alignedLength)
+            {
+                _memory.Dispose();
+                _memory = memoryAllocator.Allocate(alignedLength, sectorSize);
+            }
+            _position = 0;
+        }
+
+        public void Dispose()
+        {
+            if (_memory != null)
+            {
+                _memory.Dispose();
+            }
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            Debug.Assert(_memory != null);
+            if (sizeHint < 4096)
+            {
+                sizeHint = 4096;
+            }
+            var newLength = _position + sizeHint;
+            var alignedLength = (newLength + sectorSize - 1) / sectorSize * sectorSize;
+            if (_memory.Memory.Length < alignedLength)
+            {
+                _memory = memoryAllocator.Allocate(alignedLength,  sectorSize);
+            }
+            return _memory.Memory.Slice(_position);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            return GetMemory(sizeHint).Span;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/FileCacheSegmentWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/FileCacheSegmentWriter.cs
@@ -48,13 +48,13 @@ namespace FlowtideDotNet.Storage.FileCache
             fileStream = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite, fileCacheOptions.FileShare, 512, FileOptions.DeleteOnClose | FileOptions.RandomAccess);
         }
 
-        public void Write(long position, byte[] data)
+        public void Write(long position, Memory<byte> data)
         {
             semaphoreSlim.Wait();
             try
             {
                 fileStream.Position = position;
-                fileStream.Write(data);
+                fileStream.Write(data.Span);
             }
             finally
             {

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/FileCacheSegmentWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/FileCacheSegmentWriter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Storage.FileCache.Internal;
+using FlowtideDotNet.Storage.StateManager.Internal;
 
 namespace FlowtideDotNet.Storage.FileCache
 {
@@ -62,7 +63,24 @@ namespace FlowtideDotNet.Storage.FileCache
             }
         }
 
-        public byte[] Read(long position, int length)
+        public T Read<T>(long position, int length, IStateSerializer<T> serializer)
+            where T : ICacheObject
+        {
+            semaphoreSlim.Wait();
+            try
+            {
+                var bytes = new byte[length];
+                fileStream.Position = position;
+                fileStream.Read(bytes);
+                return serializer.Deserialize(bytes, bytes.Length);
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
+        }
+
+        public ReadOnlyMemory<byte> Read(long position, int length)
         {
             semaphoreSlim.Wait();
             try

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/IFileCacheWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/IFileCacheWriter.cs
@@ -10,12 +10,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage.StateManager.Internal;
+
 namespace FlowtideDotNet.Storage.FileCache.Internal
 {
     public interface IFileCacheWriter : IDisposable
     {
         void Write(long position, Memory<byte> data);
-        byte[] Read(long position, int length);
+        ReadOnlyMemory<byte> Read(long position, int length);
+        T Read<T>(long position, int length, IStateSerializer<T> serializer)
+            where T: ICacheObject;
         void Flush();
         void ClearTemporaryAllocations();
     }

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/IFileCacheWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/IFileCacheWriter.cs
@@ -14,7 +14,7 @@ namespace FlowtideDotNet.Storage.FileCache.Internal
 {
     public interface IFileCacheWriter : IDisposable
     {
-        void Write(long position, byte[] data);
+        void Write(long position, Memory<byte> data);
         byte[] Read(long position, int length);
         void Flush();
         void ClearTemporaryAllocations();

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/Unix/AlignedBuffer.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/Unix/AlignedBuffer.cs
@@ -10,11 +10,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Buffers;
 using System.Runtime.InteropServices;
 
 namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
 {
-    internal class AlignedBuffer : IDisposable
+    internal class AlignedBuffer : MemoryManager<byte>, IDisposable
     {
         private IntPtr buffer;
         private int bufferSize;
@@ -34,7 +35,7 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
             buffer = new IntPtr(alignedPtr);
         }
 
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
             if (allocated != IntPtr.Zero)
             {
@@ -42,6 +43,20 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
                 buffer = IntPtr.Zero;
                 allocated = IntPtr.Zero;
             }
+        }
+
+        public unsafe override Span<byte> GetSpan()
+        {
+            return new Span<byte>(buffer.ToPointer(), bufferSize);
+        }
+
+        public unsafe override MemoryHandle Pin(int elementIndex = 0)
+        {
+            return new MemoryHandle(((byte*)buffer.ToPointer()) + elementIndex, default, default);
+        }
+
+        public override void Unpin()
+        {
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/Unix/FileCacheUnixDirectWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/Unix/FileCacheUnixDirectWriter.cs
@@ -10,6 +10,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage.StateManager.Internal;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
@@ -85,25 +88,6 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
         {
             lock (_lock)
             {
-                //var alignedLength = (data.Length + alignment - 1) / alignment * alignment;
-
-                //if (alignedBuffer == null)
-                //{
-                //    alignedBuffer = new AlignedBuffer(alignedLength, alignment);
-                //}
-
-                //if (alignedLength > alignedBuffer.Size)
-                //{
-                //    alignedBuffer.Dispose();
-                //    alignedBuffer = new AlignedBuffer(alignedLength, alignment);
-                //}
-
-                //if (position % alignment != 0)
-                //{
-                //    throw new ArgumentException("Position must be aligned to block size.");
-                //}
-                //Marshal.Copy(data, 0, alignedBuffer.Buffer, data.Length);
-                
                 IntPtr bytesWritten = pwrite(fileDescriptor, (nint)data.Pin().Pointer, (IntPtr)data.Length, (IntPtr)position);
                 if (bytesWritten.ToInt64() <= 0)
                 {
@@ -114,37 +98,39 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
             }
         }
 
-        public byte[] Read(long position, int length)
+        public ReadOnlyMemory<byte> Read(long position, int length)
         {
             lock (_lock)
             {
-                if (position % alignment != 0)
-                {
-                    throw new ArgumentException("Offset must be aligned to block size.");
-                }
-                var alignedLength = (length + alignment - 1) / alignment * alignment;
-
-                if (alignedBuffer == null)
-                {
-                    alignedBuffer = new AlignedBuffer(alignedLength, alignment);
-                }
-
-                if (alignedLength > alignedBuffer.Size)
-                {
-                    alignedBuffer.Dispose();
-                    alignedBuffer = new AlignedBuffer(alignedLength, alignment);
-                }
-
-                IntPtr bytesRead = pread(fileDescriptor, alignedBuffer.Buffer, (IntPtr)alignedLength, (IntPtr)position);
-                if (bytesRead.ToInt64() <= 0)
-                {
-                    return Array.Empty<byte>(); // End of file or error
-                }
+                ReadIntoAlignedBuffer_NoLock(position, length);
 
                 byte[] buffer = new byte[length];
                 Marshal.Copy(alignedBuffer.Buffer, buffer, 0, length);
                 return buffer;
             }
+        }
+
+        [MemberNotNull(nameof(alignedBuffer))]
+        private void ReadIntoAlignedBuffer_NoLock(long position, int length)
+        {
+            if (position % alignment != 0)
+            {
+                throw new ArgumentException("Offset must be aligned to block size.");
+            }
+            var alignedLength = (length + alignment - 1) / alignment * alignment;
+
+            if (alignedBuffer == null)
+            {
+                alignedBuffer = new AlignedBuffer(alignedLength, alignment);
+            }
+
+            if (alignedLength > alignedBuffer.Size)
+            {
+                (alignedBuffer as IDisposable).Dispose();
+                alignedBuffer = new AlignedBuffer(alignedLength, alignment);
+            }
+
+            IntPtr bytesRead = pread(fileDescriptor, alignedBuffer.Buffer, (IntPtr)alignedLength, (IntPtr)position);
         }
 
         public void Flush()
@@ -158,7 +144,7 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
             {
                 if (alignedBuffer != null)
                 {
-                    alignedBuffer.Dispose();
+                    (alignedBuffer as IDisposable).Dispose();
                     alignedBuffer = null;
                 }
             }
@@ -172,7 +158,7 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
                 {
                     if (alignedBuffer != null)
                     {
-                        alignedBuffer.Dispose();
+                        (alignedBuffer as IDisposable).Dispose();
                         alignedBuffer = null;
                     }
                     if (fileDescriptor != -1)
@@ -194,6 +180,17 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+        }
+
+        public T Read<T>(long position, int length, IStateSerializer<T> serializer) where T : ICacheObject
+        {
+            lock (_lock)
+            {
+                ReadIntoAlignedBuffer_NoLock(position, length);
+
+                return serializer.Deserialize(alignedBuffer.Memory, length);
+            }
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/Unix/FileCacheUnixDirectWriter.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/Unix/FileCacheUnixDirectWriter.cs
@@ -81,29 +81,30 @@ namespace FlowtideDotNet.Storage.FileCache.Internal.Unix
             }
         }
 
-        public void Write(long position, byte[] data)
+        public unsafe void Write(long position, Memory<byte> data)
         {
             lock (_lock)
             {
-                var alignedLength = (data.Length + alignment - 1) / alignment * alignment;
+                //var alignedLength = (data.Length + alignment - 1) / alignment * alignment;
 
-                if (alignedBuffer == null)
-                {
-                    alignedBuffer = new AlignedBuffer(alignedLength, alignment);
-                }
+                //if (alignedBuffer == null)
+                //{
+                //    alignedBuffer = new AlignedBuffer(alignedLength, alignment);
+                //}
 
-                if (alignedLength > alignedBuffer.Size)
-                {
-                    alignedBuffer.Dispose();
-                    alignedBuffer = new AlignedBuffer(alignedLength, alignment);
-                }
+                //if (alignedLength > alignedBuffer.Size)
+                //{
+                //    alignedBuffer.Dispose();
+                //    alignedBuffer = new AlignedBuffer(alignedLength, alignment);
+                //}
 
-                if (position % alignment != 0)
-                {
-                    throw new ArgumentException("Position must be aligned to block size.");
-                }
-                Marshal.Copy(data, 0, alignedBuffer.Buffer, data.Length);
-                IntPtr bytesWritten = pwrite(fileDescriptor, alignedBuffer.Buffer, (IntPtr)alignedLength, (IntPtr)position);
+                //if (position % alignment != 0)
+                //{
+                //    throw new ArgumentException("Position must be aligned to block size.");
+                //}
+                //Marshal.Copy(data, 0, alignedBuffer.Buffer, data.Length);
+                
+                IntPtr bytesWritten = pwrite(fileDescriptor, (nint)data.Pin().Pointer, (IntPtr)data.Length, (IntPtr)position);
                 if (bytesWritten.ToInt64() <= 0)
                 {
                     int errorCode = Marshal.GetLastWin32Error();

--- a/src/FlowtideDotNet.Storage/FlowtideDotNet.Storage.csproj
+++ b/src/FlowtideDotNet.Storage/FlowtideDotNet.Storage.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.10" />
     <PackageReference Include="Microsoft.FASTER.Core" Version="2.6.1" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.4" />
   </ItemGroup>
 
 </Project>

--- a/src/FlowtideDotNet.Storage/Memory/NativeCreatedMemoryOwner.cs
+++ b/src/FlowtideDotNet.Storage/Memory/NativeCreatedMemoryOwner.cs
@@ -44,7 +44,7 @@ namespace FlowtideDotNet.Storage.Memory
 
         public override MemoryHandle Pin(int elementIndex = 0)
         {
-            return new MemoryHandle(ptr, default, default);
+            return new MemoryHandle(((byte*)ptr) + elementIndex, default, default);
         }
 
         public override void Unpin()

--- a/src/FlowtideDotNet.Storage/Memory/PreAllocatedMemoryOwner.cs
+++ b/src/FlowtideDotNet.Storage/Memory/PreAllocatedMemoryOwner.cs
@@ -39,7 +39,7 @@ namespace FlowtideDotNet.Storage.Memory
 
         public override MemoryHandle Pin(int elementIndex = 0)
         {
-            return new MemoryHandle(ptr, default, default);
+            return new MemoryHandle(((byte*)ptr) + elementIndex, default, default);
         }
 
         public override void Unpin()

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
@@ -43,7 +43,11 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
 
         public virtual Task Write(long key, byte[] value)
         {
-            fileCache.WriteAsync(key, value);
+            var byteWriter = fileCache.BeginWrite(key, value.Length);
+            var span = byteWriter.GetSpan(value.Length);
+            value.CopyTo(span);
+            byteWriter.Advance(value.Length);
+            fileCache.EndWrite(key, byteWriter);
             fileCache.Flush();
             return Task.CompletedTask;
         }

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage.StateManager.Internal;
+
 namespace FlowtideDotNet.Storage.Persistence.CacheStorage
 {
     internal class FileCachePersistentSession : IPersistentStorageSession
@@ -36,18 +38,20 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
         {
         }
 
-        public ValueTask<byte[]> Read(long key)
+        public ValueTask<ReadOnlyMemory<byte>> Read(long key)
         {
             return ValueTask.FromResult(fileCache.Read(key));
         }
 
-        public virtual Task Write(long key, byte[] value)
+        public ValueTask<T> Read<T>(long key, IStateSerializer<T> serializer)
+            where T : ICacheObject
         {
-            var byteWriter = fileCache.BeginWrite(key, value.Length);
-            var span = byteWriter.GetSpan(value.Length);
-            value.CopyTo(span);
-            byteWriter.Advance(value.Length);
-            fileCache.EndWrite(key, byteWriter);
+            return ValueTask.FromResult(fileCache.Read(key, serializer));
+        }
+
+        public virtual Task Write(long key, SerializableObject value)
+        {
+            fileCache.Write(key, value);
             fileCache.Flush();
             return Task.CompletedTask;
         }

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentStorage.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Storage.FileCache;
 using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.StateManager.Internal;
 using System.Diagnostics.CodeAnalysis;
 
 namespace FlowtideDotNet.Storage.Persistence.CacheStorage
@@ -77,7 +78,7 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
             return ValueTask.CompletedTask;
         }
 
-        public bool TryGetValue(long key, [NotNullWhen(true)] out byte[]? value)
+        public bool TryGetValue(long key, [NotNullWhen(true)] out ReadOnlyMemory<byte>? value)
         {
             if (m_fileCache.Exists(key))
             {
@@ -90,11 +91,7 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
 
         public virtual ValueTask Write(long key, byte[] value)
         {
-            var byteWriter = m_fileCache.BeginWrite(key, value.Length);
-            var span = byteWriter.GetSpan(value.Length);
-            value.CopyTo(span);
-            byteWriter.Advance(value.Length);
-            m_fileCache.EndWrite(key, byteWriter);
+            m_fileCache.Write(key, new SerializableObject(value));
             m_fileCache.Flush();
             return ValueTask.CompletedTask;
         }

--- a/src/FlowtideDotNet.Storage/Persistence/FasterStorage/FasterKVPersistentSession.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/FasterStorage/FasterKVPersistentSession.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Storage.StateManager.Internal;
 using FASTER.core;
+using System.Buffers;
 
 namespace FlowtideDotNet.Storage.Persistence.FasterStorage
 {
@@ -41,7 +42,7 @@ namespace FlowtideDotNet.Storage.Persistence.FasterStorage
             session.Dispose();
         }
 
-        public async ValueTask<byte[]> Read(long key)
+        public async ValueTask<ReadOnlyMemory<byte>> Read(long key)
         {
             using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             var result = await session.ReadAsync(ref key, token: tokenSource.Token);
@@ -53,15 +54,40 @@ namespace FlowtideDotNet.Storage.Persistence.FasterStorage
             return bytes;
         }
 
-        public async Task Write(long key, byte[] value)
+        public async ValueTask<T> Read<T>(long key, IStateSerializer<T> serializer)
+            where T: ICacheObject
         {
-            var mem = new Memory<byte>(value);
-            var handle = mem.Pin();
-            var spanByte = SpanByte.FromPinnedMemory(value);
+            var memory = await Read(key);
+            return serializer.Deserialize(memory, memory.Length);
+        }
+
+        private unsafe SpanByte CreateSpanByteFromHandle(MemoryHandle handle, int length)
+        {
+            var spanByte = SpanByte.FromPointer((byte*)handle.Pointer, length);
+            return spanByte;
+        }
+
+        public async Task Write(long key, SerializableObject value)
+        {
             using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            var result = await session.UpsertAsync(key, spanByte, token: tokenSource.Token);
-            var status = result.Complete();
-            handle.Dispose();
+            if (value.PreSerializedData.HasValue)
+            {
+                var handle = value.PreSerializedData.Value.Pin();
+                var spanByte = CreateSpanByteFromHandle(handle, value.PreSerializedData.Value.Length);
+                var result = await session.UpsertAsync(key, spanByte, token: tokenSource.Token);
+                var status = result.Complete();
+                handle.Dispose();
+            }
+            else
+            {
+                var writer = new ArrayBufferWriter<byte>();
+                value.Serialize(writer);
+                var handle = writer.WrittenMemory.Pin();
+                var spanByte = CreateSpanByteFromHandle(handle, writer.WrittenMemory.Length);
+                var result = await session.UpsertAsync(key, spanByte, token: tokenSource.Token);
+                var status = result.Complete();
+                handle.Dispose();
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Persistence/FasterStorage/FasterKvPersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/FasterStorage/FasterKvPersistentStorage.cs
@@ -102,7 +102,7 @@ namespace FlowtideDotNet.Storage.Persistence.FasterStorage
             await m_persistentStorage.RecoverAsync(recoverTo: checkpointVersion);
         }
 
-        public bool TryGetValue(long key, [NotNullWhen(true)] out byte[]? value)
+        public bool TryGetValue(long key, [NotNullWhen(true)] out ReadOnlyMemory<byte>? value)
         {
             var result = m_adminSession.Read(key);
             if (result.status.Found || result.status.IsPending)

--- a/src/FlowtideDotNet.Storage/Persistence/IPersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/IPersistentStorage.cs
@@ -64,7 +64,7 @@ namespace FlowtideDotNet.Storage.Persistence
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        bool TryGetValue(long key, [NotNullWhen(true)] out byte[]? value);
+        bool TryGetValue(long key, [NotNullWhen(true)] out ReadOnlyMemory<byte>? value);
 
         /// <summary>
         /// Used by administrative operations to write metadata.

--- a/src/FlowtideDotNet.Storage/SerializableObject.cs
+++ b/src/FlowtideDotNet.Storage/SerializableObject.cs
@@ -1,0 +1,66 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.StateManager.Internal;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage
+{
+    public struct SerializableObject
+    {
+        private ICacheObject? obj;
+
+        private IStateSerializer? serializer;
+
+        // If writing from file cache directly to persistence, the data is passed directly
+        private ReadOnlyMemory<byte>? serialized;
+
+        public bool HasPreSerializedData => serialized.HasValue;
+
+        public ReadOnlyMemory<byte>? PreSerializedData => serialized;
+
+        public SerializableObject(ICacheObject obj, IStateSerializer serializer)
+        {
+            this.obj = obj;
+            this.serializer = serializer;
+            serialized = null;
+        }
+
+        public SerializableObject(ReadOnlyMemory<byte> serialized)
+        {
+            this.obj = null;
+            this.serializer = null;
+            this.serialized = serialized;
+        }
+
+        public void Serialize(IBufferWriter<byte> writer)
+        {
+            if (serialized.HasValue)
+            {
+                writer.Write(serialized.Value.Span);
+            }
+            else
+            {
+                if (obj == null || serializer == null)
+                {
+                    throw new InvalidOperationException("Object not initialized");
+                }
+                serializer.Serialize(writer, obj);
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/Serializers/KeyListSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Serializers/KeyListSerializer.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -50,9 +51,12 @@ namespace FlowtideDotNet.Storage.Serializers
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in ListKeyContainer<K> values)
+        public void Serialize(in IBufferWriter<byte> writer, in ListKeyContainer<K> values)
         {
-            serializer.Serialize(writer, values._list);
+            using MemoryStream memoryStream = new MemoryStream();
+            using BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+            serializer.Serialize(binaryWriter, values._list);
+            writer.Write(memoryStream.ToArray());
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Serializers/PrimitiveListValueContainerSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Serializers/PrimitiveListValueContainerSerializer.cs
@@ -13,6 +13,8 @@
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -59,12 +61,17 @@ namespace FlowtideDotNet.Storage.Serializers
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in PrimitiveListValueContainer<T> values)
+        public void Serialize(in IBufferWriter<byte> writer, in PrimitiveListValueContainer<T> values)
         {
             var memory = values.Memory;
 
-            writer.Write(values.Count);
-            writer.Write(memory.Length);
+            var headerInfo = writer.GetSpan(8);
+            BinaryPrimitives.WriteInt32LittleEndian(headerInfo, values.Count);
+            BinaryPrimitives.WriteInt32LittleEndian(headerInfo.Slice(4), memory.Length);
+            writer.Advance(8);
+
+            //writer.Write(values.Count);
+            //writer.Write(memory.Length);
             writer.Write(memory.Span);
         }
     }

--- a/src/FlowtideDotNet.Storage/Serializers/ValueListSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Serializers/ValueListSerializer.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -50,9 +51,14 @@ namespace FlowtideDotNet.Storage.Serializers
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in ListValueContainer<V> values)
+        public void Serialize(in IBufferWriter<byte> writer, in ListValueContainer<V> values)
         {
-            serializer.Serialize(writer, values._values);
+            using MemoryStream memoryStream = new MemoryStream();
+            using BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+            serializer.Serialize(binaryWriter, values._values);
+            writer.Write(memoryStream.ToArray());
+
+            //serializer.Serialize(writer, values._values);
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/CompressedStateSerializer.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/CompressedStateSerializer.cs
@@ -91,7 +91,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
 
         public void Serialize(in IBufferWriter<byte> bufferWriter, in ICacheObject value)
         {
-            if (value is IBPlusTreeNode node)
+            if (value is TValue node)
             {
                 Serialize(bufferWriter, node);
                 return;

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/IStateSerializer.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/IStateSerializer.cs
@@ -14,11 +14,11 @@ using System.Buffers;
 
 namespace FlowtideDotNet.Storage.StateManager.Internal
 {
-    internal interface IStateSerializer
+    public interface IStateSerializer
     {
-        void Serialize(in IBufferWriter<byte> bufferWriter, in ICacheObject value, in StateSerializeOptions stateSerializeOptions);
+        void Serialize(in IBufferWriter<byte> bufferWriter, in ICacheObject value);
 
-        ICacheObject DeserializeCacheObject(IMemoryOwner<byte> bytes, int length, StateSerializeOptions stateSerializeOptions);
+        ICacheObject DeserializeCacheObject(ReadOnlyMemory<byte> bytes, int length);
 
         Task CheckpointAsync<TMetadata>(IStateSerializerCheckpointWriter checkpointWriter, StateClientMetadata<TMetadata> metadata)
             where TMetadata : IStorageMetadata;
@@ -26,11 +26,11 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
         Task InitializeAsync<TMetadata>(IStateSerializerInitializeReader reader, StateClientMetadata<TMetadata> metadata)
             where TMetadata : IStorageMetadata;
     }
-    internal interface IStateSerializer<T> : IStateSerializer
+    public interface IStateSerializer<T> : IStateSerializer
         where T: ICacheObject
     {
-        void Serialize(in IBufferWriter<byte> bufferWriter, in T value, in StateSerializeOptions stateSerializeOptions);
+        void Serialize(in IBufferWriter<byte> bufferWriter, in T value);
 
-        T Deserialize(IMemoryOwner<byte> bytes, int length, StateSerializeOptions stateSerializeOptions);
+        T Deserialize(ReadOnlyMemory<byte> bytes, int length);
     }
 }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/IStateSerializer.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/IStateSerializer.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
 {
     internal interface IStateSerializer
     {
-        byte[] Serialize(in ICacheObject value, in StateSerializeOptions stateSerializeOptions);
+        void Serialize(in IBufferWriter<byte> bufferWriter, in ICacheObject value, in StateSerializeOptions stateSerializeOptions);
 
         ICacheObject DeserializeCacheObject(IMemoryOwner<byte> bytes, int length, StateSerializeOptions stateSerializeOptions);
 
@@ -29,7 +29,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
     internal interface IStateSerializer<T> : IStateSerializer
         where T: ICacheObject
     {
-        byte[] Serialize(in T value, in StateSerializeOptions stateSerializeOptions);
+        void Serialize(in IBufferWriter<byte> bufferWriter, in T value, in StateSerializeOptions stateSerializeOptions);
 
         T Deserialize(IMemoryOwner<byte> bytes, int length, StateSerializeOptions stateSerializeOptions);
     }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/IStateSerializerInitializeReader.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/IStateSerializerInitializeReader.cs
@@ -22,6 +22,6 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
     {
         long GetNewPageId();
 
-        Task<Memory<byte>> ReadPage(long pageId);
+        Task<ReadOnlyMemory<byte>> ReadPage(long pageId);
     }
 }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/StateClientMetadata.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/StateClientMetadata.cs
@@ -12,7 +12,7 @@
 
 namespace FlowtideDotNet.Storage.StateManager.Internal
 {
-    internal class StateClientMetadata<T>
+    public class StateClientMetadata<T>
     {
         public T? Metadata { get; set; }
 

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/StateClientMetadataSerializer.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/StateClientMetadataSerializer.cs
@@ -18,12 +18,11 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
 {
     internal static class StateClientMetadataSerializer
     {
-        public static StateClientMetadata<T> Deserialize<T>(IMemoryOwner<byte> bytes, int length)
+        public static StateClientMetadata<T> Deserialize<T>(ReadOnlyMemory<byte> bytes, int length)
         {
-            var slice = bytes.Memory.Span.Slice(0, length);
+            var slice = bytes.Span.Slice(0, length);
             var reader = new Utf8JsonReader(slice);
             var deserializedValue = JsonSerializer.Deserialize<StateClientMetadata<T>>(ref reader);
-            bytes.Dispose();
             Debug.Assert(deserializedValue != null);
             return deserializedValue;
         }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/StateManagerMetadataSerializer.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/StateManagerMetadataSerializer.cs
@@ -23,19 +23,18 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
             return Task.CompletedTask;
         }
 
-        public StateManagerMetadata Deserialize(IMemoryOwner<byte> bytes, int length, StateSerializeOptions stateSerializeOptions)
+        public StateManagerMetadata Deserialize(ReadOnlyMemory<byte> bytes, int length)
         {
-            var slice = bytes.Memory.Span.Slice(0, length);
+            var slice = bytes.Span.Slice(0, length);
             var reader = new Utf8JsonReader(slice);
             var deserializedValue = JsonSerializer.Deserialize<StateManagerMetadata<T>>(ref reader);
-            bytes.Dispose();
             Debug.Assert(deserializedValue != null);
             return deserializedValue;
         }
 
-        public ICacheObject DeserializeCacheObject(IMemoryOwner<byte> bytes, int length, StateSerializeOptions stateSerializeOptions)
+        public ICacheObject DeserializeCacheObject(ReadOnlyMemory<byte> bytes, int length)
         {
-            return Deserialize(bytes, length, stateSerializeOptions);
+            return Deserialize(bytes, length);
         }
 
         public Task InitializeAsync<TMetadata>(IStateSerializerInitializeReader reader, StateClientMetadata<TMetadata> metadata) where TMetadata : IStorageMetadata
@@ -43,23 +42,23 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
             return Task.CompletedTask;
         }
 
-        public void Serialize(in IBufferWriter<byte> bufferWriter, in StateManagerMetadata value, in StateSerializeOptions stateSerializeOptions)
+        public void Serialize(in IBufferWriter<byte> bufferWriter, in StateManagerMetadata value)
         {
             if (value is StateManagerMetadata<T> metadata)
             {
                 var jsonWriter = new Utf8JsonWriter(bufferWriter);
-                //using MemoryStream memoryStream = new MemoryStream();
                 JsonSerializer.Serialize(jsonWriter, metadata);
-                //return memoryStream.ToArray();
+                return;
             }
             throw new NotSupportedException();
         }
 
-        public void Serialize(in IBufferWriter<byte> bufferWriter, in ICacheObject value, in StateSerializeOptions stateSerializeOptions)
+        public void Serialize(in IBufferWriter<byte> bufferWriter, in ICacheObject value)
         {
             if (value is StateManagerMetadata<T> metadata)
             {
-                Serialize(bufferWriter, metadata, stateSerializeOptions);
+                Serialize(bufferWriter, metadata);
+                return;
             }
             throw new NotSupportedException();
         }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/StateManagerMetadataSerializer.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/StateManagerMetadataSerializer.cs
@@ -43,22 +43,23 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
             return Task.CompletedTask;
         }
 
-        public byte[] Serialize(in StateManagerMetadata value, in StateSerializeOptions stateSerializeOptions)
+        public void Serialize(in IBufferWriter<byte> bufferWriter, in StateManagerMetadata value, in StateSerializeOptions stateSerializeOptions)
         {
             if (value is StateManagerMetadata<T> metadata)
             {
-                using MemoryStream memoryStream = new MemoryStream();
-                JsonSerializer.Serialize(memoryStream, metadata);
-                return memoryStream.ToArray();
+                var jsonWriter = new Utf8JsonWriter(bufferWriter);
+                //using MemoryStream memoryStream = new MemoryStream();
+                JsonSerializer.Serialize(jsonWriter, metadata);
+                //return memoryStream.ToArray();
             }
             throw new NotSupportedException();
         }
 
-        public byte[] Serialize(in ICacheObject value, in StateSerializeOptions stateSerializeOptions)
+        public void Serialize(in IBufferWriter<byte> bufferWriter, in ICacheObject value, in StateSerializeOptions stateSerializeOptions)
         {
             if (value is StateManagerMetadata<T> metadata)
             {
-                return Serialize(metadata, stateSerializeOptions);
+                Serialize(bufferWriter, metadata, stateSerializeOptions);
             }
             throw new NotSupportedException();
         }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/StateManagerSyncClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/StateManagerSyncClient.cs
@@ -40,7 +40,9 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             where TKeyContainer : IKeyContainer<K>
             where TValueContainer : IValueContainer<V>
         {
-            var stateClient = await CreateStateClient<IBPlusTreeNode, BPlusTreeMetadata>(name, new BPlusTreeSerializer<K, V, TKeyContainer, TValueContainer>(options.KeySerializer, options.ValueSerializer, options.MemoryAllocator), options.MemoryAllocator);
+            var serializer = new BPlusTreeSerializer<K, V, TKeyContainer, TValueContainer>(options.KeySerializer, options.ValueSerializer, options.MemoryAllocator);
+            var compressedSerializer = new BPlusTreeCompressedSerializer(serializer);
+            var stateClient = await CreateStateClient<IBPlusTreeNode, BPlusTreeMetadata>(name, compressedSerializer, options.MemoryAllocator);
 
             if (options.BucketSize == null)
             {

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/StateManagerSyncClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/StateManagerSyncClient.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Storage.AppendTree.Internal;
+using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Tree;
 using FlowtideDotNet.Storage.Tree.Internal;
 using System.Diagnostics;
@@ -39,7 +40,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             where TKeyContainer : IKeyContainer<K>
             where TValueContainer : IValueContainer<V>
         {
-            var stateClient = await CreateStateClient<IBPlusTreeNode, BPlusTreeMetadata>(name, new BPlusTreeSerializer<K, V, TKeyContainer, TValueContainer>(options.KeySerializer, options.ValueSerializer, options.MemoryAllocator));
+            var stateClient = await CreateStateClient<IBPlusTreeNode, BPlusTreeMetadata>(name, new BPlusTreeSerializer<K, V, TKeyContainer, TValueContainer>(options.KeySerializer, options.ValueSerializer, options.MemoryAllocator), options.MemoryAllocator);
 
             if (options.BucketSize == null)
             {
@@ -59,7 +60,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             where TKeyContainer : IKeyContainer<K>
             where TValueContainer : IValueContainer<V>
         {
-            var stateClient = await CreateStateClient<IBPlusTreeNode, AppendTreeMetadata>(name, new BPlusTreeSerializer<K, V, TKeyContainer, TValueContainer>(options.KeySerializer, options.ValueSerializer, options.MemoryAllocator));
+            var stateClient = await CreateStateClient<IBPlusTreeNode, AppendTreeMetadata>(name, new BPlusTreeSerializer<K, V, TKeyContainer, TValueContainer>(options.KeySerializer, options.ValueSerializer, options.MemoryAllocator), options.MemoryAllocator);
 
             if (options.BucketSize == null)
             {
@@ -72,7 +73,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
         }
 
 
-        private async ValueTask<IStateClient<V, TMetadata>> CreateStateClient<V, TMetadata>(string name, IStateSerializer<V> serializer)
+        private async ValueTask<IStateClient<V, TMetadata>> CreateStateClient<V, TMetadata>(string name, IStateSerializer<V> serializer, IMemoryAllocator memoryAllocator)
             where V : ICacheObject
             where TMetadata : class, IStorageMetadata
         {
@@ -81,7 +82,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             {
                 ValueSerializer = serializer,
                 TagList = tagList
-            });
+            }, memoryAllocator);
             await stateClient.InitializeSerializerAsync();
             return stateClient;
         }

--- a/src/FlowtideDotNet.Storage/StateSerializeOptions.cs
+++ b/src/FlowtideDotNet.Storage/StateSerializeOptions.cs
@@ -12,10 +12,26 @@
 
 namespace FlowtideDotNet.Storage
 {
+    public enum CompressionType
+    {
+        None = 0,
+        Zstd = 1
+    };
+
+    public enum CompressionMethod
+    {
+        /// <summary>
+        /// Compresses the entire page
+        /// </summary>
+        Page = 0,
+    }
+
     public class StateSerializeOptions
     {
-        public Func<Stream, Stream>? CompressFunc { get; set; }
+        public CompressionType CompressionType { get; set; }
 
-        public Func<Stream, Stream>? DecompressFunc { get; set; }
+        public CompressionMethod CompressionMethod { get; set; }
+
+        public int? ComressionLevel { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTreeKeySerializer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTreeKeySerializer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -25,7 +26,7 @@ namespace FlowtideDotNet.Storage.Tree
 
         TKeyContainer Deserialize(in BinaryReader reader);
 
-        void Serialize(in BinaryWriter writer, in TKeyContainer values);
+        void Serialize(in IBufferWriter<byte> writer, in TKeyContainer values);
 
         /// <summary>
         /// Called on each checkpoint, its primary function is to allow a serializer to write any potential metadata

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTreeKeySerializer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTreeKeySerializer.cs
@@ -24,7 +24,7 @@ namespace FlowtideDotNet.Storage.Tree
     {
         TKeyContainer CreateEmpty();
 
-        TKeyContainer Deserialize(in BinaryReader reader);
+        TKeyContainer Deserialize(ref SequenceReader<byte> reader);
 
         void Serialize(in IBufferWriter<byte> writer, in TKeyContainer values);
 

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTreeSerializerInitializeContext.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTreeSerializerInitializeContext.cs
@@ -22,7 +22,7 @@ namespace FlowtideDotNet.Storage.Tree
     {
         IReadOnlyList<long> SavedPageIds { get; }
 
-        Task<Memory<byte>> ReadPage(long pageId);
+        Task<ReadOnlyMemory<byte>> ReadPage(long pageId);
 
         long GetNewPageId();
     }

--- a/src/FlowtideDotNet.Storage/Tree/IBplusTreeValueSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBplusTreeValueSerializer.cs
@@ -24,7 +24,7 @@ namespace FlowtideDotNet.Storage.Tree
     {
         TValueContainer CreateEmpty();
 
-        TValueContainer Deserialize(in BinaryReader reader);
+        TValueContainer Deserialize(ref SequenceReader<byte> reader);
 
         void Serialize(in IBufferWriter<byte> writer, in TValueContainer values);
 

--- a/src/FlowtideDotNet.Storage/Tree/IBplusTreeValueSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBplusTreeValueSerializer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -25,7 +26,7 @@ namespace FlowtideDotNet.Storage.Tree
 
         TValueContainer Deserialize(in BinaryReader reader);
 
-        void Serialize(in BinaryWriter writer, in TValueContainer values);
+        void Serialize(in IBufferWriter<byte> writer, in TValueContainer values);
 
         Task CheckpointAsync(IBPlusTreeSerializerCheckpointContext context);
 

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeCompressedSerializer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeCompressedSerializer.cs
@@ -1,0 +1,101 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.StateManager.Internal;
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZstdSharp;
+
+namespace FlowtideDotNet.Storage.Tree.Internal
+{
+    internal class BPlusTreeCompressedSerializer : IStateSerializer<IBPlusTreeNode>
+    {
+        private readonly IStateSerializer<IBPlusTreeNode> _serializer;
+        private readonly object _writeLock = new object();
+        private readonly object _readLock = new object();
+        private ArrayBufferWriter<byte> _bufferWriter = new ArrayBufferWriter<byte>();
+        private Compressor _compressor;
+        private Decompressor _decompressor;
+
+        public BPlusTreeCompressedSerializer(IStateSerializer<IBPlusTreeNode> serializer)
+        {
+            this._serializer = serializer;
+            _compressor = new Compressor();
+            _decompressor = new Decompressor();
+        }
+
+        public Task CheckpointAsync<TMetadata>(IStateSerializerCheckpointWriter checkpointWriter, StateClientMetadata<TMetadata> metadata) where TMetadata : IStorageMetadata
+        {
+            return _serializer.CheckpointAsync(checkpointWriter, metadata);
+        }
+
+        public IBPlusTreeNode Deserialize(ReadOnlyMemory<byte> bytes, int length)
+        {
+            lock (_readLock)
+            {
+                var span = bytes.Span;
+
+                var writtenLength = BinaryPrimitives.ReadInt32LittleEndian(span);
+                var originalLength = BinaryPrimitives.ReadInt32LittleEndian(span.Slice(4));
+
+                var temporaryDestination = ArrayPool<byte>.Shared.Rent(originalLength);
+
+                _decompressor.Unwrap(span.Slice(8, writtenLength), temporaryDestination);
+                var result = _serializer.Deserialize(temporaryDestination.AsMemory().Slice(0, originalLength), originalLength);
+                ArrayPool<byte>.Shared.Return(temporaryDestination);
+                return result;
+            }
+        }
+
+        public ICacheObject DeserializeCacheObject(ReadOnlyMemory<byte> bytes, int length)
+        {
+            return this.Deserialize(bytes, length);
+        }
+
+        public Task InitializeAsync<TMetadata>(IStateSerializerInitializeReader reader, StateClientMetadata<TMetadata> metadata) where TMetadata : IStorageMetadata
+        {
+            return _serializer.InitializeAsync(reader, metadata);
+        }
+
+        public void Serialize(in IBufferWriter<byte> bufferWriter, in IBPlusTreeNode value)
+        {
+            lock (_writeLock)
+            {
+                _bufferWriter.ResetWrittenCount();
+                _serializer.Serialize(_bufferWriter, value);
+                var span = _bufferWriter.WrittenSpan;
+                var compressBound = Compressor.GetCompressBound(span.Length + 8);
+                var destinationSpan = bufferWriter.GetSpan(compressBound);
+                var writtenLength = _compressor.Wrap(span, destinationSpan.Slice(8));
+                BinaryPrimitives.WriteInt32LittleEndian(destinationSpan, writtenLength);
+                BinaryPrimitives.WriteInt32LittleEndian(destinationSpan.Slice(4), span.Length);
+                bufferWriter.Advance(writtenLength + 8);
+            }
+        }
+
+        public void Serialize(in IBufferWriter<byte> bufferWriter, in ICacheObject value)
+        {
+            if (value is IBPlusTreeNode node)
+            {
+                Serialize(bufferWriter, node);
+                return;
+            }
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeSerializerInitializeContext.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeSerializerInitializeContext.cs
@@ -37,7 +37,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             return stateSerializerInitializeReader.GetNewPageId();
         }
 
-        public Task<Memory<byte>> ReadPage(long pageId)
+        public Task<ReadOnlyMemory<byte>> ReadPage(long pageId)
         {
             return stateSerializerInitializeReader.ReadPage(pageId);
         }

--- a/tests/FlowtideDotNet.AcceptanceTests/CompressionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/CompressionTests.cs
@@ -23,7 +23,7 @@ namespace FlowtideDotNet.AcceptanceTests
         }
 
         [Fact]
-        public async Task TestZLipCompression()
+        public async Task TestZstdCompression()
         {
             GenerateData();
             await StartStream(@"
@@ -35,14 +35,8 @@ namespace FlowtideDotNet.AcceptanceTests
                 ON o.userkey = u.userkey",
                 stateSerializeOptions: new Storage.StateSerializeOptions()
                 {
-                    CompressFunc = (stream) =>
-                    {
-                        return new System.IO.Compression.ZLibStream(stream, CompressionMode.Compress);
-                    },
-                    DecompressFunc = (stream) =>
-                    {
-                        return new System.IO.Compression.ZLibStream(stream, CompressionMode.Decompress);
-                    }
+                    CompressionMethod = Storage.CompressionMethod.Page,
+                    CompressionType = Storage.CompressionType.Zstd
                 });
             await WaitForUpdate();
             await Crash();

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -73,7 +73,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
 
         public SqlPlanBuilder SqlPlanBuilder => sqlPlanBuilder;
 
-        public int CachePageCount { get; set; } = 1000;
+        public int CachePageCount { get; set; } = 0;
 
         public Watermark? LastWatermark => _lastWatermark;
 
@@ -225,6 +225,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
                     SerializeOptions = stateSerializeOptions,
                     PersistentStorage = _persistentStorage,
                     DefaultBPlusTreePageSize = pageSize,
+                    DefaultBPlusTreePageSizeBytes = 1,
                     TemporaryStorageOptions = new Storage.FileCacheOptions()
                     {
                         DirectoryPath = $"./data/tempFiles/{testName}/tmp"

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/TestStorageSession.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/TestStorageSession.cs
@@ -10,9 +10,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Storage;
 using FlowtideDotNet.Storage.FileCache;
 using FlowtideDotNet.Storage.Persistence.CacheStorage;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -30,10 +32,12 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             this.testStorage = testStorage;
         }
 
-        public override Task Write(long key, byte[] value)
+        public override Task Write(long key, SerializableObject value)
         {
             HasCommitted = false;
-            testStorage.AddWrittenKey(key, value);
+            ArrayBufferWriter<byte> bufferWriter = new ArrayBufferWriter<byte>();
+            value.Serialize(bufferWriter);
+            testStorage.AddWrittenKey(key, bufferWriter.WrittenSpan.ToArray());
             return base.Write(key, value);
         }
 

--- a/tests/FlowtideDotNet.Benchmarks/ArrowSerializeBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/ArrowSerializeBenchmark.cs
@@ -173,8 +173,9 @@ namespace FlowtideDotNet.Benchmarks
         public void FlowtideDeserialize()
         {
             Debug.Assert(_toDeserialize != null);
-            var deserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, new SequenceReader<byte>(new ReadOnlySequence<byte>(_toDeserialize)));
-            var batch = deserializer.DeserializeBatch();
+            var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(_toDeserialize));
+            var deserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance);
+            var batch = deserializer.DeserializeBatch(ref reader).EventBatch;
             batch.Dispose();
         }
 
@@ -374,8 +375,9 @@ namespace FlowtideDotNet.Benchmarks
         public void FlowtideDeserializeCompressed()
         {
             Debug.Assert(_toDeserializeCompressed != null);
-            var deserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, new SequenceReader<byte>(new ReadOnlySequence<byte>(_toDeserializeCompressed)), _batchDecompressor);
-            var batch = deserializer.DeserializeBatch();
+            var deserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, _batchDecompressor);
+            var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(_toDeserializeCompressed));
+            var batch = deserializer.DeserializeBatch(ref reader).EventBatch;
             batch.Dispose();
         }
 
@@ -384,8 +386,9 @@ namespace FlowtideDotNet.Benchmarks
         public void FlowtideDeserializeCompressedWithDictionary()
         {
             Debug.Assert(_toDeserializeCompressed != null);
-            var deserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, new SequenceReader<byte>(new ReadOnlySequence<byte>(_toDeserializeCompressed)), _batchDictionaryDecompressor);
-            var batch = deserializer.DeserializeBatch();
+            var deserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, _batchDictionaryDecompressor);
+            var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(_toDeserializeCompressed));
+            var batch = deserializer.DeserializeBatch(ref reader).EventBatch;
             batch.Dispose();
         }
 
@@ -495,8 +498,9 @@ namespace FlowtideDotNet.Benchmarks
         public void DeserializeFullCompressedBatch()
         {
             _decompressor.Unwrap(_compressedByteArray.AsSpan(), _diskDestinationBuffer.AsSpan());
-            var deserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, new SequenceReader<byte>(new ReadOnlySequence<byte>(_diskDestinationBuffer)));
-            var batch = deserializer.DeserializeBatch();
+            var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(_diskDestinationBuffer));
+            var deserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance);
+            var batch = deserializer.DeserializeBatch(ref reader).EventBatch;
             batch.Dispose();
         }
     }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/FlowtideArrowSerializerTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/FlowtideArrowSerializerTests.cs
@@ -316,8 +316,8 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(serializedBytes));
 
-            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, reader);
-            var deserializedBatch = batchDeserializer.DeserializeBatch();
+            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance);
+            var deserializedBatch = batchDeserializer.DeserializeBatch(ref reader).EventBatch;
             Assert.Equal(batch, deserializedBatch, new EventBatchDataComparer());
 
             column.Add(new Int64Value(3));
@@ -448,8 +448,8 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(serializedBytes));
 
-            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, reader);
-            var deserializedBatch = batchDeserializer.DeserializeBatch();
+            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance);
+            var deserializedBatch = batchDeserializer.DeserializeBatch(ref reader).EventBatch;
 
             Assert.Equal(batch, deserializedBatch, new EventBatchDataComparer());
         }
@@ -550,8 +550,8 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(serializedBytes));
 
-            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, reader);
-            var deserializedBatch = batchDeserializer.DeserializeBatch();
+            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance);
+            var deserializedBatch = batchDeserializer.DeserializeBatch(ref reader).EventBatch;
 
             Assert.Equal(batch, deserializedBatch, new EventBatchDataComparer());
         }
@@ -574,8 +574,8 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(serializedBytes));
 
-            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, reader);
-            var deserializedBatch = batchDeserializer.DeserializeBatch();
+            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance);
+            var deserializedBatch = batchDeserializer.DeserializeBatch(ref reader).EventBatch;
 
             Assert.Equal(batch, deserializedBatch, new EventBatchDataComparer());
 
@@ -609,8 +609,8 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(serializedBytes));
 
-            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, reader);
-            var deserializedBatch = batchDeserializer.DeserializeBatch();
+            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance);
+            var deserializedBatch = batchDeserializer.DeserializeBatch(ref reader).EventBatch;
 
             Assert.Equal(batch, deserializedBatch, new EventBatchDataComparer());
 
@@ -764,8 +764,8 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(serializedBytes));
 
-            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, reader, new BatchDecompressor(new Decompressor()));
-            var deserializedBatch = batchDeserializer.DeserializeBatch();
+            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, new BatchDecompressor(new Decompressor()));
+            var deserializedBatch = batchDeserializer.DeserializeBatch(ref reader).EventBatch;
 
             Assert.Equal(batch, deserializedBatch, new EventBatchDataComparer());
         }
@@ -806,10 +806,10 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
 
             var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(serializedBytes));
 
-            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance, reader);
+            EventBatchDeserializer batchDeserializer = new EventBatchDeserializer(GlobalMemoryManager.Instance);
             // Set the schema for the deserializer
             batchDeserializer.SetSchema(savedSchema);
-            var deserializedBatch = batchDeserializer.DeserializeBatch();
+            var deserializedBatch = batchDeserializer.DeserializeBatch(ref reader).EventBatch;
 
             Assert.Equal(batch, deserializedBatch, new EventBatchDataComparer());
         }

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeByteBased/ListKeyWithSizeSerializer.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeByteBased/ListKeyWithSizeSerializer.cs
@@ -22,12 +22,10 @@ namespace FlowtideDotNet.Storage.Tests.BPlusTreeByteBased
 {
     internal class ListKeyWithSizeSerializer : IBPlusTreeKeySerializer<KeyValuePair<long, long>, ListKeyContainerWithSize>
     {
-       // private readonly IBplusTreeSerializer<KeyValuePair<long, long>> serializer;
         private readonly int sizePerElement;
 
-        public ListKeyWithSizeSerializer( int sizePerElement)
+        public ListKeyWithSizeSerializer(int sizePerElement)
         {
-            //this.serializer = serializer;
             this.sizePerElement = sizePerElement;
         }
 
@@ -41,7 +39,7 @@ namespace FlowtideDotNet.Storage.Tests.BPlusTreeByteBased
             return new ListKeyContainerWithSize(1);
         }
 
-        public ListKeyContainerWithSize Deserialize(in BinaryReader reader)
+        public ListKeyContainerWithSize Deserialize(ref SequenceReader<byte> reader)
         {
             throw new NotImplementedException();
         }

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeByteBased/ListKeyWithSizeSerializer.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeByteBased/ListKeyWithSizeSerializer.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Storage.Tree;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -50,7 +51,7 @@ namespace FlowtideDotNet.Storage.Tests.BPlusTreeByteBased
             return Task.CompletedTask;
         }
 
-        public void Serialize(in BinaryWriter writer, in ListKeyContainerWithSize values)
+        public void Serialize(in IBufferWriter<byte> writer, in ListKeyContainerWithSize values)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This change is done to improve performance of serializing and deserializing pages in the storage.

SequenceReader is used instead of BinaryReader and IBufferWriter<byte> is used instead of BinaryWriter.

This allows the serializers to write directly to the memory block that will be written to file for the file cache.