### PR TITLE
Add regexp_string_split function for regex-based splitting

### DIFF
--- a/docs/docs/expressions/scalarfunctions/string.md
+++ b/docs/docs/expressions/scalarfunctions/string.md
@@ -238,5 +238,5 @@ _If any of the arguments is not string, null will be returned._
 ### SQL Usage
 
 ```sql
-SELECT string_split('a b', '\s') ...
+SELECT regexp_string_split('a b', '\s') ...
 ```

--- a/docs/docs/expressions/scalarfunctions/string.md
+++ b/docs/docs/expressions/scalarfunctions/string.md
@@ -226,3 +226,17 @@ _If the provided delimiter character is not a string, null will be returned._
 ```sql
 SELECT string_split('a b', ' ') ...
 ```
+
+## Regexp string split
+
+[Substrait definition](https://substrait.io/extensions/functions_string/#regexp_string_split)
+
+Splits a string into a collection of substrings based on the specified pattern.
+
+_If any of the arguments is not string, null will be returned._
+
+### SQL Usage
+
+```sql
+SELECT string_split('a b', '\s') ...
+```

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BuiltInStringFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BuiltInStringFunctions.cs
@@ -761,6 +761,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions
         {
             if (val.Type != ArrowTypeId.String || pattern.Type != ArrowTypeId.String)
             {
+                result._type = ArrowTypeId.Null;
                 return result;
             }
 

--- a/src/FlowtideDotNet.Substrait/FunctionExtensions/FunctionsString.cs
+++ b/src/FlowtideDotNet.Substrait/FunctionExtensions/FunctionsString.cs
@@ -31,6 +31,7 @@ namespace FlowtideDotNet.Substrait.FunctionExtensions
         public const string CharLength = "char_length";
         public const string StrPos = "strpos";
         public const string StringSplit = "string_split";
+        public const string RegexStringSplit = "regexp_string_split";
 
         public const string StringAgg = "string_agg";
     }

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
@@ -722,8 +722,9 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
 
             RegisterOneVariableScalarFunction(sqlFunctionRegister, "len", FunctionsString.Uri, FunctionsString.CharLength);
             RegisterTwoVariableScalarFunction(sqlFunctionRegister, "strpos", FunctionsString.Uri, FunctionsString.StrPos);
-            
-           RegisterTwoVariableScalarFunction(sqlFunctionRegister, "string_split", FunctionsString.Uri, FunctionsString.StringSplit);
+
+            RegisterTwoVariableScalarFunction(sqlFunctionRegister, "string_split", FunctionsString.Uri, FunctionsString.StringSplit);
+            RegisterTwoVariableScalarFunction(sqlFunctionRegister, "regexp_string_split", FunctionsString.Uri, FunctionsString.RegexStringSplit);
 
             // Table functions
             UnnestSqlFunction.AddUnnest(sqlFunctionRegister);

--- a/tests/FlowtideDotNet.AcceptanceTests/StringFunctionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/StringFunctionTests.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using System.Text;
+using System.Text.RegularExpressions;
 using Xunit.Abstractions;
 
 namespace FlowtideDotNet.AcceptanceTests
@@ -205,6 +206,16 @@ namespace FlowtideDotNet.AcceptanceTests
             await StartStream("INSERT INTO output SELECT string_split(concat(firstName, ' ', lastName), ' ') as NameParts FROM users");
             await WaitForUpdate();
             AssertCurrentDataEqual(Users.Select(x => new { NameParts = ($"{x.FirstName} {x.LastName}").Split(' ') }));
+        }
+
+        [Fact]
+        public async Task RegexStringSplit()
+        {
+            var pattern = @"\s";
+            GenerateData();
+            await StartStream($"INSERT INTO output SELECT regexp_string_split(concat(firstName, ' ', lastName), '{pattern}') as NameParts FROM users");
+            await WaitForUpdate();
+            AssertCurrentDataEqual(Users.Select(x => new { FirstLetter = Regex.Split($"{x.FirstName} {x.LastName}", pattern) }));
         }
     }
 }

--- a/tests/FlowtideDotNet.ComputeTests/Substrait/cases/string/regexp_string_split.test
+++ b/tests/FlowtideDotNet.ComputeTests/Substrait/cases/string/regexp_string_split.test
@@ -1,0 +1,39 @@
+﻿### SUBSTRAIT_SCALAR_TEST: v1.0
+### SUBSTRAIT_INCLUDE: '/extensions/functions_string.yaml'
+
+# lazy_matching: Examples with lazy matching
+regexp_string_split('Hello'::str, 'Hel+?'::str) = ['', 'lo']::list<str>
+regexp_string_split('Hello'::str, 'Hel+'::str) = ['', 'o']::list<str>
+
+# greedy_matching: Examples with greedy matching
+regexp_string_split('HHHelloooo'::str, 'Hel+'::str) = ['HH', 'oooo']::list<str>
+
+# position_anchors: Examples with position anchors
+regexp_string_split('abcdefg'::str, '\Aabc'::str) = ['', 'defg']::list<str>
+regexp_string_split('abcdefg'::str, 'efg$'::str) = ['abcd', '']::list<str>
+
+# metacharacters: Examples with metacharacters
+regexp_string_split('abc1abc'::str, '\d'::str) = ['abc', 'abc']::list<str>
+regexp_string_split('111a111'::str, '\D'::str) = ['111', '111']::list<str>
+regexp_string_split('abc def'::str, '\s'::str) = ['abc', 'def']::list<str>
+regexp_string_split('a bcdef'::str, '\S'::str) = ['', ' ', '', '', '', '', '']::list<str>
+regexp_string_split(' abcdef'::str, '\w'::str) = [' ', '', '', '', '', '', '']::list<str>
+regexp_string_split('a bcdef'::str, '\W'::str) = ['a', 'bcdef']::list<str>
+
+# occurrence_indicator: Examples with occurrence indicators
+regexp_string_split('abc123abc'::str, '[0-9]+'::str) = ['abc', 'abc']::list<str>
+regexp_string_split('abc123abc'::str, '[bc]'::str) = ['a', '', '123a', '', '']::list<str>
+regexp_string_split('abcde'::str, '(.*)c'::str) = ['', 'de']::list<str>
+regexp_string_split('abbbbc'::str, '[b]{2,3}'::str) = ['a', 'bc']::list<str>
+
+# lookahead: Examples with lookahead
+regexp_string_split('100 dollars'::str, '\d+(?= dollars)'::str) [lookaround:TRUE] = ['', ' dollars']::list<str>
+
+# negative_lookahead: Examples with negative lookahead
+regexp_string_split('100 pesos'::str, '\d+(?!\d| dollars)'::str) [lookaround:TRUE] = ['', ' pesos']::list<str>
+
+# lookbehind: Examples with lookbehind
+regexp_string_split('USD100'::str, '(?<=USD)\d{3}'::str) [lookaround:TRUE] = ['USD', '']::list<str>
+
+# negative_lookbehind: Examples with negative lookbehind
+regexp_string_split('JPY100'::str, '\d{3}(?<!USD\d{3})'::str) [lookaround:TRUE] = ['JPY', '']::list<str>


### PR DESCRIPTION
This commit introduces the `regexp_string_split` function, allowing strings to be split based on regular expression patterns. The function is registered in the `BuiltInStringFunctions` and `BuiltInSqlFunctions` namespaces for SQL query usage. It includes validation to return null if the arguments are not strings. Comprehensive tests have been added to cover various regex scenarios, and documentation has been updated to clarify that null will be returned if the delimiter or value is not a string.