### PR TITLE
Add lookup row method to generic data source

### DIFF
--- a/src/FlowtideDotNet.Core/Sources/Generic/GenericDataSource.cs
+++ b/src/FlowtideDotNet.Core/Sources/Generic/GenericDataSource.cs
@@ -11,11 +11,15 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Resolvers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Substrait.Relations;
 
 namespace FlowtideDotNet.Core.Sources.Generic
 {
     public abstract class GenericDataSourceAsync<T> where T : class
     {
+        private Func<string, ValueTask<T?>>? _lookupRowFunc;
+
         /// <summary>
         /// Fetches all objects from the data source
         /// </summary>
@@ -31,6 +35,37 @@ namespace FlowtideDotNet.Core.Sources.Generic
         public virtual IEnumerable<IObjectColumnResolver> GetCustomConverters()
         {
             yield break;
+        }
+
+        internal void SetLookupRowFunc(Func<string, ValueTask<T?>> lookupRowFunc)
+        {
+            _lookupRowFunc = lookupRowFunc;
+        }
+
+        public virtual Task Initialize(ReadRelation readRelation, IStateManagerClient stateManagerClient)
+        {
+            return Task.CompletedTask;
+        }
+
+        public virtual Task Checkpoint()
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Looks up a rows value in the state by key.
+        /// This only contains values for the properties that are used in the stream.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">Thrown if the lookup function has not yet been initialized</exception>
+        protected ValueTask<T?> LookupRow(string key)
+        {
+            if (_lookupRowFunc == null)
+            {
+                throw new InvalidOperationException("LookupRow is not supported, or has not yet been initialized");
+            }
+            return _lookupRowFunc(key);
         }
 
         /// <summary> 

--- a/src/FlowtideDotNet.Core/Sources/Generic/Internal/GenericReadOperator.cs
+++ b/src/FlowtideDotNet.Core/Sources/Generic/Internal/GenericReadOperator.cs
@@ -170,7 +170,7 @@ namespace FlowtideDotNet.Core.Sources.Generic.Internal
             {
                 return default;
             }
-            return (T)_batchConverter.ConvertToDotNetObject(value.value.referenceBatch.Columns, value.value.RowIndex);
+            return (T)_lookupBatchConverter.ConvertToDotNetObject(value.value.referenceBatch.Columns, value.value.RowIndex);
         }
 
         protected override async IAsyncEnumerable<DeltaReadEvent> DeltaLoad(Func<Task> EnterCheckpointLock, Action ExitCheckpointLock, CancellationToken cancellationToken, [EnumeratorCancellation] CancellationToken enumeratorCancellationToken = default)

--- a/tests/FlowtideDotNet.Core.Tests/GenericDataTests/GenericReadOperatorTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/GenericDataTests/GenericReadOperatorTests.cs
@@ -14,15 +14,18 @@ using FlowtideDotNet.AcceptanceTests.Entities;
 using FlowtideDotNet.AcceptanceTests.Internal;
 using FlowtideDotNet.Core.ColumnStore.ObjectConverter.Resolvers;
 using FlowtideDotNet.Core.Sources.Generic;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Substrait.Relations;
 using FlowtideDotNet.Substrait.Sql;
 
 namespace FlowtideDotNet.Core.Tests.GenericDataTests
 {
-    internal class GenericDataTestStream : FlowtideTestStream
+    internal class GenericDataTestStream<T> : FlowtideTestStream
+        where T: class
     {
-        private readonly TestDataSource testDataSource;
+        private readonly GenericDataSourceAsync<T> testDataSource;
 
-        public GenericDataTestStream(TestDataSource testDataSource, string testName) : base(testName)
+        public GenericDataTestStream(GenericDataSourceAsync<T> testDataSource, string testName) : base(testName)
         {
             this.testDataSource = testDataSource;
         }
@@ -82,6 +85,62 @@ namespace FlowtideDotNet.Core.Tests.GenericDataTests
         }
     }
 
+    internal class TestDataSourceWithLookup : GenericDataSourceAsync<User>
+    {
+        private readonly List<FlowtideGenericObject<User>> _changes = new List<FlowtideGenericObject<User>>();
+        private readonly TimeSpan? deltaTime;
+        private int _index = 0;
+
+        public TestDataSourceWithLookup(TimeSpan? deltaTime)
+        {
+            this.deltaTime = deltaTime;
+        }
+
+        public void AddChange(FlowtideGenericObject<User> change)
+        {
+            _changes.Add(change);
+        }
+
+        public void ClearChanges()
+        {
+            _changes.Clear();
+        }
+
+        public override TimeSpan? DeltaLoadInterval => deltaTime;
+
+        public override async IAsyncEnumerable<FlowtideGenericObject<User>> DeltaLoadAsync(long lastWatermark)
+        {
+            for (; _index < _changes.Count; _index++)
+            {
+                if (_changes[_index].Watermark > lastWatermark)
+                {
+                    var lookedUpRowBefore = await LookupRow(_changes[_index].Key);
+                    if (lookedUpRowBefore != null && !_changes[_index].isDelete)
+                    {
+                        _changes[_index].Value!.FirstName = lookedUpRowBefore.FirstName + "Updated";
+                    }
+                    
+                    yield return _changes[_index];
+                }
+            }
+        }
+
+        public override Task Checkpoint()
+        {
+            return base.Checkpoint();
+        }
+
+        public override IAsyncEnumerable<FlowtideGenericObject<User>> FullLoadAsync()
+        {
+            return _changes.ToAsyncEnumerable();
+        }
+
+        public override IEnumerable<IObjectColumnResolver> GetCustomConverters()
+        {
+            yield return new EnumResolver(enumAsStrings: true);
+        }
+    }
+
     public class GenericReadOperatorTests
     {
         [Fact]
@@ -90,7 +149,7 @@ namespace FlowtideDotNet.Core.Tests.GenericDataTests
             var source = new TestDataSource(TimeSpan.FromMilliseconds(1));
             source.AddChange(new FlowtideGenericObject<User>("1", new User { UserKey = 1, FirstName = "Test" }, 1, false));
 
-            var stream = new GenericDataTestStream(source, "TestGenericDataSource");
+            var stream = new GenericDataTestStream<User>(source, "TestGenericDataSource");
             stream.RegisterTableProviders(builder =>
             {
                 builder.AddGenericDataTable<User>("users");
@@ -118,7 +177,6 @@ namespace FlowtideDotNet.Core.Tests.GenericDataTests
             source.AddChange(new FlowtideGenericObject<User>("1", null, 4, true));
             await stream.WaitForUpdate();
             stream.AssertCurrentDataEqual(new List<User>() { new User { UserKey = 2, FirstName = "Test3" } }.Select(x => new { x.UserKey, x.FirstName }));
-
         }
 
         [Fact]
@@ -127,7 +185,7 @@ namespace FlowtideDotNet.Core.Tests.GenericDataTests
             var source = new TestDataSource(default);
             source.AddChange(new FlowtideGenericObject<User>("1", new User { UserKey = 1, FirstName = "Test" }, 1, false));
 
-            var stream = new GenericDataTestStream(source, "TestDeltaTrigger");
+            var stream = new GenericDataTestStream<User>(source, "TestDeltaTrigger");
             stream.RegisterTableProviders(builder =>
             {
                 builder.AddGenericDataTable<User>("users");
@@ -167,7 +225,7 @@ namespace FlowtideDotNet.Core.Tests.GenericDataTests
             source.AddChange(new FlowtideGenericObject<User>("1", new User { UserKey = 1, FirstName = "Test", LastName = "last1" }, 1, false));
             source.AddChange(new FlowtideGenericObject<User>("3", new User { UserKey = 3, FirstName = "Test3", LastName = "last3" }, 1, false));
 
-            var stream = new GenericDataTestStream(source, "TestEmit");
+            var stream = new GenericDataTestStream<User>(source, "TestEmit");
             stream.RegisterTableProviders(builder =>
             {
                 builder.AddGenericDataTable<User>("users");
@@ -215,7 +273,7 @@ namespace FlowtideDotNet.Core.Tests.GenericDataTests
             source.AddChange(new FlowtideGenericObject<User>("1", new User { UserKey = 1, FirstName = "Test", LastName = "last1" }, 1, false));
             source.AddChange(new FlowtideGenericObject<User>("3", new User { UserKey = 3, FirstName = "Test3", LastName = "last3" }, 1, false));
 
-            var stream = new GenericDataTestStream(source, "TestSelectKey");
+            var stream = new GenericDataTestStream<User>(source, "TestSelectKey");
             stream.RegisterTableProviders(builder =>
             {
                 builder.AddGenericDataTable<User>("users");
@@ -241,6 +299,43 @@ namespace FlowtideDotNet.Core.Tests.GenericDataTests
 
             var act = stream.GetActualRowsAsVectors();
             stream.AssertCurrentDataEqual(new List<User>() { new User { UserKey = 1, FirstName = "Test", LastName = "last1" } }.Select(x => new { x.FirstName, key = x.UserKey.ToString(), x.LastName }));
+        }
+
+        [Fact]
+        public async Task TestGenericDataSourceWithLookup()
+        {
+            var source = new TestDataSourceWithLookup(TimeSpan.FromMilliseconds(1));
+            source.AddChange(new FlowtideGenericObject<User>("1", new User { UserKey = 1, FirstName = "Test" }, 1, false));
+
+            var stream = new GenericDataTestStream<User>(source, "TestGenericDataSourceWithLookup");
+            stream.RegisterTableProviders(builder =>
+            {
+                builder.AddGenericDataTable<User>("users");
+            });
+
+            await stream.StartStream(@"
+                INSERT INTO output
+                SELECT 
+                    UserKey, 
+                    FirstName 
+                FROM users
+            ");
+            await stream.WaitForUpdate();
+
+            stream.AssertCurrentDataEqual(new List<User>() { new User { UserKey = 1, FirstName = "Test" } }.Select(x => new { x.UserKey, x.FirstName }));
+
+            // Update user 1
+            source.AddChange(new FlowtideGenericObject<User>("1", new User { UserKey = 1, FirstName = "Test2" }, 2, false));
+            source.AddChange(new FlowtideGenericObject<User>("2", new User { UserKey = 2, FirstName = "Test3" }, 3, false));
+            await stream.WaitForUpdate();
+
+            // Check that the old name is set with the extra updated to make sure that it used lookuprow
+            stream.AssertCurrentDataEqual(new List<User>() { new User { UserKey = 1, FirstName = "TestUpdated" }, new User { UserKey = 2, FirstName = "Test3" } }.Select(x => new { x.UserKey, x.FirstName }));
+
+            // Delete
+            source.AddChange(new FlowtideGenericObject<User>("1", null, 4, true));
+            await stream.WaitForUpdate();
+            stream.AssertCurrentDataEqual(new List<User>() { new User { UserKey = 2, FirstName = "Test3" } }.Select(x => new { x.UserKey, x.FirstName }));
         }
     }
 }


### PR DESCRIPTION
This allows custom sources to lookup previously sent data which can be useful in certain scenarios.

This change also adds a possibility where a custom data soure can create its own states, that is useful for say creating a custom surrogate key and saving the counter at a checkpoint.