### PR TITLE
Add element methods to list column to more easily allow modifying list elements

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -369,14 +369,31 @@ namespace FlowtideDotNet.Core.ColumnStore
                     }
                     _validityList.Unset(Count - 1);
                 }
-                _dataColumn!.Update<T>(index, value);
-
-                // Set to not null
-                if (_nullCounter > 0 &&
-                    !_validityList.Get(index))
+                if (_type != value.Type)
                 {
-                    _validityList.Set(index);
-                    _nullCounter--;
+                    var unionColumn = ConvertToUnion();
+                    _type = ArrowTypeId.Union;
+                    var previousColumn = _dataColumn;
+                    _dataColumn = unionColumn;
+                    if (previousColumn != null)
+                    {
+                        previousColumn.Dispose();
+                    }
+                    _validityList.Clear();
+                    _nullCounter = 0;
+                    _dataColumn.Update<T>(index, value);
+                }
+                else
+                {
+                    _dataColumn!.Update<T>(index, value);
+
+                    // Set to not null
+                    if (_nullCounter > 0 &&
+                        !_validityList.Get(index))
+                    {
+                        _validityList.Set(index);
+                        _nullCounter--;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This will be used by window operator to store state of different weights of duplicate rows.

This change also fixes a bug in column class where changing type of an element caused an error if the column was not a union column.