### PR TITLE
Add support for options data source from configuration

### DIFF
--- a/docs/docs/connectors/configurationdata.md
+++ b/docs/docs/connectors/configurationdata.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Configuration Data
 
-It is possible to use data from IConifugration as a data source, this can be useful if one wants to use configuration inside the stream, for instance to
+It is possible to use data from IConfiguration as a data source, this can be useful if one wants to use configuration inside the stream, for instance to
 filter out rows that do not exist in the configuration.
 
 ## Options Data Source

--- a/docs/docs/connectors/configurationdata.md
+++ b/docs/docs/connectors/configurationdata.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 1
+---
+
+# Configuration Data
+
+It is possible to use data from IConifugration as a data source, this can be useful if one wants to use configuration inside the stream, for instance to
+filter out rows that do not exist in the configuration.
+
+## Options Data Source
+
+The options data source uses `IOptionsMonitor<TOptions>` to listen to changes and to get the configuration settings.
+
+The Options data source is built-in as a default connector when installing FlowtideDotNet, so no extra nuget package is required.
+Options are added with the `AddOptionsSource<TOptions>` method on the connector maanger.
+
+One of the main benefits of this connector comes if you have a configuration provider that allows reloading, then data can be updated
+without restarting the stream.
+
+Example: 
+```csharp
+internal class TestOptions
+{
+    public string? Name { get; set; }
+}
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOptions<TestConfig>()
+    .Bind(builder.Configuration.GetSection("config"));
+
+builder.Services.AddFlowtideStream("test")
+    .AddConnectors((connectorManager) =>
+    {
+        connectorManager.AddOptionsSource<TestConfig>("config");
+
+        ...
+})
+
+...
+```
+
+Configuration settings:
+
+```json
+{
+    "config": {
+        "name": "hello"
+    }
+}
+```
+
+SQL statement:
+
+```sql
+INSERT INTO output
+SELECT name FROM config
+```
+
+This stream would result in the following data:
+
+| name  |
+| ----- |
+| hello |
+
+### Example using options data source as an exclude filter
+
+One scenario where this might be useful is to handle exclusions, say a specific row should not be sent to a destination.
+
+You could then have an options class similar to:
+
+```csharp
+internal class TestOptions
+{
+    public List<string>? ExcludedIds { get; set; }
+}
+```
+
+And an sql that looks the following:
+
+```sql
+CREATE VIEW excluded_ids WITH (BUFFERED = true) AS
+select excludedId FROM config c
+INNER JOIN UNNEST(c.excludedIds) excludedId;
+
+INSERT INTO my_destination
+SELECT m.id, m.other FROM my_table m
+LEFT JOIN excluded_ids e ON m.id = e.excludedId
+WHERE e.excludedId is null;
+```
+
+The buffered view helps with performance where it buffers the changes from the `UNNEST` statement so only changing rows are returned.
+We can then do a left join to match with the exluded ids but only return rows where there was no match.

--- a/docs/docs/connectors/configurationdata.md
+++ b/docs/docs/connectors/configurationdata.md
@@ -12,8 +12,7 @@ filter out rows that do not exist in the configuration.
 The options data source uses `IOptionsMonitor<TOptions>` to listen to changes and to get the configuration settings.
 
 The Options data source is built-in as a default connector when installing FlowtideDotNet, so no extra nuget package is required.
-Options are added with the `AddOptionsSource<TOptions>` method on the connector maanger.
-
+Options are added with the `AddOptionsSource<TOptions>` method on the connector manager.
 One of the main benefits of this connector comes if you have a configuration provider that allows reloading, then data can be updated
 without restarting the stream.
 

--- a/docs/docs/connectors/configurationdata.md
+++ b/docs/docs/connectors/configurationdata.md
@@ -89,4 +89,4 @@ WHERE e.excludedId is null;
 ```
 
 The buffered view helps with performance where it buffers the changes from the `UNNEST` statement so only changing rows are returned.
-We can then do a left join to match with the exluded ids but only return rows where there was no match.
+We can then do a left join to match with the excluded ids but only return rows where there was no match.

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ArrayConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ArrayConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -54,6 +55,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             {
                 throw new NotImplementedException();
             }
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new ListType(innerConverter.GetSubstraitType()) { Nullable = true };
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/BoolConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/BoolConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -28,6 +29,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return value.AsBool;
             }
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new BoolType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ByteArrayConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ByteArrayConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -27,6 +28,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return value.AsBinary.ToArray();
             }
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new BinaryType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/CharConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/CharConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -33,6 +34,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             }
 
             throw new NotImplementedException($"Cannot convert {value.Type} to Char");
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new StringType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DateTimeConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DateTimeConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -35,6 +36,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             }
 
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new TimestampType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DateTimeOffsetConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DateTimeOffsetConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -28,6 +29,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return value.AsTimestamp.ToDateTimeOffset();
             }
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new TimestampType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DecimalConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DecimalConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -29,6 +30,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             }
 
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new DecimalType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DictionaryConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DictionaryConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -49,6 +50,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             }
 
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new MapType(keyConverter.GetSubstraitType(), valueConverter.GetSubstraitType());
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DoubleConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/DoubleConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -28,6 +29,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return value.AsDouble;
             }
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new Fp64Type();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/EnumConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/EnumConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -30,6 +31,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return Enum.ToObject(enumType, value.AsLong);
             }
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new Int64Type();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/EnumStringConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/EnumStringConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -31,6 +32,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return Enum.Parse(enumType, value.AsString.ToString());
             }
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new StringType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/FloatConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/FloatConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -29,6 +30,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             }
 
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new Fp64Type();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/GuidConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/GuidConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -27,6 +28,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return new Guid(value.AsString.ToString());
             }
             throw new NotImplementedException($"Cannot convert {value.Type} to Guid");
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new StringType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/HashSetConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/HashSetConverter.cs
@@ -13,6 +13,7 @@
 using FlowtideDotNet.Core.ColumnStore.Comparers;
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 using System.Collections;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
@@ -51,6 +52,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             {
                 throw new NotImplementedException($"Cannot convert {value.Type} to HashSet");
             }
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new ListType(innerConverter.GetSubstraitType());
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/Int64Converter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/Int64Converter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -44,6 +45,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 throw new NotImplementedException();
             }
 
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new Int64Type();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ListConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ListConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 using System.Collections;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
@@ -49,6 +50,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             {
                 throw new NotImplementedException();
             }
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new ListType(innerConverter.GetSubstraitType());
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/MemoryByteConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/MemoryByteConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -28,6 +29,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return new Memory<byte>(value.AsBinary.ToArray());
             }
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new BinaryType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/NullableConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/NullableConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -30,6 +31,13 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
                 return null!;
             }
             return inner.Deserialize(value);
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            var t = inner.GetSubstraitType();
+            t.Nullable = true;
+            return t;
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ObjectConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ObjectConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 using System.Diagnostics;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
@@ -113,6 +114,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 
             }
             addFunc.AddValue(new MapValue(values));
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new MapType(new AnyType(), new AnyType());
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ReadOnlyMemoryConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/ReadOnlyMemoryConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -29,6 +30,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             }
 
             throw new NotImplementedException();
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new BinaryType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/StringConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/StringConverter.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -30,6 +31,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             {
                 throw new NotImplementedException();
             }
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new StringType();
         }
 
         public void Serialize(object obj, ref AddToColumnFunc addFunc)

--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/UnionConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/Converters/UnionConverter.cs
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders;
+using FlowtideDotNet.Substrait.Type;
 
 namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
 {
@@ -82,6 +83,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Converters
             var converter = GetConverter(type);
 
             converter.Serialize(obj, ref addFunc);
+        }
+
+        public SubstraitBaseType GetSubstraitType()
+        {
+            return new AnyType();
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Sources/Configuration/ConfigurationConnectorManagerExtensions.cs
+++ b/src/FlowtideDotNet.Core/Sources/Configuration/ConfigurationConnectorManagerExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core;
+using FlowtideDotNet.Core.Sources.Configuration.Internal;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ConfigurationConnectorManagerExtensions
+    {
+        public static IConnectorManager AddOptionsSource<TOptions>(this IConnectorManager connectorManager, string tableName, IOptionsMonitor<TOptions> optionsMonitor)
+        {
+            connectorManager.AddSource(new OptionsMonitorSourceFactory<TOptions>(tableName, optionsMonitor));
+            return connectorManager;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Sources/Configuration/Internal/OptionsMonitorSource.cs
+++ b/src/FlowtideDotNet.Core/Sources/Configuration/Internal/OptionsMonitorSource.cs
@@ -1,0 +1,182 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Base;
+using FlowtideDotNet.Base.Vertices.Ingress;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.ObjectConverter;
+using FlowtideDotNet.Core.Operators.Read;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Substrait.Relations;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Threading.Tasks.Dataflow;
+
+namespace FlowtideDotNet.Core.Sources.Configuration.Internal
+{
+    internal class OptionsMonitorSource<TOptions> : ReadBaseOperator
+    {
+        private readonly IOptionsMonitor<TOptions> _optionsMonitor;
+        private readonly ReadRelation _readRelation;
+        private readonly BatchConverter _batchConverter;
+        private readonly string _watermarkName;
+        private readonly string _displayName;
+        private IObjectState<OptionsMonitorState<TOptions>>? _state;
+        private IDisposable? _monitorDisposable;
+        private SemaphoreSlim _updateSemaphore;
+        private Task? _deltaTask;
+
+        public OptionsMonitorSource(IOptionsMonitor<TOptions> optionsMonitor, ReadRelation readRelation, DataflowBlockOptions options) : base(options)
+        {
+            this._optionsMonitor = optionsMonitor;
+            this._readRelation = readRelation;
+            _watermarkName = readRelation.NamedTable.DotSeperated;
+            _displayName = $"Configuration({readRelation.NamedTable.DotSeperated})";
+
+            _updateSemaphore = new SemaphoreSlim(0);
+            _batchConverter = BatchConverter.GetBatchConverter(typeof(TOptions), readRelation.BaseSchema.Names);
+        }
+
+        public override string DisplayName => _displayName;
+
+        public override Task DeleteAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task OnTrigger(string triggerName, object? state)
+        {
+            if (triggerName == "delta_load" && (_deltaTask == null || _deltaTask.IsCompleted))
+            {
+                _deltaTask = RunTask(HandleDelta);
+            }
+            
+            return Task.CompletedTask;
+        }
+
+        private async Task HandleDelta(IngressOutput<StreamEventBatch> output, object? state)
+        {
+            Debug.Assert(_state?.Value != null);
+            while (true)
+            {
+                output.CancellationToken.ThrowIfCancellationRequested();
+
+                await _updateSemaphore.WaitAsync();
+
+                await output.EnterCheckpointLock();
+                await SendDataOptions(output);
+                output.ExitCheckpointLock();
+            }
+        }
+
+        protected override Task<IReadOnlySet<string>> GetWatermarkNames()
+        {
+            return Task.FromResult<IReadOnlySet<string>>(new HashSet<string>() { _watermarkName });
+        }
+
+        protected override async Task InitializeOrRestore(long restoreTime, IStateManagerClient stateManagerClient)
+        {
+            _state = await stateManagerClient.GetOrCreateObjectStateAsync<OptionsMonitorState<TOptions>>("state");
+            
+            if (_state.Value == null)
+            {
+                _state.Value = new OptionsMonitorState<TOptions>()
+                {
+                    Version = 0
+                };
+            }
+        }
+
+        protected override async Task OnCheckpoint(long checkpointTime)
+        {
+            Debug.Assert(_state != null);
+            await _state.Commit();
+        }
+
+        private async Task SendDataOptions(IngressOutput<StreamEventBatch> output)
+        {
+            Debug.Assert(_state?.Value != null);
+            var jsonFormattedOptions = JsonSerializer.Serialize(_optionsMonitor.CurrentValue);
+            if (_state.Value.Options == null)
+            {
+                var batch = _batchConverter.ConvertToEventBatch<TOptions>([_optionsMonitor.CurrentValue], MemoryAllocator);
+                PrimitiveList<int> weights = new PrimitiveList<int>(MemoryAllocator);
+                PrimitiveList<uint> iterations = new PrimitiveList<uint>(MemoryAllocator);
+                weights.Add(1);
+                iterations.Add(0);
+
+                await output.SendAsync(new StreamEventBatch(new ColumnStore.EventBatchWeighted(weights, iterations, batch)));
+
+                _state.Value.Options = _optionsMonitor.CurrentValue;
+                _state.Value.JsonFormatted = jsonFormattedOptions;
+                _state.Value.Version++;
+
+                await output.SendWatermark(new Watermark(_watermarkName, _state.Value.Version));
+                ScheduleCheckpoint(TimeSpan.FromMilliseconds(1));
+            }
+            else if (!_state.Value.JsonFormatted.Equals(jsonFormattedOptions))
+            {
+                Column[] columns = new Column[_batchConverter.Properties.Count];
+
+                for (int i = 0; i < columns.Length; i++)
+                {
+                    columns[i] = Column.Create(MemoryAllocator);
+                }
+                _batchConverter.AppendToColumns(_optionsMonitor.CurrentValue!, columns);
+                _batchConverter.AppendToColumns(_state.Value.Options, columns);
+
+                PrimitiveList<int> weights = new PrimitiveList<int>(MemoryAllocator);
+                PrimitiveList<uint> iterations = new PrimitiveList<uint>(MemoryAllocator);
+                weights.Add(1);
+                weights.Add(-1);
+                iterations.Add(0);
+                iterations.Add(0);
+
+                _state.Value.Options = _optionsMonitor.CurrentValue;
+                _state.Value.JsonFormatted = jsonFormattedOptions;
+                _state.Value.Version++;
+
+                await output.SendAsync(new StreamEventBatch(new EventBatchWeighted(weights, iterations, new EventBatchData(columns))));
+                await output.SendWatermark(new Watermark(_watermarkName, _state.Value.Version));
+                ScheduleCheckpoint(TimeSpan.FromMilliseconds(1));
+            }
+        }
+
+        protected override async Task SendInitial(IngressOutput<StreamEventBatch> output)
+        {
+            Debug.Assert(_state?.Value != null);
+            if (_monitorDisposable != null)
+            {
+                _monitorDisposable.Dispose();
+            }
+            _monitorDisposable = _optionsMonitor.OnChange((newOptions, str) =>
+            {
+                _updateSemaphore.Release();
+            });
+
+            await output.EnterCheckpointLock();
+            await SendDataOptions(output);
+            output.ExitCheckpointLock();
+
+            await RegisterTrigger("delta_load", TimeSpan.FromMinutes(1));
+            await OnTrigger("delta_load", default);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            _monitorDisposable?.Dispose();
+            return base.DisposeAsync();
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Sources/Configuration/Internal/OptionsMonitorSourceFactory.cs
+++ b/src/FlowtideDotNet.Core/Sources/Configuration/Internal/OptionsMonitorSourceFactory.cs
@@ -1,0 +1,83 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Base.Vertices.Ingress;
+using FlowtideDotNet.Core.ColumnStore.ObjectConverter;
+using FlowtideDotNet.Core.Compute;
+using FlowtideDotNet.Core.Connectors;
+using FlowtideDotNet.Substrait.Relations;
+using FlowtideDotNet.Substrait.Sql;
+using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks.Dataflow;
+
+namespace FlowtideDotNet.Core.Sources.Configuration.Internal
+{
+    internal class OptionsMonitorSourceFactory<TOptions> : IConnectorSourceFactory, ITableProvider, IConnectorTableProviderFactory
+    {
+        private readonly string _tableName;
+        private readonly IOptionsMonitor<TOptions> _monitor;
+        private BatchConverter? batchConverter;
+
+        public OptionsMonitorSourceFactory(string tableName, IOptionsMonitor<TOptions> monitor)
+        {
+            this._tableName = tableName;
+            this._monitor = monitor;
+        }
+
+        public bool CanHandle(ReadRelation readRelation)
+        {
+            return readRelation.NamedTable.DotSeperated == _tableName;
+        }
+
+        public ITableProvider Create()
+        {
+            return this;
+        }
+
+        public IStreamIngressVertex CreateSource(ReadRelation readRelation, IFunctionsRegister functionsRegister, DataflowBlockOptions dataflowBlockOptions)
+        {
+            return new OptionsMonitorSource<TOptions>(_monitor, readRelation, dataflowBlockOptions);
+        }
+
+        public Relation ModifyPlan(ReadRelation readRelation)
+        {
+            if (readRelation.Filter != null)
+            {
+                return new FilterRelation()
+                {
+                    Emit = readRelation.Emit,
+                    Condition = readRelation.Filter,
+                    Input = readRelation,
+                };
+            }
+            return readRelation;
+        }
+
+        public bool TryGetTableInformation(IReadOnlyList<string> tableName, [NotNullWhen(true)] out TableMetadata? tableMetadata)
+        {
+            if (string.Join(".", tableName) == _tableName)
+            {
+                if (batchConverter == null)
+                {
+                    // Use batch converter to get the full schema of the type
+                    batchConverter = BatchConverter.GetBatchConverter(typeof(TOptions));
+                }
+
+                tableMetadata = new TableMetadata(_tableName, batchConverter.GetSchema());
+                return true;
+            }
+            tableMetadata = default;
+            return false;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Sources/Configuration/Internal/OptionsMonitorState.cs
+++ b/src/FlowtideDotNet.Core/Sources/Configuration/Internal/OptionsMonitorState.cs
@@ -10,17 +10,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using FlowtideDotNet.Substrait.Type;
-
-namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter.Encoders
+namespace FlowtideDotNet.Core.Sources.Configuration.Internal
 {
-    public interface IObjectColumnConverter
+    internal class OptionsMonitorState<TOptions>
     {
-        void Serialize(object obj, ref AddToColumnFunc addFunc);
+        public long Version { get; set; }
 
-        object Deserialize<T>(T value)
-            where T : IDataValue;
+        public TOptions? Options { get; set; }
 
-        SubstraitBaseType GetSubstraitType();
+        /// <summary>
+        /// Contains the options as json, used to compare for actual changes
+        /// </summary>
+        public string JsonFormatted { get; set; } = string.Empty;
     }
 }

--- a/src/FlowtideDotNet.DependencyInjection/Extensions/DependencyInjectionConnectorManagerExtensions.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Extensions/DependencyInjectionConnectorManagerExtensions.cs
@@ -1,0 +1,19 @@
+﻿using FlowtideDotNet.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class DependencyInjectionConnectorManagerExtensions
+    {
+        public static IDependencyInjectionConnectorManager AddOptionsSource<TOptions>(this IDependencyInjectionConnectorManager connectorManager, string tableName)
+        {
+            connectorManager.AddOptionsSource(tableName, connectorManager.ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>());
+            return connectorManager;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/TableFunctions/UnnestSqlFunction.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/TableFunctions/UnnestSqlFunction.cs
@@ -39,6 +39,13 @@ namespace FlowtideDotNet.Substrait.Sql.Internal.TableFunctions
                         columnName = arg.TableAlias;
                     }
 
+                    SubstraitBaseType outputType = new AnyType();
+
+                    if (result.Type is ListType listType)
+                    {
+                        outputType = listType.ValueType;
+                    }
+                    
                     NamedStruct outputSchema = new NamedStruct()
                     {
                         Names = new List<string>() { columnName },
@@ -46,7 +53,7 @@ namespace FlowtideDotNet.Substrait.Sql.Internal.TableFunctions
                         {
                             Types = new List<SubstraitBaseType>()
                             {
-                                new AnyType()
+                                outputType
                             }
                         }
                     };

--- a/tests/FlowtideDotNet.Core.Tests/OptionsMonitorTests/OptionsDataSourceTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/OptionsMonitorTests/OptionsDataSourceTests.cs
@@ -1,0 +1,84 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.AcceptanceTests.Internal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Tests.OptionsMonitorTests
+{
+    internal class TestOptions
+    {
+        public string? Name { get; set; }
+    }
+
+    internal class OptionsDataTestStream : FlowtideTestStream
+    {
+        private readonly IOptionsMonitor<TestOptions> options;
+
+        public OptionsDataTestStream(IOptionsMonitor<TestOptions> options, string testName) : base(testName)
+        {
+            this.options = options;
+        }
+
+        protected override void AddReadResolvers(IConnectorManager manager)
+        {
+            manager.AddOptionsSource<TestOptions>("testtable", options);
+            base.AddReadResolvers(manager);
+        }
+    }
+
+    public class OptionsDataSourceTests
+    {
+        [Fact]
+        public async Task TestOptionSource()
+        {
+            Dictionary<string, string?> optionsDict = new Dictionary<string, string?>();
+            optionsDict["config:name"] = "hello";
+            var configBuilder = new ConfigurationBuilder()
+                .AddInMemoryCollection(optionsDict);
+            var config = configBuilder.Build();
+            ServiceCollection services = new ServiceCollection();
+
+            services.AddOptions<TestOptions>()
+                .Bind(config.GetSection("config"));
+
+            var provider = services.BuildServiceProvider();
+
+            var options = provider.GetRequiredService<IOptionsMonitor<TestOptions>>();
+
+            var stream = new OptionsDataTestStream(options, nameof(TestOptionSource));
+
+            await stream.StartStream(@"
+                INSERT INTO output
+                SELECT name FROM testtable
+            ");
+
+            await stream.WaitForUpdate();
+
+            stream.AssertCurrentDataEqual(new[] { new { name = "hello" } });
+
+            config["config:name"] = "hello2";
+            config.Reload();
+
+            await stream.WaitForUpdate();
+
+            stream.AssertCurrentDataEqual(new[] { new { name = "hello2" } });
+        }
+    }
+}


### PR DESCRIPTION
This adds a new data source that uses IOptionsMonitor to read updates and outputs the data as a table into the stream.

This change also includes a small fix to include the inner data type from lists during UNNEST since UNNEST would be quite common with this case if a list is used.