### PR TITLE
Add versioning support to DataflowStreamBuilder

### DIFF
--- a/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
@@ -30,6 +30,7 @@ namespace FlowtideDotNet.Base.Engine
         private StreamState? _state;
         private IStateHandler? _stateHandler;
         private readonly string _streamName;
+        private string _version = "";
         private IStreamScheduler? _streamScheduler;
         private StateManagerOptions? _stateManagerOptions;
         private ILoggerFactory? _loggerFactory;
@@ -96,9 +97,9 @@ namespace FlowtideDotNet.Base.Engine
             return this;
         }
 
-        public DataflowStreamBuilder SetVersionInformation(long streamVersion, string hash)
+        public DataflowStreamBuilder SetVersionInformation(string hash, string version)
         {
-            _streamVersionInformation = new StreamVersionInformation(streamVersion, hash);
+            _streamVersionInformation = new StreamVersionInformation(hash, version);
             return this;
         }
 
@@ -138,6 +139,13 @@ namespace FlowtideDotNet.Base.Engine
             return this;
         }
 
+        public DataflowStreamBuilder SetVersion(string version)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(version);
+            _version = version;
+            return this;
+        }
+
         public DataflowStream Build()
         {
             if (_stateManagerOptions == null)
@@ -155,6 +163,7 @@ namespace FlowtideDotNet.Base.Engine
 
             var streamContext = new StreamContext(
                 _streamName,
+                _version,
                 _propagatorBlocks,
                 _ingressBlocks,
                 _egressBlocks,

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
@@ -55,7 +55,6 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 // Write the latest state
                 run._context._lastState = new StreamState(
                     run._currentCheckpoint.CheckpointTime,
-                    _context._streamVersionInformation?.Version ?? 0,
                     _context._streamVersionInformation?.Hash ?? string.Empty);
 
                 run._context._stateManager.Metadata = run._context._lastState;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
@@ -164,10 +164,6 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 if (_context._streamVersionInformation != null)
                 {
                     _context._logger.CheckingStreamHashConsistency(_context.streamName);
-                    if (_context._streamVersionInformation.Version != _context._lastState.StrreamVersion)
-                    {
-                        throw new InvalidOperationException("Stream version missmatch, the version stored in storage is different than the version used.");
-                    }
                     if (_context._streamVersionInformation.Hash != _context._lastState.StreamHash)
                     {
                         throw new InvalidOperationException("Stream plan hash stored in storage is different than the hash used.");

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StoppingStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StoppingStreamState.cs
@@ -72,7 +72,6 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 // Write the latest state
                 run._context._lastState = new StreamState(
                     run._currentCheckpoint.CheckpointTime,
-                    _context._streamVersionInformation?.Version ?? 0,
                     _context._streamVersionInformation?.Hash ?? string.Empty);
 
                 run._context._stateManager.Metadata = run._context._lastState;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -44,6 +44,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         private static ActivitySource s_exceptionActivitySource = new ActivitySource("FlowtideDotNet.Base.StreamException");
 
         internal readonly string streamName;
+        internal readonly string version;
         internal readonly Dictionary<string, IStreamVertex> propagatorBlocks;
         internal readonly Dictionary<string, IStreamIngressVertex> ingressBlocks;
         internal readonly Dictionary<string, IStreamEgressVertex> egressBlocks;
@@ -138,6 +139,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         public StreamContext(
             string streamName,
+            string version,
             Dictionary<string, IStreamVertex> propagatorBlocks,
             Dictionary<string, IStreamIngressVertex> ingressBlocks,
             Dictionary<string, IStreamEgressVertex> egressBlocks,
@@ -153,6 +155,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             IOptionsMonitor<FlowtidePauseOptions>? pauseMonitor)
         {
             this.streamName = streamName;
+            this.version = version;
             this.propagatorBlocks = propagatorBlocks;
             this.ingressBlocks = ingressBlocks;
             this.egressBlocks = egressBlocks;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StreamVersionInformation.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StreamVersionInformation.cs
@@ -14,16 +14,14 @@ namespace FlowtideDotNet.Base.Engine.Internal
 {
     internal class StreamVersionInformation
     {
-        public StreamVersionInformation(long version, string hash)
+        public StreamVersionInformation(string hash, string version)
         {
-            Version = version;
             Hash = hash;
+            Version = version;
         }
-
-        public long Version { get; }
 
         public string Hash { get; }
 
-
+        public string Version { get; }
     }
 }

--- a/src/FlowtideDotNet.Base/Engine/StreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/StreamState.cs
@@ -14,21 +14,18 @@ namespace FlowtideDotNet.Base.Engine
 {
     public class StreamState
     {
-        public static readonly StreamState NullState = new StreamState(-1, 0, string.Empty);
+        public static readonly StreamState NullState = new StreamState(-1, string.Empty);
 
         /// <summary>
         /// The stream time this checkpoint refers to.
         /// </summary>
         public long Time { get; }
 
-        public long StrreamVersion { get; }
-
         public string StreamHash { get; }
 
-        public StreamState(long time, long strreamVersion, string streamHash)
+        public StreamState(long time, string streamHash)
         {
             Time = time;
-            StrreamVersion = strreamVersion;
             StreamHash = streamHash;
         }
     }

--- a/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
+++ b/src/FlowtideDotNet.Core/Engine/FlowtideBuilder.cs
@@ -38,6 +38,8 @@ namespace FlowtideDotNet.Core.Engine
         private TimeSpan _getTimestampInterval = TimeSpan.FromHours(1);
         private TaskScheduler? _taskScheduler;
         private bool _useColumnStore = true;
+        private string _version = "";
+        private bool _useHashPlanAsVersion = false;
 
         public FlowtideBuilder(string streamName)
         {
@@ -185,6 +187,19 @@ namespace FlowtideDotNet.Core.Engine
             return this;
         }
 
+        public FlowtideBuilder SetVersion(string version)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(version);
+            _version = version;
+            return this;
+        }
+
+        public FlowtideBuilder SetHashPlanAsVersion()
+        {
+            _useHashPlanAsVersion = true;
+            return this;
+        }
+
         private string ComputePlanHash()
         {
             Debug.Assert(_plan != null, "Plan should not be null.");
@@ -214,8 +229,15 @@ namespace FlowtideDotNet.Core.Engine
             {
                 throw new InvalidOperationException("No connector manager or ReadWriteFactory has been added.");
             }
+
             var hash = ComputePlanHash();
-            dataflowStreamBuilder.SetVersionInformation(1, hash);
+
+            if (_useHashPlanAsVersion)
+            {
+                SetVersion(hash);
+            }
+
+            dataflowStreamBuilder.SetVersionInformation(hash, _version);
 
             // Modify plan
             if (_connectorManager != null)

--- a/src/FlowtideDotNet.DependencyInjection/IFlowtideDIBuilder.cs
+++ b/src/FlowtideDotNet.DependencyInjection/IFlowtideDIBuilder.cs
@@ -30,5 +30,21 @@ namespace FlowtideDotNet.DependencyInjection
         IFlowtideDIBuilder AddStorage(Action<IFlowtideStorageBuilder> storageOptions);
 
         IFlowtideDIBuilder AddCustomOptions(Action<IServiceProvider, FlowtideBuilder> options);
+
+        /// <summary>
+        /// Sets the current entry assembly version as the stream version. A new version is created if the assembly version changes.
+        /// </summary>
+        IFlowtideDIBuilder AddVersioningFromAssembly();
+
+        /// <summary>
+        /// Sets a custom string as the stream version. A new version is created if the string changes.
+        /// </summary>
+        /// <param name="version"></param>
+        IFlowtideDIBuilder AddVersioningFromString(string version);
+
+        /// <summary>
+        /// Sets the plan hash as the stream version. A new version is created if the plan changes.
+        /// </summary>
+        IFlowtideDIBuilder AddVersioningFromPlanHash();
     }
 }


### PR DESCRIPTION
- Introduced `_version` field and `SetVersion` method in `DataflowStreamBuilder` for managing stream versions.
- Updated `SetVersionInformation` to accept a string version and modified `StreamVersionInformation` constructor accordingly.
- Adjusted `StreamState` to use a string for version instead of a long.
- Enhanced `StreamContext` constructor to accept the new version parameter.
- Added `_useHashPlanAsVersion` field and related methods in `FlowtideBuilder` for versioning based on hash plans or custom strings.
- Extended `IFlowtideDIBuilder` interface with methods for versioning from assembly, custom strings, and plan hashes.
- Implemented new versioning methods in `FlowtideDIBuilder` for flexible version management.