### PR TITLE
Add support for agg function surrogate_key_int64

### DIFF
--- a/docs/docs/expressions/aggregatefunctions/generic.md
+++ b/docs/docs/expressions/aggregatefunctions/generic.md
@@ -15,3 +15,21 @@ Counts all rows in a query. This function takes no parameters, the implementatio
 ```sql
 SELECT count(*) FROM ... 
 ```
+
+## Surrogate Key Int64
+
+*This function does not have a substrait definition.*
+
+Generates a unique int64 value for each combination of the "group by" columns in an aggregate query.
+This can be used for instance when creating a SCD table where the group by can be on both the primary key and date.
+
+### SQL Usage
+
+```sql
+SELECT
+    surrogate_key_int64() as SK_MyKey,
+    id,
+    insertDate
+FROM testtable
+GROUP BY id, insertDate
+```

--- a/docs/docs/expressions/windowfunctions/generic.md
+++ b/docs/docs/expressions/windowfunctions/generic.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 2
+---
+
+# Generic Functions
+
+## Surrogate Key Int64
+
+*This function does not have a substrait definition.*
+
+Generates a unique int64 value for each combination of the "partition by" columns in an window function query.
+This can be used for instance when creating a SCD table where the partition by can be on both the primary key and date.
+
+*This is non-deterministic across replays of a full rerun of a stream.*
+
+### SQL Usage
+
+```sql
+SELECT
+    surrogate_key_int64() OVER (PARTITION BY id, insertDate) as SK_MyKey,
+    id,
+    insertDate
+FROM testtable
+```

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/SurrogateKey/SurrogateKeyInt64Aggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/SurrogateKey/SurrogateKeyInt64Aggregation.cs
@@ -1,0 +1,118 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.Compute.Internal;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.StateManager;
+using System.Linq.Expressions;
+using FlowtideDotNet.Substrait.FunctionExtensions;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.SurrogateKey
+{
+    internal class SurrogateKeyInt64AggregationSingleton
+    {
+        public SurrogateKeyInt64AggregationSingleton(IObjectState<long> state)
+        {
+            State = state;
+        }
+
+        public IObjectState<long> State { get; }
+    }
+
+    internal class SurrogateKeyInt64Aggregation
+    {
+        private static async Task<SurrogateKeyInt64AggregationSingleton> Initialize(int groupingLength, IStateManagerClient stateManagerClient, IMemoryAllocator memoryAllocator)
+        {
+            var counter = await stateManagerClient.GetOrCreateObjectStateAsync<long>("counter");
+            return new SurrogateKeyInt64AggregationSingleton(counter);
+        }
+
+        private static Expression SurrogateKeyMapFunction(
+           Substrait.Expressions.AggregateFunction function,
+           ColumnParameterInfo parametersInfo,
+           ColumnarExpressionVisitor visitor,
+           ParameterExpression stateParameter,
+           ParameterExpression weightParameter,
+           ParameterExpression singletonAccess,
+           ParameterExpression groupingKeyParameter)
+        {
+            if (function.Arguments.Count != 0)
+            {
+                throw new InvalidOperationException("surrogate_key_int64 must have zero arguments.");
+            }
+
+            var expr = GetSurrogateKeyBody();
+            var body = expr.Body;
+            var e = body;
+            var replacer = new ParameterReplacerVisitor(expr.Parameters[0], stateParameter);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[1], weightParameter);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[2], singletonAccess);
+            e = replacer.Visit(e);
+            replacer = new ParameterReplacerVisitor(expr.Parameters[3], groupingKeyParameter);
+            e = replacer.Visit(e);
+            return e;
+        }
+
+        private static LambdaExpression GetSurrogateKeyBody()
+        {
+            var methodInfo = typeof(SurrogateKeyInt64Aggregation).GetMethod(nameof(DoSurrogateKeyInt64), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+            var state = Expression.Parameter(typeof(ColumnReference), "state");
+            var weight = Expression.Parameter(typeof(long), "weight");
+            var singleton = Expression.Parameter(typeof(SurrogateKeyInt64AggregationSingleton), "singleton");
+            var groupingKey = Expression.Parameter(typeof(ColumnRowReference), "groupingKey");
+
+            var call = Expression.Call(methodInfo, state, weight, singleton, groupingKey);
+            return Expression.Lambda(call, state, weight, singleton, groupingKey);
+        }
+
+        private static ValueTask DoSurrogateKeyInt64(ColumnReference currentState, long weight, SurrogateKeyInt64AggregationSingleton singleton, ColumnRowReference groupingKey)
+        {
+            var stateValue = currentState.GetValue();
+
+            if (stateValue.IsNull)
+            {
+                var nextId = singleton.State.Value++;
+                currentState.Update(new Int64Value(nextId));
+            }
+            return ValueTask.CompletedTask;
+        }
+
+        private static ValueTask SurrogateKeyGetValue(ColumnReference state, ColumnRowReference groupingKey, SurrogateKeyInt64AggregationSingleton singleton, Column outputColumn)
+        {
+            outputColumn.Add(state.GetValue());
+            return ValueTask.CompletedTask;
+        }
+
+        private static async Task Commit(SurrogateKeyInt64AggregationSingleton singleton)
+        {
+            await singleton.State.Commit();
+        }
+
+        public static void Register(IFunctionsRegister functionsRegister)
+        {
+            functionsRegister.RegisterStatefulColumnAggregateFunction(
+                FunctionsAggregateGeneric.Uri,
+                FunctionsAggregateGeneric.SurrogateKeyInt64,
+                Initialize,
+                (singleton) => { },
+                Commit,
+                SurrogateKeyMapFunction,
+                SurrogateKeyGetValue
+                );
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StreamingAggregations/BuiltInGenericFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StreamingAggregations/BuiltInGenericFunctions.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.SurrogateKey;
 using FlowtideDotNet.Core.Compute.Internal;
 using FlowtideDotNet.Substrait.FunctionExtensions;
 using System.Diagnostics;
@@ -60,6 +61,8 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StreamingAggregations
                 },
                 GetCountValue
                 );
+
+            SurrogateKeyInt64Aggregation.Register(functionsRegister);
         }
 
         private static LambdaExpression GetCountWithArgBody(System.Type inputType)

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/BuiltInWindowFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/BuiltInWindowFunctions.cs
@@ -10,12 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.SurrogateKey;
 using FlowtideDotNet.Substrait.FunctionExtensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions
 {
@@ -26,6 +22,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions
             functionsRegister.RegisterWindowFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.Sum, new SumWindowFunctionDefinition());
             functionsRegister.RegisterWindowFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.RowNumber, new RowNumberWindowFunctionDefinition());
             functionsRegister.RegisterWindowFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.Lead, new LeadWindowFunctionDefinition());
+            functionsRegister.RegisterWindowFunction(FunctionsAggregateGeneric.Uri, FunctionsAggregateGeneric.SurrogateKeyInt64, new SurrogateKeyInt64WindowFunctionDefinition());
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/IWindowFunction.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/IWindowFunction.cs
@@ -16,18 +16,15 @@ using FlowtideDotNet.Core.Operators.Window;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions
 {
     internal interface IWindowFunction
     {
+        bool RequirePartitionCompute { get; }
+
         Task Initialize(
-            IBPlusTree<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer> persistentTree,
+            IBPlusTree<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer>? persistentTree,
             List<int> partitionColumns,
             IMemoryAllocator memoryAllocator,
             IStateManagerClient stateManagerClient,
@@ -35,5 +32,12 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions
 
         IAsyncEnumerable<EventBatchWeighted> ComputePartition(
             ColumnRowReference partitionValues);
+
+        IAsyncEnumerable<EventBatchWeighted> OnReceive(
+            ColumnRowReference partitionValues,
+            ColumnRowReference inputRow,
+            int weight);
+
+        ValueTask Commit();
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyInt64Function.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyInt64Function.cs
@@ -1,0 +1,125 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Base.Utils;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Operators.Window;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Substrait.Expressions;
+using System.Diagnostics;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.SurrogateKey
+{
+    internal class SurrogateKeyInt64WindowFunctionDefinition : WindowFunctionDefinition
+    {
+        public override IWindowFunction Create(WindowFunction aggregateFunction, IFunctionsRegister functionsRegister)
+        {
+            return new SurrogateKeyInt64Function();
+        }
+    }
+
+    internal class SurrogateKeyInt64Function : IWindowFunction
+    {
+        private IBPlusTree<ColumnRowReference, SurrogateKeyValue, ColumnKeyStorageContainer, SurrogateKeyValueContainer>? _tree;
+        private IBPlusTreeIterator<ColumnRowReference, SurrogateKeyValue, ColumnKeyStorageContainer, SurrogateKeyValueContainer>? _iterator;
+        private IWindowAddOutputRow? _addOutputRow;
+        private IObjectState<long>? _keyCounterState;
+
+        public bool RequirePartitionCompute => false;
+
+        public async ValueTask Commit()
+        {
+            Debug.Assert(_tree != null);
+            Debug.Assert(_keyCounterState != null);
+
+            await _tree.Commit();
+            await _keyCounterState.Commit();
+        }
+
+        public IAsyncEnumerable<EventBatchWeighted> ComputePartition(ColumnRowReference partitionValues)
+        {
+            return EmptyAsyncEnumerable<EventBatchWeighted>.Instance;
+        }
+
+        public async Task Initialize(
+            IBPlusTree<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer>? persistentTree, 
+            List<int> partitionColumns, 
+            IMemoryAllocator memoryAllocator, 
+            IStateManagerClient stateManagerClient, 
+            IWindowAddOutputRow addOutputRow)
+        {
+            _addOutputRow = addOutputRow;
+            _tree = await stateManagerClient.GetOrCreateTree("partitions", 
+                new BPlusTreeOptions<ColumnRowReference, SurrogateKeyValue, ColumnKeyStorageContainer, SurrogateKeyValueContainer>()
+                {
+                    Comparer = new ColumnComparer(partitionColumns.Count),
+                    KeySerializer = new ColumnStoreSerializer(partitionColumns.Count, memoryAllocator),
+                    ValueSerializer = new SurrogateKeyValueContainerSerializer(memoryAllocator),
+                    MemoryAllocator = memoryAllocator
+                });
+            _iterator = _tree.CreateIterator();
+            _keyCounterState = await stateManagerClient.GetOrCreateObjectStateAsync<long>("key_counter");
+        }
+
+        public async IAsyncEnumerable<EventBatchWeighted> OnReceive(
+            ColumnRowReference partitionValues, 
+            ColumnRowReference inputRow, 
+            int weight)
+        {
+            Debug.Assert(_tree != null);
+            Debug.Assert(_addOutputRow != null);
+            Debug.Assert(_keyCounterState != null);
+
+            var inputValue = new SurrogateKeyValue()
+            {
+                Value = NullValue.Instance,
+                Weight = weight
+            };
+            await _tree.RMWNoResult(partitionValues, inputValue, (input, current, exists) =>
+            {
+                if (exists)
+                {
+                    var value = current.Value;
+                    _addOutputRow.AddOutputRow(inputRow, value, input.Weight);
+                    var newWeight = current.Weight + input.Weight;
+                    current.Weight = newWeight;
+                    if (newWeight == 0)
+                    {
+                        return (current, GenericWriteOperation.Delete);
+                    }
+
+                    return (current, GenericWriteOperation.Upsert);
+                }
+                else
+                {
+                    var newKey = _keyCounterState.Value++;
+                    var newValue = new SurrogateKeyValue()
+                    {
+                        Value = new Int64Value(newKey),
+                        Weight = input.Weight
+                    };
+                    _addOutputRow.AddOutputRow(inputRow, newValue.Value, input.Weight);
+                    return (newValue, GenericWriteOperation.Upsert);
+                }
+            });
+            
+            if (_addOutputRow.Count >= 100)
+            {
+                yield return _addOutputRow.GetCurrentBatch();
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyValueContainer.cs
@@ -1,0 +1,111 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Tree;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.SurrogateKey
+{
+    internal struct SurrogateKeyValue
+    {
+        public IDataValue Value;
+        public int Weight;
+    }
+    internal class SurrogateKeyValueContainer : IValueContainer<SurrogateKeyValue>
+    {
+        internal readonly Column _column;
+        internal readonly PrimitiveList<int> _weights;
+
+        internal SurrogateKeyValueContainer(IMemoryAllocator memoryAllocator)
+        {
+            _column = new Column(memoryAllocator);
+            _weights = new PrimitiveList<int>(memoryAllocator);
+        }
+
+        internal SurrogateKeyValueContainer(Column column, PrimitiveList<int> weights)
+        {
+            _column = column;
+            _weights = weights;
+        }
+
+        public int Count => _column.Count;
+
+        public void AddRangeFrom(IValueContainer<SurrogateKeyValue> container, int start, int count)
+        {
+            if (container is SurrogateKeyValueContainer valueContainer)
+            {
+                _column.InsertRangeFrom(_column.Count, valueContainer._column, start, count);
+                _weights.InsertRangeFrom(_weights.Count, valueContainer._weights, start, count);
+            }
+            else
+            {
+                throw new InvalidOperationException("Invalid container type");
+            }
+        }
+
+        public void Dispose()
+        {
+            _column.Dispose();
+            _weights.Dispose();
+        }
+
+        public SurrogateKeyValue Get(int index)
+        {
+            return new SurrogateKeyValue()
+            {
+                Value = _column.GetValueAt(index, default),
+                Weight = _weights.Get(index)
+            };
+        }
+
+        public int GetByteSize()
+        {
+            return _column.GetByteSize() + _weights.Count * sizeof(int);
+        }
+
+        public int GetByteSize(int start, int end)
+        {
+            return _column.GetByteSize(start, end) + ((end - start + 1) * sizeof(int));
+        }
+
+        public ref SurrogateKeyValue GetRef(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Insert(int index, SurrogateKeyValue value)
+        {
+            _column.InsertAt(index, value.Value);
+            _weights.InsertAt(index, value.Weight);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _column.RemoveAt(index);
+            _weights.RemoveAt(index);
+        }
+
+        public void RemoveRange(int start, int count)
+        {
+            _column.RemoveRange(start, count);
+            _weights.RemoveRange(start, count);
+        }
+
+        public void Update(int index, SurrogateKeyValue value)
+        {
+            _column.UpdateAt(index, value.Value);
+            _weights.Update(index, value.Weight);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyValueContainerSerializer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyValueContainerSerializer.cs
@@ -1,0 +1,87 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.Serialization;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Tree;
+using System.Buffers;
+using System.Buffers.Binary;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.SurrogateKey
+{
+    internal class SurrogateKeyValueContainerSerializer : IBplusTreeValueSerializer<SurrogateKeyValue, SurrogateKeyValueContainer>
+    {
+        private readonly IMemoryAllocator _memoryAllocator;
+        private readonly EventBatchBPlusTreeSerializer _batchSerializer;
+
+        public SurrogateKeyValueContainerSerializer(IMemoryAllocator memoryAllocator)
+        {
+            _memoryAllocator = memoryAllocator;
+            _batchSerializer = new EventBatchBPlusTreeSerializer();
+        }
+
+        public Task CheckpointAsync(IBPlusTreeSerializerCheckpointContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public SurrogateKeyValueContainer CreateEmpty()
+        {
+            return new SurrogateKeyValueContainer(_memoryAllocator);
+        }
+
+        public SurrogateKeyValueContainer Deserialize(ref SequenceReader<byte> reader)
+        {
+            var result = _batchSerializer.Deserialize(ref reader, _memoryAllocator);
+
+            if (!reader.TryReadLittleEndian(out int weightsLength))
+            {
+                throw new InvalidOperationException("Failed to read weights length");
+            }
+
+            var weightsMemory = _memoryAllocator.Allocate(weightsLength, 64);
+
+            if (!reader.TryCopyTo(weightsMemory.Memory.Span.Slice(0, weightsLength)))
+            {
+                throw new InvalidOperationException("Failed to copy weights memory");
+            }
+            reader.Advance(weightsLength);
+
+            
+            var column = result.EventBatch.Columns[0];
+            if (column is Column c)
+            {
+                return new SurrogateKeyValueContainer(c, new PrimitiveList<int>(weightsMemory, weightsLength / sizeof(int), _memoryAllocator));
+            }
+            throw new NotImplementedException();
+        }
+
+        public Task InitializeAsync(IBPlusTreeSerializerInitializeContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Serialize(in IBufferWriter<byte> writer, in SurrogateKeyValueContainer values)
+        {
+            _batchSerializer.Serialize(writer, new EventBatchData([values._column]), values.Count);
+
+            var weightsMemory = values._weights.SlicedMemory;
+            var weightsSpan = writer.GetSpan(4 + weightsMemory.Length);
+
+            BinaryPrimitives.WriteInt32LittleEndian(weightsSpan, weightsMemory.Length);
+            weightsMemory.Span.CopyTo(weightsSpan.Slice(4));
+            writer.Advance(weightsMemory.Length + 4);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Substrait/FunctionExtensions/FunctionsAggregateGeneric.cs
+++ b/src/FlowtideDotNet.Substrait/FunctionExtensions/FunctionsAggregateGeneric.cs
@@ -16,5 +16,6 @@ namespace FlowtideDotNet.Substrait.FunctionExtensions
     {
         public const string Uri = "/functions_aggregate_generic.yaml";
         public const string Count = "count";
+        public const string SurrogateKeyInt64 = "surrogate_key_int64";
     }
 }

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
@@ -784,6 +784,7 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
             // WindowFunction
             RegisterSingleVariableWindowFunction(sqlFunctionRegister, "sum", FunctionsArithmetic.Uri, FunctionsArithmetic.Sum, new AnyType(), true, false);
             RegisterZeroVariableWindowFunction(sqlFunctionRegister, "row_number", FunctionsArithmetic.Uri, FunctionsArithmetic.RowNumber, new Int64Type(), false, true);
+            RegisterZeroVariableWindowFunction(sqlFunctionRegister, "surrogate_key_int64", FunctionsAggregateGeneric.Uri, FunctionsAggregateGeneric.SurrogateKeyInt64, new Int64Type(), false, false);
 
             sqlFunctionRegister.RegisterWindowFunction("lead",
                 (func, visitor, emitData) =>

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/BuiltInSqlFunctions.cs
@@ -720,6 +720,25 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
                 throw new InvalidOperationException("string_agg must have exactly two arguments, and not be '*'");
             });
 
+            sqlFunctionRegister.RegisterAggregateFunction("surrogate_key_int64", (f, visitor, emitData) =>
+            {
+                var argList = GetFunctionArguments(f.Args);
+                if (argList.Args != null && argList.Args.Count != 0)
+                {
+                    throw new InvalidOperationException("surrogate_key_int64 must have exactly zero arguments.");
+                }
+
+                return new AggregateResponse(
+                        new AggregateFunction()
+                        {
+                            ExtensionUri = FunctionsAggregateGeneric.Uri,
+                            ExtensionName = FunctionsAggregateGeneric.SurrogateKeyInt64,
+                            Arguments = new List<Expressions.Expression>()
+                        },
+                        new StringType() { Nullable = true }
+                        );
+            });
+
 
 
             RegisterTwoVariableScalarFunction(sqlFunctionRegister, "power", FunctionsArithmetic.Uri, FunctionsArithmetic.Power);

--- a/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
@@ -313,5 +313,32 @@ namespace FlowtideDotNet.AcceptanceTests
                 { "company", x.CompanyId! }
             }).ToList() } });
         }
+
+        [Fact]
+        public async Task TestSurrogateKeyInt64()
+        {
+            GenerateData();
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT
+                surrogate_key_int64() as key,
+                userkey
+            FROM users
+            GROUP BY userkey
+            ");
+
+            await WaitForUpdate();
+
+            long counter = 0;
+            AssertCurrentDataEqual(Users.Select(x =>
+            {
+                return new
+                {
+                    key = counter++,
+                    x.UserKey
+                };
+            }));
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/WindowFunctionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/WindowFunctionTests.cs
@@ -64,7 +64,7 @@ namespace FlowtideDotNet.AcceptanceTests
                         values.Enqueue(orderedByKey[i].DoubleValue);
                         sum += orderedByKey[i].DoubleValue;
                         output.Add(new SumResult(orderedByKey[i].CompanyId, orderedByKey[i].UserKey, (long)sum));
-                        
+
                     }
                     return output;
                 }).ToList();
@@ -228,8 +228,8 @@ namespace FlowtideDotNet.AcceptanceTests
                     Queue<double> values = new Queue<double>();
                     List<SumResult> output = new List<SumResult>();
                     for (int i = 0, z = 0; i < orderedByKey.Count; i++)
-                    {   
-                        for (; z < (i+ 3); z++)
+                    {
+                        for (; z < (i + 3); z++)
                         {
                             if (z < orderedByKey.Count)
                             {
@@ -240,14 +240,14 @@ namespace FlowtideDotNet.AcceptanceTests
                             {
                                 values.Enqueue(0);
                             }
-                            
+
                         }
                         while (values.Count > 7)
                         {
                             var dequeued = values.Dequeue();
                             sum -= dequeued;
                         }
-                        
+
                         output.Add(new SumResult(orderedByKey[i].CompanyId, orderedByKey[i].UserKey, (long)sum));
 
                     }
@@ -554,7 +554,7 @@ namespace FlowtideDotNet.AcceptanceTests
 
             await WaitForUpdate();
 
-            while(Users.Count > 0)
+            while (Users.Count > 0)
             {
                 DeleteUser(Users[0]);
             }
@@ -673,6 +673,63 @@ namespace FlowtideDotNet.AcceptanceTests
                     }
                     return output;
                 }).ToList();
+
+            AssertCurrentDataEqual(expected);
+        }
+
+        [Fact]
+        public async Task SurrogateKeyInt64()
+        {
+            GenerateData();
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT 
+                surrogate_key_int64() OVER (PARTITION BY CompanyId)
+            FROM users
+            ");
+
+            await WaitForUpdate();
+
+            var act = GetActualRows();
+
+            await Crash();
+
+            GenerateData();
+
+            await WaitForUpdate();
+
+            Dictionary<string, int> keyLookup = new Dictionary<string, int>();
+            int counter = 0;
+            int nullKey = -1;
+
+            var expected = Users.Select(x =>
+            {
+                if (x.CompanyId == null)
+                {
+                    if (nullKey == -1)
+                    {
+                        nullKey = counter++;
+                    }
+                    return new
+                    {
+                        key = nullKey
+                    };
+                }
+                if (keyLookup.TryGetValue(x.CompanyId, out var key))
+                {
+                    return new
+                    {
+                        key
+                    };
+                }
+                key = counter++;
+                keyLookup.Add(x.CompanyId, key);
+                return new
+                {
+                    key
+                };
+            }).ToList();
 
             AssertCurrentDataEqual(expected);
         }


### PR DESCRIPTION
This function returns a unique number per grouping in an aggregate. This fixes #751

This PR also changes window function to allow a window function to skip using the persistent tree from the operator and instead define its own structures.