### PR TITLE
Add support to pause and resume a stream

### DIFF
--- a/docs/docs/deployment/index.md
+++ b/docs/docs/deployment/index.md
@@ -1,0 +1,13 @@
+---
+sidebar_position: 4
+---
+
+import DocCardList from '@theme/DocCardList';
+
+
+
+# Deployment
+
+This section covers information that can be useful when deploying flowtide.
+
+<DocCardList />

--- a/docs/docs/deployment/pauseresume.md
+++ b/docs/docs/deployment/pauseresume.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 1
+---
+
+# Pause And Resume
+
+It is possible to pause and resume a flowtide stream, this is useful when there might be maintainance work on a source system, or as a panic button to stop
+the execution.
+
+A pause does not stop the stream, but stops the traversal of all events inside of the stream. This means that resuming a paused stream is quick and does
+not need to download any state from persistent storage.
+
+## Pause and stop using IConfiguration
+
+One of the easier ways to add pause and resume is to utilize `IConfiguration` in .NET. Flowtide uses an `IOptionsMonitor<FlowtidePauseOptions>` to check
+for changes on the configuration and pauses and resumes the stream based on the value.
+
+The class looks as follows:
+
+```
+public class FlowtidePauseOptions
+{
+    public bool IsPaused { get; set; }
+}
+```
+
+So to utilize this when using `FlowtideDotNet.AspNetCore` or `FlowtideDotNet.DependencyInjection` you add the following:
+
+```
+var builder = WebApplication.CreateBuilder(args);
+
+...
+
+// Map flowtide pause options to enable pausing and resuming from configuration
+builder.Services.AddOptions<FlowtidePauseOptions>()
+    .Bind(builder.Configuration.GetSection("your_section"));
+
+...
+
+// Add the stream as normal
+builder.Services.AddFlowtideStream("stream_name")
+...
+```
+
+This is best fitted with an `IConfiguration` provider that supports loading changes dynamically such as Hashicorp Vault or Azure Key Vault.
+Pausing and resuming using `IConfiguration`provider is dependent on the update frequency of the provider, so to utilize this fully this interval should be
+kept quite low. 
+
+## Pause and stop using API endpoint
+
+When using `FlowtideDotNet.AspNetCore` you can also map API endpoints to allow for pause and resume.
+
+Example:
+
+```
+var builder = WebApplication.CreateBuilder(args);
+
+...
+
+// Add the stream as normal
+builder.Services.AddFlowtideStream("stream_name")
+
+...
+
+var app = builder.Build();
+
+...
+
+// Map pause and resume endpoints
+app.UseFlowtidePauseResumeEndpoints("base_path");
+```
+
+Two endpoints are registered under the base path, `/pause` and `/resume`.

--- a/samples/SqlSampleWithUI/Program.cs
+++ b/samples/SqlSampleWithUI/Program.cs
@@ -22,8 +22,13 @@ using FlowtideDotNet.DependencyInjection;
 using FlowtideDotNet.Core.Sources.Generic;
 using OpenTelemetry.Metrics;
 using FlowtideDotNet.Core.Sinks;
+using FlowtideDotNet.Base;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Map flowtide pause options to enable pausing and resuming from configuration
+builder.Services.AddOptions<FlowtidePauseOptions>()
+    .Bind(builder.Configuration.GetSection("flowtide"));
 
 var sqlText = @"
 CREATE TABLE testtable (
@@ -68,6 +73,5 @@ app.UseCors(b =>
 
 app.UseHealthChecks("/health");
 app.UseFlowtideUI("/");
-
 
 app.Run();

--- a/samples/SqlSampleWithUI/appsettings.json
+++ b/samples/SqlSampleWithUI/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "flowtide": {
+    "isPaused": false
+  }
 }

--- a/src/FlowtideDotNet.AspNetCore/HealthCheck/FlowtideHealthCheck.cs
+++ b/src/FlowtideDotNet.AspNetCore/HealthCheck/FlowtideHealthCheck.cs
@@ -25,22 +25,18 @@ namespace FlowtideDotNet.AspNetCore.HealthCheck
         }
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            var status = dataflowStream.Status;
+            var health = dataflowStream.Health;
 
-            switch (status)
+            switch (health)
             {
-                case StreamStatus.Failing:
-                    return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, "Stream is in state 'failing'."));
-                case StreamStatus.Running:
+                case Base.FlowtideHealth.Unhealthy:
+                    return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy));
+                case Base.FlowtideHealth.Healthy:
                     return Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));
-                case StreamStatus.Starting:
-                    return Task.FromResult(new HealthCheckResult(HealthStatus.Degraded, "Stream is in state 'starting'."));
-                case StreamStatus.Stopped:
-                    return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, "Stream is in state 'stopped'."));
-                case StreamStatus.Degraded:
-                    return Task.FromResult(new HealthCheckResult(HealthStatus.Degraded, "Stream is in state 'degraded'."));
+                case Base.FlowtideHealth.Degraded:
+                    return Task.FromResult(new HealthCheckResult(HealthStatus.Degraded));
                 default:
-                    return Task.FromResult(new HealthCheckResult(HealthStatus.Degraded, "Stream is in unknown state."));
+                    return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy));
             }
         }
     }

--- a/src/FlowtideDotNet.AspNetCore/UiMiddleware.cs
+++ b/src/FlowtideDotNet.AspNetCore/UiMiddleware.cs
@@ -49,6 +49,10 @@ namespace FlowtideDotNet.AspNetCore
                 {
                     return uiMiddlewareState.DiagnosticsEndpoint.Invoke(httpContext);
                 }
+                if (remaining == "/pause" || remaining == "/resume")
+                {
+                    return _next(httpContext);
+                }
                 return uiMiddlewareState.ReactEndpoint.Invoke(httpContext);
             }
             else if (requestPath.StartsWith(_nextComparePath))

--- a/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
@@ -29,9 +29,11 @@ namespace FlowtideDotNet.Base.Engine
 
         public StreamStateValue WantedState => streamContext._wantedState;
 
-        public StreamStatus Status => streamContext.GetStatus();
+        public StreamStatus Status => streamContext.Status;
 
         public IStreamScheduler Scheduler => streamContext._streamScheduler;
+
+        public FlowtideHealth Health => streamContext.Health;
 
         public Task StartAsync()
         {
@@ -118,6 +120,16 @@ namespace FlowtideDotNet.Base.Engine
         public Task StopAsync()
         {
             return streamContext.StopAsync();
+        }
+
+        public void Pause()
+        {
+            streamContext.Pause();
+        }
+
+        public void Resume()
+        {
+            streamContext.Resume();
         }
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
@@ -18,6 +18,7 @@ using FlowtideDotNet.Base.Vertices.Ingress;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.StateManager;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace FlowtideDotNet.Base.Engine
 {
@@ -35,6 +36,7 @@ namespace FlowtideDotNet.Base.Engine
         private ILoggerFactory? _loggerFactory;
         private StreamVersionInformation? _streamVersionInformation;
         private readonly DataflowStreamOptions _dataflowStreamOptions;
+        private IOptionsMonitor<FlowtidePauseOptions>? _pauseMonitor;
 
         public DataflowStreamBuilder(string streamName)
         {
@@ -117,6 +119,12 @@ namespace FlowtideDotNet.Base.Engine
             return this;
         }
 
+        public DataflowStreamBuilder WithPauseMonitor(IOptionsMonitor<FlowtidePauseOptions> pauseMonitor)
+        {
+            _pauseMonitor = pauseMonitor;
+            return this;
+        }
+
         public DataflowStream Build()
         {
             if (_stateManagerOptions == null)
@@ -145,8 +153,9 @@ namespace FlowtideDotNet.Base.Engine
                 _loggerFactory,
                 _streamVersionInformation,
                 _dataflowStreamOptions,
-                new StreamMemoryManager(_streamName));
-
+                new StreamMemoryManager(_streamName),
+                _pauseMonitor);
+            
             return new DataflowStream(streamContext);
         }
     }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletedStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletedStreamState.cs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
+
 namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 {
     internal class DeletedStreamState : StreamStateMachineState
@@ -40,6 +42,8 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         public override void Initialize(StreamStateValue previousState)
         {
+            Debug.Assert(_context != null, nameof(_context));
+            _context.SetStatus(StreamStatus.Deleted);
         }
 
         public override Task OnFailure()

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletingStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletingStreamState.cs
@@ -41,8 +41,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         public override void Initialize(StreamStateValue previousState)
         {
+            Debug.Assert(_context != null, nameof(_context));
+            _context.CheckForPause();
             lock (_lock)
             {
+                _context.SetStatus(StreamStatus.Deleting);
                 if (_deleteTask != null && !_deleteTask.IsCompleted)
                 {
                     return;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/FailureStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/FailureStreamState.cs
@@ -21,8 +21,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         public override void Initialize(StreamStateValue previousState)
         {
+            Debug.Assert(_context != null, nameof(_context));
+            _context.CheckForPause();
             lock (_lock)
             {
+                _context.SetStatus(StreamStatus.Failing);
                 if (_currentTask != null)
                 {
                     return;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/NotStartedStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/NotStartedStreamState.cs
@@ -51,7 +51,8 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         public override void Initialize(StreamStateValue previousState)
         {
-            
+            Debug.Assert(_context != null, nameof(_context));
+            _context.SetStatus(StreamStatus.Stopped);
         }
 
         public override Task OnFailure()

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
@@ -75,6 +75,13 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             Debug.Assert(_context != null, nameof(_context));
             _context._logger.StartingStream(_context.streamName);
 
+            if (_context.Status != StreamStatus.Failing)
+            {
+                // We only set starting if we are not failing.
+                // Failure goes directly to running if everything is ok.
+                _context.SetStatus(StreamStatus.Starting);
+            }
+
             if (previousState == StreamStateValue.NotStarted)
             {
                 StartStream().GetAwaiter().GetResult();

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StoppingStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StoppingStreamState.cs
@@ -179,6 +179,8 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         public override void Initialize(StreamStateValue previousState)
         {
             Debug.Assert(_context != null);
+            _context.CheckForPause();
+            _context.SetStatus(StreamStatus.Stopping);
             _context._logger.StoppingStream(_context.streamName);
             _context.TryScheduleCheckpointIn(TimeSpan.FromMilliseconds(1));
         }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics.Metrics;
 using FlowtideDotNet.Base.Utils;
 using FlowtideDotNet.Storage.Memory;
+using Microsoft.Extensions.Options;
 
 namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 {
@@ -78,10 +79,13 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         internal StreamStateValue currentState;
         internal StreamStateValue _wantedState;
 
-        /// <summary>
-        /// Flag that tells if the stream has failed once
-        /// </summary>
-        private bool _hasFailed = false;
+        private StreamStatus _streamStatus;
+
+        internal object _pauseLock = new object();
+        private StreamStatus _statusBeforePause;
+        internal TaskCompletionSource? _pauseSource;
+        private IOptionsMonitor<FlowtidePauseOptions>? _pauseMonitor;
+
         /// <summary>
         /// Enables or disables trigger registration, used often during failures
         /// </summary>
@@ -91,7 +95,41 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         internal readonly ILogger<StreamContext> _logger;
 
         internal bool _initialCheckpointTaken = false;
-        
+
+        public StreamStatus Status => _streamStatus;
+
+        public FlowtideHealth Health
+        {
+            get
+            {
+                switch (Status)
+                {
+                    case StreamStatus.Failing:
+                        return FlowtideHealth.Unhealthy;
+                    case StreamStatus.Running:
+                        return FlowtideHealth.Healthy;
+                    case StreamStatus.Paused:
+                        if (currentState == Base.Engine.Internal.StateMachine.StreamStateValue.Running)
+                        {
+                            return FlowtideHealth.Healthy;
+                        }
+                        if (currentState == Base.Engine.Internal.StateMachine.StreamStateValue.Failure)
+                        {
+                            return FlowtideHealth.Unhealthy;
+                        }
+                        return FlowtideHealth.Degraded;
+                    case StreamStatus.Starting:
+                        return FlowtideHealth.Degraded;
+                    case StreamStatus.Stopped:
+                        return FlowtideHealth.Unhealthy;
+                    case StreamStatus.Degraded:
+                        return FlowtideHealth.Degraded;
+                    default:
+                        return FlowtideHealth.Unhealthy;
+                }
+            }
+        }
+
 
         public StreamContext(
             string streamName,
@@ -106,7 +144,8 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             ILoggerFactory? loggerFactory,
             StreamVersionInformation? streamVersionInformation,
             DataflowStreamOptions dataflowStreamOptions,
-            IStreamMemoryManager streamMemoryManager)
+            IStreamMemoryManager streamMemoryManager,
+            IOptionsMonitor<FlowtidePauseOptions>? pauseMonitor)
         {
             this.streamName = streamName;
             this.propagatorBlocks = propagatorBlocks;
@@ -125,19 +164,16 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             _contextMeter = new Meter($"flowtide.{streamName}");
             _contextMeter.CreateObservableGauge<float>("flowtide_health", () =>
             {
-                var currentStatus = GetStatus();
                 var val = 0.0f;
-                switch (currentStatus)
+                switch (Health)
                 {
-                    case StreamStatus.Running:
+                    case FlowtideHealth.Healthy:
                         val = 1.0f;
                         break;
-                    case StreamStatus.Failing:
-                    case StreamStatus.Stopped:
+                    case FlowtideHealth.Unhealthy:
                         val = 0.0f;
                         break;
-                    case StreamStatus.Starting:
-                    case StreamStatus.Degraded:
+                    case FlowtideHealth.Degraded:
                         val = 0.5f;
                         break;
                     default:
@@ -145,6 +181,10 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                         break;
                 }
                 return new Measurement<float>(val, new KeyValuePair<string, object?>("stream", streamName));
+            });
+            _contextMeter.CreateObservableGauge<int>("flowtide_status", () =>
+            {
+                return new Measurement<int>((int)Status, new KeyValuePair<string, object?>("stream", streamName));
             });
             _contextMeter.CreateObservableGauge<int>("flowtide_state", () =>
             {
@@ -191,6 +231,26 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             currentState = StreamStateValue.NotStarted;
             _state = new NotStartedStreamState();
             _state.SetContext(this);
+            _pauseMonitor = pauseMonitor;
+
+            if (_pauseMonitor != null)
+            {
+                if (_pauseMonitor.CurrentValue.IsPaused)
+                {
+                    Pause();
+                }
+                _pauseMonitor.OnChange((opt) =>
+                {
+                    if (opt.IsPaused)
+                    {
+                        Pause();
+                    }
+                    else
+                    {
+                        Resume();
+                    }
+                });
+            }
         }
 
         private Task TransitionTo(StreamStateMachineState current, StreamStateMachineState state, StreamStateValue previous)
@@ -229,7 +289,6 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 case StreamStateValue.Starting:
                     return TransitionTo(current, new StartStreamState(), oldState);
                 case StreamStateValue.Failure:
-                    _hasFailed = true;
                     return TransitionTo(current, new FailureStreamState(), oldState);
                 case StreamStateValue.Running:
                     return TransitionTo(current, new RunningStreamState(), oldState);
@@ -260,6 +319,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             {
                 return _state!.CallTrigger(operatorName, triggerName, state);
             }
+        }
+
+        internal void SetStatus(StreamStatus status)
+        {
+            _streamStatus = status;
         }
 
         internal Task CallTrigger_Internal(string triggerName, object? state)
@@ -610,32 +674,60 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             return new StreamGraph(nodes, edges, currentState);
         }
 
-        internal StreamStatus GetStatus()
+        internal ValueTask CheckForPauseAsync()
         {
-            switch (currentState)
+            lock (_pauseLock)
             {
-                case StreamStateValue.NotStarted:
-                    return StreamStatus.Stopped;
-                case StreamStateValue.Starting:
-                    if (_hasFailed)
-                    {
-                        return StreamStatus.Failing;
-                    }
-                    return StreamStatus.Starting;
-                case StreamStateValue.Running:
-                    var graph = GetGraph();
-                    var hasDegradedNode = graph.Nodes.Any(x => x.Value.Gauges.Any(y => y.Name == "health" && y.Dimensions.First().Value.Value != 1));
-                    if (hasDegradedNode)
-                    {
-                        return StreamStatus.Degraded;
-                    }
-                    return StreamStatus.Running;
-                case StreamStateValue.Failure:
-                    return StreamStatus.Failing;
-                case StreamStateValue.Stopping:
-                    return StreamStatus.Running;
-                default:
-                    return StreamStatus.Degraded;
+                if (_pauseSource != null)
+                {
+                    return new ValueTask(_pauseSource.Task);
+                }
+            }
+            return ValueTask.CompletedTask;
+        }
+
+        internal void CheckForPause()
+        {
+            Task? task = default;
+            lock (_pauseLock)
+            {
+                if (_pauseSource != null)
+                {
+                    task = _pauseSource.Task;
+                }
+            }
+            if (task != null)
+            {
+                task.Wait();
+            }
+        }
+
+        public void Pause()
+        {
+            lock (_pauseLock)
+            {
+                if (_pauseSource != null)
+                {
+                    return;
+                }
+                _pauseSource = new TaskCompletionSource();
+                _state!.Pause();
+                _statusBeforePause = Status;
+                SetStatus(StreamStatus.Paused);
+            }
+        }
+
+        public void Resume()
+        {
+            lock (_pauseLock)
+            {
+                if (_pauseSource != null)
+                {
+                    SetStatus(_statusBeforePause);
+                    _pauseSource.SetResult();
+                    _pauseSource = null;
+                    _state!.Resume();
+                }
             }
         }
     }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamStateMachineState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamStateMachineState.cs
@@ -48,5 +48,13 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             Debug.Assert(_context != null, nameof(_context));
             return _context.TransitionTo(this, newState);
         }
+
+        public virtual void Pause()
+        {
+        }
+
+        public virtual void Resume()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/FlowtideHealth.cs
+++ b/src/FlowtideDotNet.Base/FlowtideHealth.cs
@@ -10,18 +10,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace FlowtideDotNet.Base.Engine
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Base
 {
-    public enum StreamStatus
+    public enum FlowtideHealth
     {
-        Stopped,
-        Starting,
-        Running,
+        Healthy,
         Degraded,
-        Failing,
-        Stopping,
-        Deleting,
-        Deleted,
-        Paused
+        Unhealthy
     }
 }

--- a/src/FlowtideDotNet.Base/FlowtidePauseOptions.cs
+++ b/src/FlowtideDotNet.Base/FlowtidePauseOptions.cs
@@ -10,18 +10,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace FlowtideDotNet.Base.Engine
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Base
 {
-    public enum StreamStatus
+    public class FlowtidePauseOptions
     {
-        Stopped,
-        Starting,
-        Running,
-        Degraded,
-        Failing,
-        Stopping,
-        Deleting,
-        Deleted,
-        Paused
+        public bool IsPaused { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointSource.cs
+++ b/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointSource.cs
@@ -147,5 +147,13 @@ namespace FlowtideDotNet.Base.Vertices.FixedPoint
         {
             throw new NotImplementedException();
         }
+
+        public void Pause()
+        {
+        }
+
+        public void Resume()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/IStreamVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/IStreamVertex.cs
@@ -45,5 +45,9 @@ namespace FlowtideDotNet.Base.Vertices
         Task DeleteAsync();
 
         IEnumerable<ITargetBlock<IStreamEvent>> GetLinks();
+
+        void Pause();
+
+        void Resume();
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/Ingress/IngressOutput.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Ingress/IngressOutput.cs
@@ -72,7 +72,19 @@ namespace FlowtideDotNet.Base.Vertices.Ingress
 
         internal void Stop()
         {
-            _stopEvents = new TaskCompletionSource();
+            if (_stopEvents == null)
+            {
+                _stopEvents = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+
+        internal void Resume()
+        {
+            if (_stopEvents != null)
+            {
+                _stopEvents.SetResult();
+                _stopEvents = null;
+            }
         }
 
         internal void Fault(Exception exception)

--- a/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
@@ -492,5 +492,17 @@ namespace FlowtideDotNet.Base.Vertices.Ingress
         {
             return Task.CompletedTask;
         }
+
+        public void Pause()
+        {
+            Debug.Assert(_ingressState?._output != null, nameof(_ingressState._output));
+            _ingressState._output.Stop();
+        }
+
+        public void Resume()
+        {
+            Debug.Assert(_ingressState?._output != null, nameof(_ingressState._output));
+            _ingressState._output.Resume();
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/PartitionVertices/PartitionVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/PartitionVertices/PartitionVertex.cs
@@ -39,6 +39,7 @@ namespace FlowtideDotNet.Base.Vertices.PartitionVertices
         private IMeter? _metrics;
         private bool _isHealthy = true;
         private IMemoryAllocator? _memoryAllocator;
+        private TaskCompletionSource? _pauseSource;
 
         public ILogger Logger => _logger ?? throw new InvalidOperationException("Logger can only be fetched after or during initialize");
 
@@ -94,6 +95,11 @@ namespace FlowtideDotNet.Base.Vertices.PartitionVertices
                 {
                     var enumerator = PartitionData(message.Data, message.Time);
 
+                    if (_pauseSource != null)
+                    {
+                        enumerator = WaitForPause(enumerator);
+                    }
+
                     if (message.Data is IRentable rentable)
                     {
                         return new AsyncEnumerableReturnRentable<KeyValuePair<int, StreamMessage<T>>, KeyValuePair<int, IStreamEvent>>(rentable, enumerator, (source) =>
@@ -138,6 +144,20 @@ namespace FlowtideDotNet.Base.Vertices.PartitionVertices
                 _inputBlock.LinkTo(_sources[i].Target, new DataflowLinkOptions { PropagateCompletion = true }, x => x.Key == index);
             }
             
+        }
+
+        private async IAsyncEnumerable<KeyValuePair<int, StreamMessage<T>>> WaitForPause(IAsyncEnumerable<KeyValuePair<int, StreamMessage<T>>> input)
+        {
+            var task = _pauseSource?.Task;
+            if (task != null)
+            {
+                await task;
+            }
+
+            await foreach (var element in input)
+            {
+                yield return element;
+            }
         }
 
         private IAsyncEnumerable<KeyValuePair<int, IStreamEvent>> Broadcast(IStreamEvent streamEvent)
@@ -286,6 +306,23 @@ namespace FlowtideDotNet.Base.Vertices.PartitionVertices
                 output.AddRange(source.GetLinks());
             }
             return output;
+        }
+
+        public void Pause()
+        {
+            if (_pauseSource == null)
+            {
+                _pauseSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+
+        public void Resume()
+        {
+            if (_pauseSource != null)
+            {
+                _pauseSource.SetResult();
+                _pauseSource = null;
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
+++ b/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
@@ -20,6 +20,8 @@ using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Core.Compute.Internal;
 using System.Diagnostics;
 using FlowtideDotNet.Core.Connectors;
+using Microsoft.Extensions.Options;
+using FlowtideDotNet.Base;
 
 namespace FlowtideDotNet.Core.Engine
 {
@@ -99,6 +101,12 @@ namespace FlowtideDotNet.Core.Engine
         public FlowtideBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
         {
             dataflowStreamBuilder.WithLoggerFactory(loggerFactory);
+            return this;
+        }
+
+        public FlowtideBuilder WithPauseMonitor(IOptionsMonitor<FlowtidePauseOptions> pauseMonitor)
+        {
+            dataflowStreamBuilder.WithPauseMonitor(pauseMonitor);
             return this;
         }
 

--- a/src/FlowtideDotNet.DependencyInjection/Internal/FlowtideDIBuilder.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Internal/FlowtideDIBuilder.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base;
 using FlowtideDotNet.Base.Engine;
 using FlowtideDotNet.Core;
 using FlowtideDotNet.Core.Engine;
@@ -17,6 +18,7 @@ using FlowtideDotNet.DependencyInjection.Exceptions;
 using FlowtideDotNet.Storage.StateManager;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.IO.Compression;
@@ -84,6 +86,8 @@ namespace FlowtideDotNet.DependencyInjection.Internal
             var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
             var stateManager = serviceProvider.GetKeyedService<StateManagerOptions>(streamName);
 
+            var pauseMonitor = serviceProvider.GetService<IOptionsMonitor<FlowtidePauseOptions>>();
+            
             if (connectorManager == null)
             {
                 throw new FlowtideMissingConnectorManagerException("IConnectorManager must be registered in the service collection, please do so manually or use the \"AddConnectors\" method.");
@@ -105,6 +109,11 @@ namespace FlowtideDotNet.DependencyInjection.Internal
                 .AddConnectorManager(connectorManager)
                 .AddPlan(plan)
                 .WithStateOptions(stateManager);
+
+            if (pauseMonitor != null)
+            {
+                streamBuilder.WithPauseMonitor(pauseMonitor);
+            }
 
             if (loggerFactory != null)
             {


### PR DESCRIPTION
This adds two options, using IConfiguration or API endpoint binding. It is also possible to manually call pause and resume on the stream.