### PR TITLE
Refactor connection string handling for flexibility

### DIFF
--- a/docs/docs/statepersistence.md
+++ b/docs/docs/statepersistence.md
@@ -161,10 +161,12 @@ builder.Services.AddFlowtideStream("yourstream")
     {
         // register sql server storage using default settings
         s.AddSqlServerStorage("[connectionstring]");
+        // register sql server storge using function to retrieve the connection string.
+        s.AddSqlServerStorage(() => "[connectionstring]");
         // or use the overload to specify more settings
         s.AddSqlServerStorage(new SqlServerPersistentStorageSettings()
         {
-            ConnectionString = "[connectionstring]",
+            ConnectionStringFunc = () => builder.Configuration.GetConnectionString("[connectionstring]"),
             // if you created the tables on a non default schema (or with another name) you can specify the full name for the tables used here.
             // it's also possible to specify the database name as part of table name.
             StreamTableName = "[MySchema].[Streams]",

--- a/src/FlowtideDotNet.Storage.SqlServer/Data/BaseSqlRepository.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/Data/BaseSqlRepository.cs
@@ -10,13 +10,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure;
 using FlowtideDotNet.Storage.SqlServer.Exceptions;
 using Microsoft.Data.SqlClient;
 using System.Buffers.Binary;
 using System.Data;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace FlowtideDotNet.Storage.SqlServer.Data
@@ -61,7 +58,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             DebugWriter!.WriteCall([key]);
 #endif
 
-            using var connection = new SqlConnection(Settings.ConnectionString);
+            using var connection = new SqlConnection(Settings.ConnectionStringFunc());
             using var cmd = new SqlCommand();
             cmd.Connection = connection;
             cmd.Parameters.AddWithValue("@key", key);
@@ -105,7 +102,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             DebugWriter!.WriteCall([key]);
 #endif
 
-            using var connection = new SqlConnection(Settings.ConnectionString);
+            using var connection = new SqlConnection(Settings.ConnectionStringFunc());
             using var cmd = new SqlCommand();
             cmd.Connection = connection;
             cmd.Parameters.AddWithValue("@key", key);
@@ -158,7 +155,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
 
             if (transaction == null)
             {
-                using var connection = new SqlConnection(Settings.ConnectionString);
+                using var connection = new SqlConnection(Settings.ConnectionStringFunc());
                 await connection.OpenAsync();
                 await SaveStreamPagesAsync(reader, connection);
             }
@@ -236,7 +233,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             DebugWriter!.WriteCall();
 #endif
 
-            using var connection = new SqlConnection(Settings.ConnectionString);
+            using var connection = new SqlConnection(Settings.ConnectionStringFunc());
             using var cmd = new SqlCommand($"DELETE FROM {Settings.StreamPageTableName} WHERE Version > @Version AND StreamKey = @StreamKey", connection);
             cmd.Parameters.AddWithValue("@Version", Stream.Metadata.CurrentVersion);
             cmd.Parameters.AddWithValue("@StreamKey", Stream.Metadata.StreamKey);

--- a/src/FlowtideDotNet.Storage.SqlServer/Data/SessionRepository.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/Data/SessionRepository.cs
@@ -45,7 +45,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             DebugWriter!.WriteCall();
 #endif
             var reader = new StreamPageDataReader(pages);
-            using var connection = new SqlConnection(Settings.ConnectionString);
+            using var connection = new SqlConnection(Settings.ConnectionStringFunc());
             await connection.OpenAsync();
             await SaveStreamPagesAsync(reader, connection);
         }

--- a/src/FlowtideDotNet.Storage.SqlServer/Data/StorageRepository.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/Data/StorageRepository.cs
@@ -28,7 +28,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             DebugWriter!.WriteCall();
 #endif
             ArgumentNullException.ThrowIfNull(Stream.Metadata.StreamKey);
-            using var connection = new SqlConnection(Settings.ConnectionString);
+            using var connection = new SqlConnection(Settings.ConnectionStringFunc());
             using var cmd = new SqlCommand(
                 $"DELETE FROM {Settings.StreamPageTableName} WHERE StreamKey = @StreamKey; " +
                 $"UPDATE {Settings.StreamTableName} SET LastSuccessfulVersion = 0 WHERE StreamKey = @StreamKey", connection);
@@ -39,7 +39,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
 
         public static async Task<StreamInfo> UpsertStream(string name, SqlServerPersistentStorageSettings settings)
         {
-            using var connection = new SqlConnection(settings.ConnectionString);
+            using var connection = new SqlConnection(settings.ConnectionStringFunc());
             using var command = new SqlCommand($@"
                     DECLARE @StreamKey INT;
                     DECLARE @Version INT = 0;
@@ -81,7 +81,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
 #if DEBUG_WRITE
             DebugWriter!.WriteCall();
 #endif
-            using var connection = new SqlConnection(Settings.ConnectionString);
+            using var connection = new SqlConnection(Settings.ConnectionStringFunc());
             using var cmd = new SqlCommand($"UPDATE {Settings.StreamTableName} SET LastSuccessfulVersion = @Version WHERE StreamKey = @StreamKey", connection);
             cmd.Parameters.AddWithValue("@Version", Stream.Metadata.CurrentVersion);
             cmd.Parameters.AddWithValue("@StreamKey", Stream.Metadata.StreamKey);

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorage.cs
@@ -44,7 +44,7 @@ namespace FlowtideDotNet.Storage.SqlServer
             Debug.Assert(_stream != null, "Stream should be initialized");
             Debug.Assert(_storageRepository != null, "Stream repository should be initialized");
 
-            using var connection = new SqlConnection(_settings.ConnectionString);
+            using var connection = new SqlConnection(_settings.ConnectionStringFunc());
             await connection.OpenAsync();
             using var transaction = (SqlTransaction)await connection.BeginTransactionAsync();
 
@@ -98,7 +98,7 @@ namespace FlowtideDotNet.Storage.SqlServer
 
             // todo: We might not actually need to do anything on compact as it's already done in checkpoint?
             Debug.Assert(_storageRepository != null, "Stream repository should be initialized");
-            using var connection = new SqlConnection(_settings.ConnectionString);
+            using var connection = new SqlConnection(_settings.ConnectionStringFunc());
             await connection.OpenAsync();
             using var transaction = (SqlTransaction)await connection.BeginTransactionAsync();
 
@@ -146,7 +146,7 @@ namespace FlowtideDotNet.Storage.SqlServer
                 await repo.ClearLocalAndWaitForBackgroundTasks();
             }
 
-            using var connection = new SqlConnection(_settings.ConnectionString);
+            using var connection = new SqlConnection(_settings.ConnectionStringFunc());
             await connection.OpenAsync();
             using var transaction = (SqlTransaction)await connection.BeginTransactionAsync();
 

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorageSettings.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorageSettings.cs
@@ -18,9 +18,9 @@ namespace FlowtideDotNet.Storage.SqlServer
     public class SqlServerPersistentStorageSettings
     {
         /// <summary>
-        /// Gets or sets the connection string used to connect to the SQL Server database.
+        /// Gets or sets function for retrieval of the connection string used to connect to the SQL Server database.
         /// </summary>
-        public required string ConnectionString { get; set; }
+        public required Func<string> ConnectionStringFunc { get; set; }
 
         /// <summary>
         /// Gets or sets the limit for the number of pages to be written in bulk operations. 

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerStorageExtensions.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerStorageExtensions.cs
@@ -27,7 +27,17 @@ namespace FlowtideDotNet.Storage.SqlServer
         {
             storageBuilder.SetPersistentStorage(new SqlServerPersistentStorage(new SqlServerPersistentStorageSettings
             {
-                ConnectionString = connectionString,
+                ConnectionStringFunc = () => connectionString,
+            }));
+
+            return storageBuilder;
+        }
+
+        public static IFlowtideStorageBuilder AddSqlServerStorage(this IFlowtideStorageBuilder storageBuilder, Func<string> connectionStringFunc)
+        {
+            storageBuilder.SetPersistentStorage(new SqlServerPersistentStorage(new SqlServerPersistentStorageSettings
+            {
+                ConnectionStringFunc = connectionStringFunc,
             }));
 
             return storageBuilder;

--- a/tests/FlowtideDotNet.Storage.SqlServer.Tests/SqlStorageTests.cs
+++ b/tests/FlowtideDotNet.Storage.SqlServer.Tests/SqlStorageTests.cs
@@ -391,7 +391,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Tests
         {
             var settings = new SqlServerPersistentStorageSettings
             {
-                ConnectionString = _fixture.ConnectionString,
+                ConnectionStringFunc = () => _fixture.ConnectionString,
                 WritePagesBulkLimit = writePagesBulkLimit,
                 BulkCopySettings = new SqlServerBulkCopySettings(),
                 StreamTableName = $"[{schema}].[Streams]",


### PR DESCRIPTION
Replaced direct usage of connection strings with a function that retrieves the connection string. 

This change allows for runtime generation or modification of the connection string. Updates were made across multiple files, including `BaseSqlRepository.cs`, `SessionRepository.cs`, `StorageRepository.cs`, `SqlServerPersistentStorage.cs`, `SqlServerPersistentStorageSettings.cs`, `SqlServerStorageExtensions.cs`, and `SqlStorageTests.cs`. 

The connection string is now accessed via a `ConnectionStringFunc` delegate, and corresponding tests have been updated to reflect this new structure.