### PR TITLE
[Bugfix] Add that the tree is commited in grouped write operator

### DIFF
--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ColumnGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ColumnGroupedWriteOperator.cs
@@ -156,12 +156,14 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
         protected override async Task OnCheckpoint(long checkpointTime)
         {
             Debug.Assert(m_hasSentInitialData != null);
+            Debug.Assert(m_tree != null);
             if (m_executionMode == ExecutionMode.OnCheckpoint || (m_executionMode == ExecutionMode.Hybrid && !m_hasSentInitialData.Value))
             {
                 await SendData();
             }
             Checkpoint(checkpointTime);
             await m_hasSentInitialData.Commit();
+            await m_tree.Commit();
         }
 
         protected abstract void Checkpoint(long checkpointTime);


### PR DESCRIPTION
This bug caused that scenarios where a primary key have two rows for the same id, and the one written to destiantion is deleted, the other row with the same id would not be written.