### PR TITLE
Add string_split function for substring manipulation

### DIFF
--- a/docs/docs/expressions/scalarfunctions/string.md
+++ b/docs/docs/expressions/scalarfunctions/string.md
@@ -219,6 +219,8 @@ Splits a string into a collection of substrings based on the specified delimiter
 
 _If the provided delimiter character is null, the original string will be returned as the only element in the resulting collection._
 
+_If the provided delimiter character is not a string, null will be returned._
+
 ### SQL Usage
 
 ```sql

--- a/docs/docs/expressions/scalarfunctions/string.md
+++ b/docs/docs/expressions/scalarfunctions/string.md
@@ -210,3 +210,17 @@ index 1 for the first character.
 ```sql
 SELECT strpos(c1, 'abc') FROM ...
 ```
+
+## String split
+
+[Substrait definition](https://substrait.io/extensions/functions_string/#string_split)
+
+Splits a string into a collection of substrings based on the specified delimiter character. 
+
+_If the provided delimiter character is null, the original string will be returned as the only element in the resulting collection._
+
+### SQL Usage
+
+```sql
+SELECT string_split('a b', ' ') ...
+```

--- a/src/FlowtideDotNet.Core/ColumnStore/RowEventToEventBatchData.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/RowEventToEventBatchData.cs
@@ -48,6 +48,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                     return new BinaryValue(blob.ToArray());
                 case FlexBuffers.Type.Map:
                     return MapToDataValue(flxValue);
+                case FlexBuffers.Type.VectorString:
                 case FlexBuffers.Type.Vector:
                     return ListToDataValue(flxValue);
             }

--- a/src/FlowtideDotNet.Core/Compute/Internal/BuiltInStringFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/BuiltInStringFunctions.cs
@@ -309,6 +309,11 @@ namespace FlowtideDotNet.Core.Compute.Internal
                 return FlxValue.FromBytes(FlexBuffer.From(result));
             }
 
+            if (splitStr.ValueType != FlexBuffers.Type.String)
+            {
+                return NullValue;
+            }
+
             var split = val.AsString.Split([splitStr.AsString], StringSplitOptions.None);
             return FlxValue.FromBytes(FlexBuffer.From(split));
         }

--- a/src/FlowtideDotNet.Core/Compute/Internal/BuiltInStringFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/BuiltInStringFunctions.cs
@@ -87,8 +87,6 @@ namespace FlowtideDotNet.Core.Compute.Internal
                 });
 
             StringAggAggregation.Register(functionsRegister);
-
-            functionsRegister.RegisterScalarFunctionWithExpression(FunctionsString.Uri, FunctionsString.StringSplit, (x, y) => StringSplitImplementation(x, y));
         }
 
         private static FlxValue ToStringImplementation(in FlxValue val)
@@ -294,28 +292,6 @@ namespace FlowtideDotNet.Core.Compute.Internal
                 return NullValue;
             }
             return FlxValue.FromBytes(FlexBuffer.SingleValue(val.AsString.Length));
-        }
-
-        private static FlxValue StringSplitImplementation(in FlxValue val, in FlxValue splitStr)
-        {
-            if (val.ValueType != FlexBuffers.Type.String)
-            {
-                return NullValue;
-            }
-
-            if (splitStr.ValueType == FlexBuffers.Type.Null)
-            {
-                var result = new string[] { val.AsString };
-                return FlxValue.FromBytes(FlexBuffer.From(result));
-            }
-
-            if (splitStr.ValueType != FlexBuffers.Type.String)
-            {
-                return NullValue;
-            }
-
-            var split = val.AsString.Split([splitStr.AsString], StringSplitOptions.None);
-            return FlxValue.FromBytes(FlexBuffer.From(split));
         }
     }
 }

--- a/src/FlowtideDotNet.Substrait/FunctionExtensions/FunctionsString.cs
+++ b/src/FlowtideDotNet.Substrait/FunctionExtensions/FunctionsString.cs
@@ -30,6 +30,7 @@ namespace FlowtideDotNet.Substrait.FunctionExtensions
         public const string StringBase64Decode = "string_base64_decode";
         public const string CharLength = "char_length";
         public const string StrPos = "strpos";
+        public const string StringSplit = "string_split";
 
         public const string StringAgg = "string_agg";
     }

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
@@ -722,6 +722,8 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
 
             RegisterOneVariableScalarFunction(sqlFunctionRegister, "len", FunctionsString.Uri, FunctionsString.CharLength);
             RegisterTwoVariableScalarFunction(sqlFunctionRegister, "strpos", FunctionsString.Uri, FunctionsString.StrPos);
+            
+           RegisterTwoVariableScalarFunction(sqlFunctionRegister, "string_split", FunctionsString.Uri, FunctionsString.StringSplit);
 
             // Table functions
             UnnestSqlFunction.AddUnnest(sqlFunctionRegister);

--- a/tests/FlowtideDotNet.AcceptanceTests/StringFunctionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/StringFunctionTests.cs
@@ -202,7 +202,7 @@ namespace FlowtideDotNet.AcceptanceTests
         public async Task StringSplit()
         {
             GenerateData();
-            await StartStream("INSERT INTO output SELECT string_split(concat(firstName, ' ',lastName), ' ') as NameParts FROM users");
+            await StartStream("INSERT INTO output SELECT string_split(concat(firstName, ' ', lastName), ' ') as NameParts FROM users");
             await WaitForUpdate();
             AssertCurrentDataEqual(Users.Select(x => new { NameParts = ($"{x.FirstName} {x.LastName}").Split(' ') }));
         }

--- a/tests/FlowtideDotNet.AcceptanceTests/StringFunctionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/StringFunctionTests.cs
@@ -197,5 +197,14 @@ namespace FlowtideDotNet.AcceptanceTests
             await WaitForUpdate();
             AssertCurrentDataEqual(Users.Select(x => new { val = x.FirstName!.IndexOf(start) + 1 }));
         }
+
+        [Fact]
+        public async Task StringSplit()
+        {
+            GenerateData();
+            await StartStream("INSERT INTO output SELECT string_split(concat(firstName, ' ',lastName), ' ') as NameParts FROM users");
+            await WaitForUpdate();
+            AssertCurrentDataEqual(Users.Select(x => new { NameParts = ($"{x.FirstName} {x.LastName}").Split(' ') }));
+        }
     }
 }

--- a/tests/FlowtideDotNet.ComputeTests/Internal/Parser/Tests/DataTypeValueWriter.cs
+++ b/tests/FlowtideDotNet.ComputeTests/Internal/Parser/Tests/DataTypeValueWriter.cs
@@ -47,6 +47,7 @@ namespace FlowtideDotNet.ComputeTests.SourceGenerator.Internal.Tests
                     }
                     return new DoubleValue(double.Parse(value, CultureInfo.InvariantCulture));
                 case "str":
+                    value = value.Trim('\'');
                     return new StringValue(value);
                 case "dec":
                     return new DecimalValue(decimal.Parse(value, CultureInfo.InvariantCulture));

--- a/tests/FlowtideDotNet.ComputeTests/Substrait/cases/string/string_split.test
+++ b/tests/FlowtideDotNet.ComputeTests/Substrait/cases/string/string_split.test
@@ -1,0 +1,9 @@
+﻿### SUBSTRAIT_SCALAR_TEST: v1.0
+### SUBSTRAIT_INCLUDE: '/extensions/functions_string.yaml'
+
+# basic: Basic examples without any special cases
+string_split('abc'::str, ' '::str) = ['abc']::list<str>
+string_split('abc abc'::str, ' '::str) = ['abc', 'abc']::list<str>
+string_split('bacad'::str, 'a'::str) = ['b', 'c', 'd']::list<str>
+string_split('a b c d'::str, ' '::str) = ['a', 'b', 'c', 'd']::list<str>
+string_split('a b c d'::str, null::str) = ['a b c d']::list<str>


### PR DESCRIPTION
Introduce a new `string_split` function that splits a string into a collection of substrings based on a specified delimiter. If the delimiter is null, the original string is returned as the only element. The function is implemented in `BuiltInStringFunctions.cs` and registered in the `FunctionsString` class. Tests for `string_split` are added in `StringFunctionTests.cs`, along with a new test file `string_split.test` to validate its functionality.