### PR TITLE
Refactor assertion property name in StringFunctionTests

### DIFF
--- a/tests/FlowtideDotNet.AcceptanceTests/StringFunctionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/StringFunctionTests.cs
@@ -215,7 +215,7 @@ namespace FlowtideDotNet.AcceptanceTests
             GenerateData();
             await StartStream($"INSERT INTO output SELECT regexp_string_split(concat(firstName, ' ', lastName), '{pattern}') as NameParts FROM users");
             await WaitForUpdate();
-            AssertCurrentDataEqual(Users.Select(x => new { FirstLetter = Regex.Split($"{x.FirstName} {x.LastName}", pattern) }));
+            AssertCurrentDataEqual(Users.Select(x => new { NameParts = Regex.Split($"{x.FirstName} {x.LastName}", pattern) }));
         }
     }
 }


### PR DESCRIPTION
Updated the property name in the assertion from `FirstLetter` to `NameParts` for better clarity. This change accurately reflects the data being processed by the `Regex.Split` method, which splits full names into their constituent parts.