### PR TITLE
[Bugfix] Fix insert range from basic column for union column

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -812,10 +812,10 @@ namespace FlowtideDotNet.Core.ColumnStore
                     {
                         Debug.Assert(_dataColumn != null);
                         Debug.Assert(column._dataColumn != null);
-                        _dataColumn.InsertRangeFrom(index, column._dataColumn, start, count, column._validityList);
+                        _dataColumn.InsertRangeFrom(index, column._dataColumn, start, count, column._nullCounter > 0 ? column._validityList : default);
                         return;
                     }
-                    //Debug.Assert(_dataColumn != null);
+
                     if (_nullCounter > 0 || column._nullCounter > 0)
                     {
                         if (_nullCounter > 0 && column._nullCounter > 0)
@@ -851,7 +851,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                     Debug.Assert(_dataColumn != null);
                     Debug.Assert(column._dataColumn != null);
                     // Insert the actual data
-                    _dataColumn.InsertRangeFrom(index, column._dataColumn, start, count, column._validityList);
+                    _dataColumn.InsertRangeFrom(index, column._dataColumn, start, count, column._nullCounter > 0 ? column._validityList : default);
                 }
                 else
                 {
@@ -921,7 +921,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                     Debug.Assert(column._dataColumn != null);
 
                     // Insert the data into the union column
-                    _dataColumn.InsertRangeFrom(index, column._dataColumn, start, count, column._validityList);
+                    _dataColumn.InsertRangeFrom(index, column._dataColumn, start, count, column._nullCounter > 0 ? column._validityList : default);
                 }
             }
             else

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/UnionColumnTests.cs
@@ -13,9 +13,11 @@
 using FlowtideDotNet.Core.ColumnStore;
 using FlowtideDotNet.Core.ColumnStore.DataColumns;
 using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.Serialization;
 using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Storage.Memory;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -487,6 +489,29 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Assert.Equal("world", unionColumn.GetValueAt(1, default).AsString.ToString());
             Assert.True(unionColumn.GetValueAt(2, default).IsNull);
             Assert.Equal(3, unionColumn.GetValueAt(3, default).AsDecimal);
+        }
+
+        [Fact]
+        public void TestInsertRangeFromInsertBasicColumnWithEmptyValidityList()
+        {
+            Column unionColumn = new Column(GlobalMemoryManager.Instance)
+            {
+                new Int64Value(1),
+                new DecimalValue(3)
+            };
+
+            Column stringColumn = new Column(GlobalMemoryManager.Instance)
+            {
+                new StringValue("hello"),
+                new StringValue("world")
+            };
+
+            unionColumn.InsertRangeFrom(1, stringColumn, 1, 1);
+
+            Assert.Equal(3, unionColumn.Count);
+            Assert.Equal(1, unionColumn.GetValueAt(0, default).AsLong);
+            Assert.Equal("world", unionColumn.GetValueAt(1, default).AsString.ToString());
+            Assert.Equal(3, unionColumn.GetValueAt(2, default).AsDecimal);
         }
 
         [Fact]


### PR DESCRIPTION
Inserting range from a basic column could cause an exception if the basic column did not contain any null values