### PR TITLE
Add types for stream notifications

### DIFF
--- a/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
@@ -42,7 +42,7 @@ namespace FlowtideDotNet.Base.Engine
         {
             _streamName = streamName;
             _dataflowStreamOptions = new DataflowStreamOptions();
-            _streamNotificationReceiver = new StreamNotificationReceiver();
+            _streamNotificationReceiver = new StreamNotificationReceiver(streamName);
         }
 
         public DataflowStreamBuilder AddPropagatorBlock(string name, IStreamVertex block)

--- a/src/FlowtideDotNet.Base/Engine/FailureStrategies/CustomExceptionStrategy.cs
+++ b/src/FlowtideDotNet.Base/Engine/FailureStrategies/CustomExceptionStrategy.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Base.Engine;
+using FlowtideDotNet.Base.Engine.Internal;
 
 namespace FlowtideDotNet.Engine.FailureStrategies
 {
@@ -27,9 +28,9 @@ namespace FlowtideDotNet.Engine.FailureStrategies
             _handler = handler;
         }
 
-        public void OnFailure(Exception? exception)
+        public void OnFailure(StreamFailureNotification notification)
         {
-            _handler(exception);
+            _handler(notification.Exception);
         }
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/FailureStrategies/ExitProcessStrategy.cs
+++ b/src/FlowtideDotNet.Base/Engine/FailureStrategies/ExitProcessStrategy.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Base.Engine;
+using FlowtideDotNet.Base.Engine.Internal;
 
 namespace FlowtideDotNet.Engine.FailureStrategies
 {
@@ -19,7 +20,7 @@ namespace FlowtideDotNet.Engine.FailureStrategies
     /// </summary>
     public class ExitProcessStrategy : IFailureListener
     {
-        public void OnFailure(Exception? exception)
+        public void OnFailure(StreamFailureNotification notification)
         {
             Environment.Exit(Environment.ExitCode);
         }

--- a/src/FlowtideDotNet.Base/Engine/FailureStrategies/KillProcessStrategy.cs
+++ b/src/FlowtideDotNet.Base/Engine/FailureStrategies/KillProcessStrategy.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Base.Engine;
+using FlowtideDotNet.Base.Engine.Internal;
 using System.Diagnostics;
 
 namespace FlowtideDotNet.Engine.FailureStrategies
@@ -20,7 +21,7 @@ namespace FlowtideDotNet.Engine.FailureStrategies
     /// </summary>
     public class KillProcessStrategy : IFailureListener
     {
-        public void OnFailure(Exception? exception)
+        public void OnFailure(StreamFailureNotification notification)
         {
             Process.GetCurrentProcess().Kill();
         }

--- a/src/FlowtideDotNet.Base/Engine/ICheckpointListener.cs
+++ b/src/FlowtideDotNet.Base/Engine/ICheckpointListener.cs
@@ -14,6 +14,6 @@ namespace FlowtideDotNet.Base.Engine
 {
     public interface ICheckpointListener
     {
-        void OnCheckpointComplete();
+        void OnCheckpointComplete(StreamCheckpointNotification notification);
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/IFailureListener.cs
+++ b/src/FlowtideDotNet.Base/Engine/IFailureListener.cs
@@ -14,6 +14,6 @@ namespace FlowtideDotNet.Base.Engine
 {
     public interface IFailureListener
     {
-        void OnFailure(Exception? exception);
+        void OnFailure(StreamFailureNotification notification);
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StreamNotificationReceiver.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StreamNotificationReceiver.cs
@@ -19,7 +19,7 @@ namespace FlowtideDotNet.Base.Engine.Internal
         private readonly List<ICheckpointListener> _checkpointListeners = [];
         private readonly List<IStreamStateChangeListener> _streamStateListeners = [];
         private readonly List<IFailureListener> _failureListeners = [];
-        private readonly string _streamName;
+        private string _streamName;
 
         public StreamNotificationReceiver(string streamName)
         {
@@ -28,7 +28,7 @@ namespace FlowtideDotNet.Base.Engine.Internal
 
         public void OnCheckpointComplete()
         {
-            var notification = new StreamCheckpointNotification(_streamName);
+            var notification = new StreamCheckpointNotification(ref _streamName);
             foreach (var listener in _checkpointListeners)
             {
                 try
@@ -44,7 +44,7 @@ namespace FlowtideDotNet.Base.Engine.Internal
 
         public void OnStreamStateChange(StreamStateValue newState)
         {
-            var notification = new StreamStateChangeNotification(_streamName, newState);
+            var notification = new StreamStateChangeNotification(ref _streamName, ref newState);
             foreach (var listener in _streamStateListeners)
             {
                 try
@@ -60,7 +60,7 @@ namespace FlowtideDotNet.Base.Engine.Internal
 
         public void OnFailure(Exception? exception)
         {
-            var notification = new StreamFailureNotification(_streamName, exception);
+            var notification = new StreamFailureNotification(ref _streamName, exception);
             foreach (var listener in _failureListeners)
             {
                 try

--- a/src/FlowtideDotNet.Base/Engine/Internal/StreamNotificationReceiver.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StreamNotificationReceiver.cs
@@ -19,14 +19,21 @@ namespace FlowtideDotNet.Base.Engine.Internal
         private readonly List<ICheckpointListener> _checkpointListeners = [];
         private readonly List<IStreamStateChangeListener> _streamStateListeners = [];
         private readonly List<IFailureListener> _failureListeners = [];
+        private readonly string _streamName;
+
+        public StreamNotificationReceiver(string streamName)
+        {
+            _streamName = streamName;
+        }
 
         public void OnCheckpointComplete()
         {
+            var notification = new StreamCheckpointNotification(_streamName);
             foreach (var listener in _checkpointListeners)
             {
                 try
                 {
-                    listener.OnCheckpointComplete();
+                    listener.OnCheckpointComplete(notification);
                 }
                 catch
                 {
@@ -37,11 +44,12 @@ namespace FlowtideDotNet.Base.Engine.Internal
 
         public void OnStreamStateChange(StreamStateValue newState)
         {
+            var notification = new StreamStateChangeNotification(_streamName, newState);
             foreach (var listener in _streamStateListeners)
             {
                 try
                 {
-                    listener.OnStreamStateChange(newState);
+                    listener.OnStreamStateChange(notification);
                 }
                 catch
                 {
@@ -52,13 +60,14 @@ namespace FlowtideDotNet.Base.Engine.Internal
 
         public void OnFailure(Exception? exception)
         {
+            var notification = new StreamFailureNotification(_streamName, exception);
             foreach (var listener in _failureListeners)
             {
                 try
                 {
-                    listener.OnFailure(exception);
+                    listener.OnFailure(notification);
                 }
-                catch 
+                catch
                 {
                     // All errors are catched so failure listeners cant break the stream
                 }

--- a/src/FlowtideDotNet.Base/Engine/Notifications/StreamEventNotifications.cs
+++ b/src/FlowtideDotNet.Base/Engine/Notifications/StreamEventNotifications.cs
@@ -10,10 +10,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base.Engine.Internal.StateMachine;
+
 namespace FlowtideDotNet.Base.Engine
 {
-    public interface IStreamStateChangeListener
-    {
-        void OnStreamStateChange(StreamStateChangeNotification notification);
-    }
+    public record class StreamNotification(string StreamName);
+    public record class StreamCheckpointNotification(string StreamName) : StreamNotification(StreamName);
+    public record class StreamFailureNotification(string StreamName, Exception? Exception) : StreamNotification(StreamName);
+    public record class StreamStateChangeNotification(string StreamName, StreamStateValue State) : StreamNotification(StreamName);
 }

--- a/src/FlowtideDotNet.Base/Engine/Notifications/StreamEventNotifications.cs
+++ b/src/FlowtideDotNet.Base/Engine/Notifications/StreamEventNotifications.cs
@@ -14,7 +14,34 @@ using FlowtideDotNet.Base.Engine.Internal.StateMachine;
 
 namespace FlowtideDotNet.Base.Engine
 {
-    public record struct StreamCheckpointNotification(string StreamName);
-    public record struct StreamFailureNotification(string StreamName, Exception? Exception);
-    public record struct StreamStateChangeNotification(string StreamName, StreamStateValue State);
+    public ref struct StreamStateChangeNotification
+    {
+        public readonly ref string StreamName;
+        public readonly ref StreamStateValue State;
+        public StreamStateChangeNotification(ref string streamName, ref StreamStateValue state)
+        {
+            StreamName = ref streamName;
+            State = ref state;
+        }
+    }
+
+    public ref struct StreamCheckpointNotification
+    {
+        public readonly ref string StreamName;
+        public StreamCheckpointNotification(ref string streamName)
+        {
+            StreamName = ref streamName;
+        }
+    }
+
+    public ref struct StreamFailureNotification
+    {
+        public readonly ref string StreamName;
+        public readonly Exception? Exception;
+        public StreamFailureNotification(ref string streamName, Exception? exception)
+        {
+            StreamName = ref streamName;
+            Exception = exception;
+        }
+    }
 }

--- a/src/FlowtideDotNet.Base/Engine/Notifications/StreamEventNotifications.cs
+++ b/src/FlowtideDotNet.Base/Engine/Notifications/StreamEventNotifications.cs
@@ -14,8 +14,7 @@ using FlowtideDotNet.Base.Engine.Internal.StateMachine;
 
 namespace FlowtideDotNet.Base.Engine
 {
-    public record class StreamNotification(string StreamName);
-    public record class StreamCheckpointNotification(string StreamName) : StreamNotification(StreamName);
-    public record class StreamFailureNotification(string StreamName, Exception? Exception) : StreamNotification(StreamName);
-    public record class StreamStateChangeNotification(string StreamName, StreamStateValue State) : StreamNotification(StreamName);
+    public record struct StreamCheckpointNotification(string StreamName);
+    public record struct StreamFailureNotification(string StreamName, Exception? Exception);
+    public record struct StreamStateChangeNotification(string StreamName, StreamStateValue State);
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/NotificationReciever.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/NotificationReciever.cs
@@ -11,7 +11,6 @@
 // limitations under the License.
 
 using FlowtideDotNet.Base.Engine;
-using FlowtideDotNet.Base.Engine.Internal.StateMachine;
 
 namespace FlowtideDotNet.AcceptanceTests.Internal
 {
@@ -26,7 +25,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             this.onCheckpointComplete = onCheckpointComplete;
         }
 
-        public void OnCheckpointComplete()
+        public void OnCheckpointComplete(StreamCheckpointNotification notification)
         {
             onCheckpointComplete();
         }
@@ -48,17 +47,17 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             return false;
         }
 
-        public void OnFailure(Exception? exception)
+        public void OnFailure(StreamFailureNotification notification)
         {
-            if (IsCrashException(exception))
+            if (IsCrashException(notification.Exception))
             {
                 return;
             }
             _error = true;
-            _exception = exception;
+            _exception = notification.Exception;
         }
 
-        public void OnStreamStateChange(StreamStateValue newState)
+        public void OnStreamStateChange(StreamStateChangeNotification notification)
         {
 
         }


### PR DESCRIPTION
Adds container types for stream notifications to allow us to more easily modify this functionality later without introducing breaking changes. Also changes the signatures for the listener interfaces to use these new container types.

```csharp
public ref struct StreamStateChangeNotification
{
    public readonly ref string StreamName;
    public readonly ref StreamStateValue State;
    public StreamStateChangeNotification(ref string streamName, ref StreamStateValue state)
    {
        StreamName = ref streamName;
        State = ref state;
    }
}

public ref struct StreamCheckpointNotification
{
    public readonly ref string StreamName;
    public StreamCheckpointNotification(ref string streamName)
    {
        StreamName = ref streamName;
    }
}

public ref struct StreamFailureNotification
{
    public readonly ref string StreamName;
    public readonly Exception? Exception;
    public StreamFailureNotification(ref string streamName, Exception? exception)
    {
        StreamName = ref streamName;
        Exception = exception;
    }
}

public interface ICheckpointListener
{
    void OnCheckpointComplete(StreamCheckpointNotification notification);
}
public interface IFailureListener
{
    void OnFailure(StreamFailureNotification notification);
}
public interface IStreamStateChangeListener
{
    void OnStreamStateChange(StreamStateChangeNotification notification);
}
```

It would be nice to consider a bit if this is good enough if we were to introduce different types of notifications/listeners, or if there's something that could be improved.

Can/will write some documentation about notifications once we are happy with signatures and functionality etc.

