### PR TITLE
Add sql storage versioning

### DIFF
--- a/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStreamBuilder.cs
@@ -15,6 +15,7 @@ using FlowtideDotNet.Base.Engine.Internal.StateMachine;
 using FlowtideDotNet.Base.Vertices;
 using FlowtideDotNet.Base.Vertices.Egress;
 using FlowtideDotNet.Base.Vertices.Ingress;
+using FlowtideDotNet.Storage;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.StateManager;
 using Microsoft.Extensions.Logging;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
@@ -148,7 +148,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             _context.EnableTriggerRegistration();
 
             // Initialize state
-            await _context._stateManager.InitializeAsync();
+            await _context._stateManager.InitializeAsync(_context._streamVersionInformation);
             _context._lastState = _context._stateManager.Metadata;
             _context._startCheckpointVersion = _context._stateManager.CurrentVersion;
             if (_context._lastState == null)

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -18,6 +18,7 @@ using FlowtideDotNet.Base.Vertices;
 using FlowtideDotNet.Base.Vertices.Egress;
 using FlowtideDotNet.Base.Vertices.Ingress;
 using FlowtideDotNet.Base.Vertices.MultipleInput;
+using FlowtideDotNet.Storage;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.StateManager;
 using Microsoft.Extensions.Logging;

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorage.cs
@@ -133,7 +133,13 @@ namespace FlowtideDotNet.Storage.SqlServer
 
         public async Task InitializeAsync(StorageInitializationMetadata metadata)
         {
-            _stream = await StorageRepository.UpsertStream(metadata.StreamName, _settings);
+            var name = metadata.StreamName;
+            if (!string.IsNullOrWhiteSpace(metadata.StreamVersion?.Version) && _settings.UseFlowtideVersioning)
+            {
+                name += $"-{metadata.StreamVersion.Version}";
+            }
+
+            _stream = await StorageRepository.UpsertStream(name, _settings);
             _storageRepository = new StorageRepository(_stream, _settings);
 #if DEBUG_WRITE
             _debugWriter = new DebugWriter(_stream.Metadata.Name);

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorageSettings.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorageSettings.cs
@@ -44,8 +44,8 @@ namespace FlowtideDotNet.Storage.SqlServer
         public string StreamPageTableName { get; set; } = "[dbo].[StreamPages]";
 
         /// <summary>
-        /// If set to true, flowtide versioning will be used, if a new version is detected, a new stream will be created.
-        /// If set to false, the flowtide stream name the stream is considered the same independant of version and will not be recreated.
+        /// If set to true, flowtide versioning will be used in combination with the stream name to create a unique key, if a new version is detected, a new stream will be created.
+        /// If set to false, the flowtide stream name is used as the key, and considered the same independant of version.
         /// </summary>
         public bool UseFlowtideVersioning { get; set; } = true;
     }

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorageSettings.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorageSettings.cs
@@ -47,7 +47,7 @@ namespace FlowtideDotNet.Storage.SqlServer
         /// If set to true, flowtide versioning will be used in combination with the stream name to create a unique key, if a new version is detected, a new stream will be created.
         /// If set to false, the flowtide stream name is used as the key, and considered the same independant of version.
         /// </summary>
-        public bool UseFlowtideVersioning { get; set; } = true;
+        public bool UseFlowtideVersioning { get; set; }
     }
 
     /// <summary>

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorageSettings.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentStorageSettings.cs
@@ -42,6 +42,12 @@ namespace FlowtideDotNet.Storage.SqlServer
         /// Gets or sets the name of the stream page table, can include schema and database name.
         /// </summary>
         public string StreamPageTableName { get; set; } = "[dbo].[StreamPages]";
+
+        /// <summary>
+        /// If set to true, flowtide versioning will be used, if a new version is detected, a new stream will be created.
+        /// If set to false, the flowtide stream name the stream is considered the same independant of version and will not be recreated.
+        /// </summary>
+        public bool UseFlowtideVersioning { get; set; } = true;
     }
 
     /// <summary>

--- a/src/FlowtideDotNet.Storage/Persistence/StorageInitializationMetadata.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/StorageInitializationMetadata.cs
@@ -16,9 +16,12 @@ namespace FlowtideDotNet.Storage.Persistence
     {
         public string StreamName { get; }
 
-        public StorageInitializationMetadata(string streamName)
+        public StreamVersionInformation? StreamVersion { get;  }
+
+        public StorageInitializationMetadata(string streamName, StreamVersionInformation? streamVersion = null)
         {
             StreamName = streamName;
+            StreamVersion = streamVersion;
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/StateManager/IStateManager.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/IStateManager.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Storage.StateManager
     public interface IStateManager
     {
         bool Initialized { get; }
-        Task InitializeAsync();
+        Task InitializeAsync(StreamVersionInformation? streamVersionInformation);
 
         long CurrentVersion { get; }
 

--- a/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
@@ -386,7 +386,7 @@ namespace FlowtideDotNet.Storage.StateManager
 
         internal abstract StateManagerMetadata NewMetadata();
 
-        public async Task InitializeAsync()
+        public async Task InitializeAsync(StreamVersionInformation? streamVersionInformation = null)
         {
             bool newMetadata = false;
             Setup();
@@ -394,7 +394,7 @@ namespace FlowtideDotNet.Storage.StateManager
             Debug.Assert(m_persistentStorage != null);
             Debug.Assert(options != null);
             m_lruTable.Clear();
-            await m_persistentStorage.InitializeAsync(new StorageInitializationMetadata(streamName)).ConfigureAwait(false);
+            await m_persistentStorage.InitializeAsync(new StorageInitializationMetadata(streamName, streamVersionInformation)).ConfigureAwait(false);
 
             if (m_persistentStorage.TryGetValue(1, out var metadataBytes))
             {

--- a/src/FlowtideDotNet.Storage/StreamVersionInformation.cs
+++ b/src/FlowtideDotNet.Storage/StreamVersionInformation.cs
@@ -10,9 +10,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace FlowtideDotNet.Base.Engine.Internal
+namespace FlowtideDotNet.Storage
 {
-    internal class StreamVersionInformation
+    public class StreamVersionInformation
     {
         public StreamVersionInformation(string hash, string version)
         {


### PR DESCRIPTION
Adds stream version information to the initialization of Statemanager and to StorageInitializationMetadata. This is optional but available for all storage implementations.