### PR TITLE
[DeltaLake] Fix so new columns are read as null when schema is evolved for old data files

### DIFF
--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/BinaryEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/BinaryEncoder.cs
@@ -31,7 +31,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
             
             if (_array.IsNull(index))
             {
@@ -58,6 +62,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = default;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/BoolEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/BoolEncoder.cs
@@ -31,7 +31,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetValue(index);
             if (!val.HasValue)
@@ -58,6 +62,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = null;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/DateEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/DateEncoder.cs
@@ -30,7 +30,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetDateTimeOffset(index);
 
@@ -58,6 +62,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = default;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/DecimalEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/DecimalEncoder.cs
@@ -31,7 +31,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetValue(index);
 
@@ -59,6 +63,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = default;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Float32Encoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Float32Encoder.cs
@@ -31,7 +31,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetValue(index);
 
@@ -59,6 +63,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = null;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Float64Encoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Float64Encoder.cs
@@ -32,7 +32,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetValue(index);
             if (!val.HasValue)
@@ -59,6 +63,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = default;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/IArrowEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/IArrowEncoder.cs
@@ -25,6 +25,7 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
         bool IsPartitionValueEncoder { get; }
         void NewFile(Dictionary<string, string>? partitionValues);
         void NewBatch(IArrowArray arrowArray);
+        void NewNullBatch();
         void AddValue(int index, ref AddToColumnFunc func);
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Int32Encoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Int32Encoder.cs
@@ -32,7 +32,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetValue(index);
             if (!val.HasValue)
@@ -59,6 +63,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = null;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Int64Encoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Int64Encoder.cs
@@ -31,7 +31,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetValue(index);
             if (!val.HasValue)
@@ -58,6 +62,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = null;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Int8Encoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/Int8Encoder.cs
@@ -31,7 +31,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetValue(index);
             if (!val.HasValue)
@@ -58,6 +62,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = default;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/ListEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/ListEncoder.cs
@@ -28,6 +28,7 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
     {
         private readonly IArrowEncoder _childEncoder;
         private ListArray? _array;
+        private bool _isNullColumn;
 
         public bool IsPartitionValueEncoder => false;
 
@@ -39,6 +40,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
+            if (_isNullColumn)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
             Debug.Assert(_array != null);
 
             if (_array.IsNull(index))
@@ -64,10 +70,16 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
         {
             _array = (ListArray)arrowArray;
             _childEncoder.NewBatch(_array.Values);
+            _isNullColumn = false;
         }
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _isNullColumn = true;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/MapEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/MapEncoder.cs
@@ -39,7 +39,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             if (_array.IsNull(index))
             {
@@ -84,6 +88,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = null;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/ShortEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/ShortEncoder.cs
@@ -31,7 +31,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetValue(index);
             if (!val.HasValue)
@@ -58,6 +62,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+           _array = null;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/StringEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/StringEncoder.cs
@@ -31,7 +31,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null) 
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             if (_array.IsNull(index))
             {
@@ -58,6 +62,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = default;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/StructEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/StructEncoder.cs
@@ -38,7 +38,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
         }
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             if (_array.IsNull(index))
             {
@@ -76,6 +80,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = null;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/TimestampEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowEncoders/TimestampEncoder.cs
@@ -30,7 +30,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void AddValue(int index, ref AddToColumnFunc func)
         {
-            Debug.Assert(_array != null);
+            if (_array == null)
+            {
+                func.AddValue(NullValue.Instance);
+                return;
+            }
 
             var val = _array.GetTimestamp(index);
             if (!val.HasValue)
@@ -57,6 +61,11 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowE
 
         public void NewFile(Dictionary<string, string>? partitionValues)
         {
+        }
+
+        public void NewNullBatch()
+        {
+            _array = default;
         }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/BinaryPartitionEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/BinaryPartitionEncoder.cs
@@ -66,5 +66,9 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowP
             byte[] byteArray = Encoding.Unicode.GetBytes(value);
             _value = new BinaryValue(byteArray);
         }
+
+        public void NewNullBatch()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/BoolPartitionEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/BoolPartitionEncoder.cs
@@ -70,5 +70,9 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowP
 
             _value = new BoolValue(boolValue);
         }
+
+        public void NewNullBatch()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/DatePartitionEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/DatePartitionEncoder.cs
@@ -69,5 +69,9 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowP
 
             _value = new TimestampTzValue(dateValue);
         }
+
+        public void NewNullBatch()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/DecimalPartitionEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/DecimalPartitionEncoder.cs
@@ -71,5 +71,9 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowP
 
             _value = new DecimalValue(decimalValue);
         }
+
+        public void NewNullBatch()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/FloatingPointPartitionEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/FloatingPointPartitionEncoder.cs
@@ -71,5 +71,9 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowP
 
             _value = new DoubleValue(doubleValue);
         }
+
+        public void NewNullBatch()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/IntegerPartitionEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/IntegerPartitionEncoder.cs
@@ -70,5 +70,9 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowP
 
             _value = new Int64Value(intValue);
         }
+
+        public void NewNullBatch()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/StringPartitionEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/StringPartitionEncoder.cs
@@ -65,5 +65,9 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowP
 
             _partitionValue = new StringValue(value);
         }
+
+        public void NewNullBatch()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/TimestampPartitionEncoder.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ArrowPartitionEncoders/TimestampPartitionEncoder.cs
@@ -69,5 +69,9 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.ArrowP
 
             _value = new TimestampTzValue(dateValue);
         }
+
+        public void NewNullBatch()
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ParquetSharpReader.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ParquetSharpReader.cs
@@ -402,6 +402,7 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat
                 encoder.NewFile(partitionValues);
             }
 
+            HashSet<int> nullColumns = new HashSet<int>();
             for (int i = 0; i < _physicalColumnNamesInBatch.Count; i++)
             {
                 
@@ -420,7 +421,7 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat
                 }
                 if (!found)
                 {
-                    throw new InvalidOperationException($"Could not find field {_physicalColumnNamesInBatch[i]} in batch");
+                    nullColumns.Add(i);
                 }
             }
 
@@ -444,7 +445,15 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat
                         var encoder = _encoders[i];
                         if (!encoder.IsPartitionValueEncoder)
                         {
-                            encoder.NewBatch(batch.Column(columnIndex));
+                            if (nullColumns.Contains(i))
+                            {
+                                encoder.NewNullBatch();
+                            }
+                            else
+                            {
+                                encoder.NewBatch(batch.Column(columnIndex));
+                            }
+                            
                             columnIndex++;
                         }
                     }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ParquetWriters/ParquetStructWriter.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/ParquetFormat/ParquetWriters/ParquetStructWriter.cs
@@ -100,7 +100,16 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.ParquetFormat.Parque
 
         public IStatisticsComparer? GetStatisticsComparer()
         {
-            return new StructStatisticsComparer(propertyWriters.Select(x => new KeyValuePair<string, IStatisticsComparer>(x.Key, x.Value.GetStatisticsComparer())), _nullCount);
+            List<KeyValuePair<string, IStatisticsComparer>> statisticsComparers = new List<KeyValuePair<string, IStatisticsComparer>>();
+            foreach(var writer in propertyWriters)
+            {
+                var comparer = writer.Value.GetStatisticsComparer();
+                if (comparer != null)
+                {
+                    statisticsComparers.Add(new KeyValuePair<string, IStatisticsComparer>(writer.Key, comparer));
+                }
+            }
+            return new StructStatisticsComparer(statisticsComparers, _nullCount);
         }
 
         public void NewBatch()

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/DeltaLakeSource.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/DeltaLakeSource.cs
@@ -422,15 +422,17 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal
                 maxVersion = 0;
             }
 
+            // Always fetch latest table to get all the latest column names
+            var latestTable = await DeltaTransactionReader.ReadTable(_options.StorageLocation, _tableLoc);
             _table = await DeltaTransactionReader.ReadTable(_options.StorageLocation, _tableLoc, maxVersion);
 
-            if (_table == null)
+            if (_table == null || latestTable == null)
             {
                 throw new InvalidOperationException($"Delta Lake Table {_tableName} does not exist");
             }
 
             var reader = new ParquetSharpReader();
-            reader.Initialize(_table, _readRelation.BaseSchema.Names);
+            reader.Initialize(latestTable, _readRelation.BaseSchema.Names);
             _reader = reader;
 
             _changesTree = await stateManagerClient.GetOrCreateTree("changes", new BPlusTreeOptions<ColumnRowReference, int, ColumnKeyStorageContainer, PrimitiveListValueContainer<int>>() 


### PR DESCRIPTION
This also fixes a warning in the parquet struct writer