### PR TITLE
Add support for min_by and max_by as window functions

### DIFF
--- a/docs/docs/expressions/aggregatefunctions/arithmetic.md
+++ b/docs/docs/expressions/aggregatefunctions/arithmetic.md
@@ -60,7 +60,7 @@ SELECT max(column1) FROM ...
 
 *This function does not have a substrait definition.*
 
-Returns the value of `x` associated with the minimum value of `y`. If there are no rows, a `NULL` value is returned. `MIN_BY` ignores any rows where either `x` or `y` is `NULL`.
+Returns the value of `x` associated with the minimum value of `y`. If there are no rows, a `NULL` value is returned. `MIN_BY` ignores any rows where `y` is `NULL`.
 
 ### SQL Usage
 
@@ -72,7 +72,7 @@ SELECT min_by(x, y) FROM ...
 
 *This function does not have a substrait definition.*
 
-Returns the value of `x` associated with the maximum value of `y`. If there are no rows, a `NULL` value is returned. `MAX_BY` ignores any rows where either `x` or `y` is `NULL`.
+Returns the value of `x` associated with the maximum value of `y`. If there are no rows, a `NULL` value is returned. `MAX_BY` ignores any rows where `y` is `NULL`.
 
 ### SQL Usage
 

--- a/docs/docs/expressions/windowfunctions/arithmetic.md
+++ b/docs/docs/expressions/windowfunctions/arithmetic.md
@@ -99,3 +99,33 @@ SELECT LAST_VALUE(column1) OVER (PARTITION BY column2 ORDER BY column3 ROWS BETW
 -- Last value from start to current row ignoring nulls
 SELECT LAST_VALUE(column1) IGNORE NULLS OVER (PARTITION BY column2 ORDER BY column3) FROM ...
 ```
+
+## Min By
+
+*This function does not have a substrait definition.*
+
+Returns the value of `x` associated with the minimum value of `y`. If there are no rows, a `NULL` value is returned. `MIN_BY` ignores any rows where `y` is `NULL`.
+
+This function **requires an ORDER BY clause** to establish row sequence and supports frame boundaries to control which rows are considered.
+
+### SQL Usage
+
+```sql
+SELECT min_by(x, y) OVER (PARTITION BY column2 ORDER BY column3) FROM ...
+SELECT min_by(x, y) OVER (PARTITION BY column2 ORDER BY column3 ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) FROM ...
+```
+
+## Max By
+
+*This function does not have a substrait definition.*
+
+Returns the value of `x` associated with the maximum value of `y`. If there are no rows, a `NULL` value is returned. `MAX_BY` ignores any rows where `y` is `NULL`.
+
+This function **requires an ORDER BY clause** to establish row sequence and supports frame boundaries to control which rows are considered.
+
+### SQL Usage
+
+```sql
+SELECT max_by(x, y) OVER (PARTITION BY column2 ORDER BY column3) FROM ...
+SELECT max_by(x, y) OVER (PARTITION BY column2 ORDER BY column3 ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) FROM ...
+```

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/BuiltInWindowFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/BuiltInWindowFunctions.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.MinMax;
 using FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.SurrogateKey;
 using FlowtideDotNet.Substrait.FunctionExtensions;
 
@@ -25,6 +26,8 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions
             functionsRegister.RegisterWindowFunction(FunctionsAggregateGeneric.Uri, FunctionsAggregateGeneric.SurrogateKeyInt64, new SurrogateKeyInt64WindowFunctionDefinition());
             functionsRegister.RegisterWindowFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.Lag, new LagWindowFunctionDefinition());
             functionsRegister.RegisterWindowFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.LastValue, new LastValueWindowFunctionDefinition());
+            functionsRegister.RegisterWindowFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.MinBy, new MinByWindowFunctionDefinition());
+            functionsRegister.RegisterWindowFunction(FunctionsArithmetic.Uri, FunctionsArithmetic.MaxBy, new MaxByWindowFunctionDefinition());
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByIndexValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByIndexValueContainer.cs
@@ -1,0 +1,128 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.MinMax
+{
+    internal struct MinMaxByIndexValue
+    {
+        public IDataValue Value;
+        public IDataValue CompareValue;
+        public long Index;
+    }
+
+    internal class MinMaxByIndexValueContainer : IValueContainer<MinMaxByIndexValue>
+    {
+        internal Column _data;
+        internal Column _compareData;
+        internal PrimitiveList<long> _indices;
+
+        public MinMaxByIndexValueContainer(IMemoryAllocator memoryAllocator)
+        {
+            _data = Column.Create(memoryAllocator);
+            _compareData = Column.Create(memoryAllocator);
+            _indices = new PrimitiveList<long>(memoryAllocator);
+        }
+
+        public MinMaxByIndexValueContainer(Column data, Column compareData, PrimitiveList<long> indices)
+        {
+            _data = data;
+            _compareData = compareData;
+            _indices = indices;
+        }
+        public int Count => _indices.Count;
+
+        public void AddRangeFrom(IValueContainer<MinMaxByIndexValue> container, int start, int count)
+        {
+            if (container is MinMaxByIndexValueContainer other)
+            {
+                _data.InsertRangeFrom(_data.Count, other._data, start, count);
+                _compareData.InsertRangeFrom(_data.Count, other._compareData, start, count);
+                _indices.AddRangeFrom(other._indices, start, count);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public void Dispose()
+        {
+            _data.Dispose();
+            _compareData.Dispose();
+            _indices.Dispose();
+        }
+
+        public MinMaxByIndexValue Get(int index)
+        {
+            return new MinMaxByIndexValue()
+            {
+                Value = _data.GetValueAt(index, default),
+                CompareValue = _compareData.GetValueAt(index, default),
+                Index = _indices.Get(index)
+            };
+        }
+
+        public int GetByteSize()
+        {
+            return _data.GetByteSize() + _compareData.GetByteSize() + (_indices.Count * sizeof(long));
+        }
+
+        public int GetByteSize(int start, int end)
+        {
+            return _data.GetByteSize(start, end) + _compareData.GetByteSize(start, end) + ((end - start + 1) * sizeof(long));
+        }
+
+        public ref MinMaxByIndexValue GetRef(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Insert(int index, MinMaxByIndexValue value)
+        {
+            _data.InsertAt(index, value.Value);
+            _compareData.InsertAt(index, value.CompareValue);
+            _indices.InsertAt(index, value.Index);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _data.RemoveAt(index);
+            _compareData.RemoveAt(index);
+            _indices.RemoveAt(index);
+        }
+
+        public void RemoveRange(int start, int count)
+        {
+            _data.RemoveRange(in start, in count);
+            _compareData.RemoveRange(in start, in count);
+            _indices.RemoveRange(start, count);
+        }
+
+        public void Update(int index, MinMaxByIndexValue value)
+        {
+            _data.UpdateAt(index, value.Value);
+            _compareData.UpdateAt(index, value.CompareValue);
+            _indices.Update(index, value.Index);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByIndexValueContainerSerializer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByIndexValueContainerSerializer.cs
@@ -1,0 +1,102 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.Serialization;
+using FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Tree;
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.MinMax
+{
+    internal class MinMaxByIndexValueContainerSerializer : IBplusTreeValueSerializer<MinMaxByIndexValue, MinMaxByIndexValueContainer>
+    {
+        private readonly IMemoryAllocator _memoryAllocator;
+        private readonly EventBatchSerializer _batchSerializer;
+
+        public MinMaxByIndexValueContainerSerializer(IMemoryAllocator memoryAllocator)
+        {
+            _memoryAllocator = memoryAllocator;
+            _batchSerializer = new EventBatchSerializer();
+        }
+
+        public Task CheckpointAsync(IBPlusTreeSerializerCheckpointContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public MinMaxByIndexValueContainer CreateEmpty()
+        {
+            return new MinMaxByIndexValueContainer(_memoryAllocator);
+        }
+
+        public MinMaxByIndexValueContainer Deserialize(ref SequenceReader<byte> reader)
+        {
+            if (!reader.TryReadLittleEndian(out int indicesMemoryLength))
+            {
+                throw new InvalidOperationException("Failed to read weights memory length");
+            }
+
+            var indicesNativeMemory = _memoryAllocator.Allocate(indicesMemoryLength, 64);
+            var slice = indicesNativeMemory.Memory.Span.Slice(0, indicesMemoryLength);
+
+            if (!reader.TryCopyTo(slice))
+            {
+                throw new InvalidOperationException("Failed to read weights memory");
+            }
+            reader.Advance(indicesMemoryLength);
+
+            var indices = new PrimitiveList<long>(indicesNativeMemory, indicesMemoryLength / sizeof(long), _memoryAllocator);
+
+            var deserializer = new EventBatchDeserializer(_memoryAllocator);
+            var batch = deserializer.DeserializeBatch(ref reader);
+
+            if (batch.EventBatch.Columns[0] is not Column column)
+            {
+                throw new InvalidOperationException("Failed to deserialize column");
+            }
+
+            if (batch.EventBatch.Columns[1] is not Column compareColumn)
+            {
+                throw new InvalidOperationException("Failed to deserialize column");
+            }
+
+            return new MinMaxByIndexValueContainer(column, compareColumn, indices);
+        }
+
+        public Task InitializeAsync(IBPlusTreeSerializerInitializeContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Serialize(in IBufferWriter<byte> writer, in MinMaxByIndexValueContainer values)
+        {
+            var indicesmemory = values._indices.SlicedMemory.Span;
+
+            var writeSpan = writer.GetSpan(indicesmemory.Length + 4);
+
+            BinaryPrimitives.WriteInt32LittleEndian(writeSpan, indicesmemory.Length);
+            indicesmemory.CopyTo(writeSpan.Slice(4));
+            writer.Advance(indicesmemory.Length + 4);
+
+            _batchSerializer.SerializeEventBatch(writer, new ColumnStore.EventBatchData([values._data, values._compareData]), values._indices.Count);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByWindowFunction.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByWindowFunction.cs
@@ -1,0 +1,527 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.Comparers;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Operators.Window;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Queue;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Substrait.Expressions;
+using System.Diagnostics;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.MinMax
+{
+    internal static class MinMaxBoundUtils
+    {
+        public static void GetBoundInfo(WindowFunction windowFunction, out bool isRowBounded, out long lowerBoundRowOffset, out long upperBoundRowOffset)
+        {
+            isRowBounded = false;
+            lowerBoundRowOffset = long.MinValue;
+            upperBoundRowOffset = long.MaxValue;
+            if (windowFunction.LowerBound != null)
+            {
+                if (windowFunction.LowerBound is PreceedingRowWindowBound lowerPreceedingRow)
+                {
+                    isRowBounded = true;
+                    lowerBoundRowOffset = -lowerPreceedingRow.Offset;
+                }
+                else if (windowFunction.LowerBound is CurrentRowWindowBound lowerCurrentRow)
+                {
+                    isRowBounded = true;
+                    lowerBoundRowOffset = 0;
+                }
+                else if (windowFunction.LowerBound is FollowingRowWindowBound lowerFollowingRow)
+                {
+                    isRowBounded = true;
+                    lowerBoundRowOffset = lowerFollowingRow.Offset;
+                }
+                else if (windowFunction.LowerBound is UnboundedWindowBound)
+                {
+                    isRowBounded = true;
+                    lowerBoundRowOffset = long.MinValue;
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            if (windowFunction.UpperBound != null)
+            {
+                if (windowFunction.UpperBound is PreceedingRowWindowBound lowerPreceedingRow)
+                {
+                    isRowBounded = true;
+                    upperBoundRowOffset = -lowerPreceedingRow.Offset;
+                }
+                else if (windowFunction.UpperBound is CurrentRowWindowBound lowerCurrentRow)
+                {
+                    isRowBounded = true;
+                    upperBoundRowOffset = 0;
+                }
+                else if (windowFunction.UpperBound is FollowingRowWindowBound lowerFollowingRow)
+                {
+                    isRowBounded = true;
+                    upperBoundRowOffset = lowerFollowingRow.Offset;
+                }
+                else if (windowFunction.UpperBound is UnboundedWindowBound)
+                {
+                    isRowBounded = true;
+                    upperBoundRowOffset = long.MaxValue;
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+    }
+    internal class MinByWindowFunctionDefinition : WindowFunctionDefinition
+    {
+        public override IWindowFunction Create(WindowFunction windowFunction, IFunctionsRegister functionsRegister)
+        {
+            var compiledValue = ColumnProjectCompiler.CompileToValue(windowFunction.Arguments[0], functionsRegister);
+            var compiledCompareValue = ColumnProjectCompiler.CompileToValue(windowFunction.Arguments[1], functionsRegister);
+
+            MinMaxBoundUtils.GetBoundInfo(windowFunction, out var isRowBounded, out var lowerBoundRowOffset, out var upperBoundRowOffset);
+            
+            if (isRowBounded && lowerBoundRowOffset != long.MinValue)
+            {
+                return new MinMaxByWindowFunctionBounded(compiledValue, compiledCompareValue, lowerBoundRowOffset, upperBoundRowOffset, true);
+            }
+            else if (isRowBounded && lowerBoundRowOffset == long.MinValue && upperBoundRowOffset == long.MaxValue)
+            {
+                return new MinMaxByWindowFunctionUnbounded(compiledValue, compiledCompareValue, true);
+            }
+            else if (isRowBounded && lowerBoundRowOffset == long.MinValue)
+            {
+                return new MinMaxByWindowFunctionUnboundedFrom(compiledValue, compiledCompareValue, upperBoundRowOffset, true);
+            }
+
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class MaxByWindowFunctionDefinition : WindowFunctionDefinition
+    {
+        public override IWindowFunction Create(WindowFunction windowFunction, IFunctionsRegister functionsRegister)
+        {
+            var compiledValue = ColumnProjectCompiler.CompileToValue(windowFunction.Arguments[0], functionsRegister);
+            var compiledCompareValue = ColumnProjectCompiler.CompileToValue(windowFunction.Arguments[1], functionsRegister);
+
+            MinMaxBoundUtils.GetBoundInfo(windowFunction, out var isRowBounded, out var lowerBoundRowOffset, out var upperBoundRowOffset);
+
+            if (isRowBounded && lowerBoundRowOffset != long.MinValue)
+            {
+                return new MinMaxByWindowFunctionBounded(compiledValue, compiledCompareValue, lowerBoundRowOffset, upperBoundRowOffset, false);
+            }
+            else if (isRowBounded && lowerBoundRowOffset == long.MinValue && upperBoundRowOffset == long.MaxValue)
+            {
+                return new MinMaxByWindowFunctionUnbounded(compiledValue, compiledCompareValue, false);
+            }
+            else if (isRowBounded && lowerBoundRowOffset == long.MinValue)
+            {
+                return new MinMaxByWindowFunctionUnboundedFrom(compiledValue, compiledCompareValue, upperBoundRowOffset, false);
+            }
+
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class MinMaxByWindowFunctionBounded : IWindowFunction
+    {
+        private IFlowtideQueue<MinMaxByIndexValue, MinMaxByIndexValueContainer>? _queue;
+        private IBPlusTreeIterator<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer>? _windowIterator;
+        private PartitionIterator? _windowPartitionIterator;
+        private long _windowRowIndex = 0;
+        private IAsyncEnumerator<KeyValuePair<ColumnRowReference, WindowStateReference>>? _windowEnumerator;
+        private readonly Func<EventBatchData, int, IDataValue> _fetchValueFunction;
+        private readonly Func<EventBatchData, int, IDataValue> _fetchCompareValueFunction;
+        private readonly long _from;
+        private readonly long _to;
+        private readonly bool _isMin;
+        private Action? _returnAction;
+
+        public MinMaxByWindowFunctionBounded(
+            Func<EventBatchData, int, IDataValue> fetchValueFunction,
+            Func<EventBatchData, int, IDataValue> fetchCompareValueFunction,
+            long from, 
+            long to,
+            bool isMin)
+        {
+            _fetchValueFunction = fetchValueFunction;
+            _fetchCompareValueFunction = fetchCompareValueFunction;
+            _from = from;
+            _to = to;
+            _isMin = isMin;
+        }
+
+        public ValueTask Commit()
+        {
+            return ValueTask.CompletedTask;
+        }
+        public async ValueTask NewPartition(ColumnRowReference partitionValues)
+        {
+            Debug.Assert(_queue != null);
+            Debug.Assert(_windowPartitionIterator != null);
+            await _queue.Clear();
+
+            await _windowPartitionIterator.Reset(partitionValues);
+            _windowEnumerator = _windowPartitionIterator.GetAsyncEnumerator();
+            _windowRowIndex = 0;
+        }
+
+        public async ValueTask<IDataValue> ComputeRow(KeyValuePair<ColumnRowReference, WindowStateReference> row, long partitionRowIndex)
+        {
+            Debug.Assert(_queue != null);
+            Debug.Assert(_windowEnumerator != null);
+
+            ReturnPageIfNeeded();
+
+            var windowEnd = partitionRowIndex + _to;
+            var windowStart = partitionRowIndex + _from;
+
+            while (_windowRowIndex <= windowEnd && await _windowEnumerator.MoveNextAsync())
+            {
+                var compareVal = _fetchCompareValueFunction(_windowEnumerator.Current.Key.referenceBatch, _windowEnumerator.Current.Key.RowIndex);
+                var val = _fetchValueFunction(_windowEnumerator.Current.Key.referenceBatch, _windowEnumerator.Current.Key.RowIndex);
+
+                if (compareVal.IsNull)
+                {
+                    _windowRowIndex++;
+                    continue;
+                }
+
+                while (_queue.Count > 0)
+                {
+                    var peekedVal = await _queue.PeekPop();
+                    bool popped = false;
+                    if (_isMin)
+                    {
+                        if (DataValueComparer.Instance.Compare(peekedVal.value.CompareValue, compareVal) > 0)
+                        {
+                            popped = true;
+                            await _queue.Pop();
+                        }
+                    }
+                    else
+                    {
+                        if (DataValueComparer.Instance.Compare(peekedVal.value.CompareValue, compareVal) < 0)
+                        {
+                            popped = true;
+                            await _queue.Pop();
+                        }
+                    }
+                    
+                    if (peekedVal.returnFunc != null)
+                    {
+                        // Return the page, since we peeked across page boundries
+                        peekedVal.returnFunc();
+                    }
+                    if (!popped)
+                    {
+                        break;
+                    }
+                }
+
+                await _queue.Enqueue(new MinMaxByIndexValue()
+                {
+                    Index = _windowRowIndex,
+                    Value = val,
+                    CompareValue = compareVal
+                });
+                _windowRowIndex++;
+            }
+
+            MinMaxByIndexValue peekValue = default;
+
+            while (_queue.Count > 0)
+            {
+                (peekValue, _returnAction) = await _queue.Peek();
+                if (peekValue.Index < windowStart)
+                {
+                    await _queue.Dequeue();
+                    ReturnPageIfNeeded();
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (_queue.Count > 0)
+            {
+                return peekValue.Value!;
+            }
+
+            return NullValue.Instance;
+        }
+
+        public ValueTask EndPartition(ColumnRowReference partitionValues)
+        {
+            ReturnPageIfNeeded();
+            return ValueTask.CompletedTask;
+        }
+
+        private void ReturnPageIfNeeded()
+        {
+            if (_returnAction != null)
+            {
+                _returnAction();
+                _returnAction = null;
+            }
+        }
+
+        public async Task Initialize(IBPlusTree<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer>? persistentTree, List<int> partitionColumns, IMemoryAllocator memoryAllocator, IStateManagerClient stateManagerClient)
+        {
+            if (persistentTree == null)
+            {
+                throw new ArgumentNullException(nameof(persistentTree));
+            }
+            _windowIterator = persistentTree.CreateIterator();
+
+            _windowPartitionIterator = new PartitionIterator(_windowIterator, partitionColumns);
+
+            _queue = await stateManagerClient.GetOrCreateQueue("queue", new FlowtideDotNet.Storage.Queue.FlowtideQueueOptions<MinMaxByIndexValue, MinMaxByIndexValueContainer>()
+            {
+                MemoryAllocator = memoryAllocator,
+                ValueSerializer = new MinMaxByIndexValueContainerSerializer(memoryAllocator),
+            });
+        }
+    }
+
+    internal class MinMaxByWindowFunctionUnboundedFrom : IWindowFunction
+    {
+        private IBPlusTreeIterator<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer>? _windowIterator;
+        private PartitionIterator? _windowPartitionIterator;
+        private long _windowRowIndex = 0;
+        private IAsyncEnumerator<KeyValuePair<ColumnRowReference, WindowStateReference>>? _windowEnumerator;
+        private readonly Func<EventBatchData, int, IDataValue> _fetchValueFunction;
+        private readonly Func<EventBatchData, int, IDataValue> _fetchCompareValueFunction;
+        private readonly long _to;
+        private readonly bool _isMin;
+
+        /// <summary>
+        /// Column used to store the minimum value.
+        /// It is a column to store the actual data and not just a reference
+        /// </summary>
+        private Column? _minValueCompareColumn;
+        private Column? _minValueColumn;
+
+        public MinMaxByWindowFunctionUnboundedFrom(
+            Func<EventBatchData, int, IDataValue> fetchValueFunction,
+            Func<EventBatchData, int, IDataValue> fetchCompareValueFunction,
+            long to,
+            bool isMin)
+        {
+            _fetchValueFunction = fetchValueFunction;
+            _fetchCompareValueFunction = fetchCompareValueFunction;
+            _to = to;
+            _isMin = isMin;
+        }
+
+        public ValueTask Commit()
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public async ValueTask NewPartition(ColumnRowReference partitionValues)
+        {
+            Debug.Assert(_windowPartitionIterator != null);
+
+            await _windowPartitionIterator.Reset(partitionValues);
+            _windowEnumerator = _windowPartitionIterator.GetAsyncEnumerator();
+            _windowRowIndex = 0;
+        }
+
+        public async ValueTask<IDataValue> ComputeRow(KeyValuePair<ColumnRowReference, WindowStateReference> row, long partitionRowIndex)
+        {
+            Debug.Assert(_windowEnumerator != null);
+            Debug.Assert(_minValueColumn != null);
+            Debug.Assert(_minValueCompareColumn != null);
+
+            var windowEnd = partitionRowIndex + _to;
+
+            var currentVal = _minValueCompareColumn.GetValueAt(0, default);
+            while (_windowRowIndex <= windowEnd && await _windowEnumerator.MoveNextAsync())
+            {
+                var compareVal = _fetchCompareValueFunction(_windowEnumerator.Current.Key.referenceBatch, _windowEnumerator.Current.Key.RowIndex);
+                var val = _fetchValueFunction(_windowEnumerator.Current.Key.referenceBatch, _windowEnumerator.Current.Key.RowIndex);
+
+                if (_isMin)
+                {
+                    if (currentVal.IsNull || DataValueComparer.Instance.Compare(compareVal, currentVal) < 0)
+                    {
+                        _minValueColumn.UpdateAt(0, val);
+                        _minValueCompareColumn.UpdateAt(0, compareVal);
+                        // Use reference from the column instead of the fetched value since it can leave memory
+                        currentVal = _minValueCompareColumn.GetValueAt(0, default);
+                    }
+                }
+                else
+                {
+                    if (currentVal.IsNull || DataValueComparer.Instance.Compare(compareVal, currentVal) > 0)
+                    {
+                        _minValueColumn.UpdateAt(0, val);
+                        _minValueCompareColumn.UpdateAt(0, compareVal);
+                        // Use reference from the column instead of the fetched value since it can leave memory
+                        currentVal = _minValueCompareColumn.GetValueAt(0, default);
+                    }
+                }
+                
+
+                _windowRowIndex++;
+            }
+
+            return currentVal;
+        }
+
+        public ValueTask EndPartition(ColumnRowReference partitionValues)
+        {
+            Debug.Assert(_minValueColumn != null);
+            Debug.Assert(_minValueCompareColumn != null);
+
+            _minValueColumn.UpdateAt(0, NullValue.Instance);
+            _minValueCompareColumn.UpdateAt(0, NullValue.Instance);
+            return ValueTask.CompletedTask;
+        }
+
+        public Task Initialize(IBPlusTree<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer>? persistentTree, List<int> partitionColumns, IMemoryAllocator memoryAllocator, IStateManagerClient stateManagerClient)
+        {
+            if (persistentTree == null)
+            {
+                throw new ArgumentNullException(nameof(persistentTree));
+            }
+            _windowIterator = persistentTree.CreateIterator();
+
+            _windowPartitionIterator = new PartitionIterator(_windowIterator, partitionColumns);
+
+            _minValueCompareColumn = Column.Create(memoryAllocator);
+            _minValueColumn = Column.Create(memoryAllocator);
+
+            // Add null to both
+            _minValueCompareColumn.Add(NullValue.Instance);
+            _minValueColumn.Add(NullValue.Instance);
+
+            return Task.CompletedTask;
+        }
+    }
+
+    internal class MinMaxByWindowFunctionUnbounded : IWindowFunction
+    {
+        private IBPlusTreeIterator<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer>? _windowIterator;
+        private PartitionIterator? _windowPartitionIterator;
+        private IAsyncEnumerator<KeyValuePair<ColumnRowReference, WindowStateReference>>? _windowEnumerator;
+        private readonly Func<EventBatchData, int, IDataValue> _fetchValueFunction;
+        private readonly Func<EventBatchData, int, IDataValue> _fetchCompareValueFunction;
+        private readonly bool _isMin;
+
+        /// <summary>
+        /// Column used to store the minimum value.
+        /// It is a column to store the actual data and not just a reference
+        /// </summary>
+        private Column? _minValueCompareColumn;
+        private Column? _minValueColumn;
+
+        public MinMaxByWindowFunctionUnbounded(
+            Func<EventBatchData, int, IDataValue> fetchValueFunction,
+            Func<EventBatchData, int, IDataValue> fetchCompareValueFunction,
+            bool isMin)
+        {
+            _fetchValueFunction = fetchValueFunction;
+            _fetchCompareValueFunction = fetchCompareValueFunction;
+            _isMin = isMin;
+        }
+
+        public ValueTask Commit()
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public async ValueTask NewPartition(ColumnRowReference partitionValues)
+        {
+            Debug.Assert(_windowPartitionIterator != null);
+            Debug.Assert(_minValueColumn != null);
+            Debug.Assert(_minValueCompareColumn != null);
+
+            await _windowPartitionIterator.Reset(partitionValues);
+            _windowEnumerator = _windowPartitionIterator.GetAsyncEnumerator();
+
+            var currentVal = _minValueCompareColumn.GetValueAt(0, default);
+            while (await _windowEnumerator.MoveNextAsync())
+            {
+                var compareVal = _fetchCompareValueFunction(_windowEnumerator.Current.Key.referenceBatch, _windowEnumerator.Current.Key.RowIndex);
+                var val = _fetchValueFunction(_windowEnumerator.Current.Key.referenceBatch, _windowEnumerator.Current.Key.RowIndex);
+
+                if (_isMin)
+                {
+                    if (currentVal.IsNull || DataValueComparer.Instance.Compare(compareVal, currentVal) < 0)
+                    {
+                        _minValueColumn.UpdateAt(0, val);
+                        _minValueCompareColumn.UpdateAt(0, compareVal);
+                        // Use reference from the column instead of the fetched value since it can leave memory
+                        currentVal = _minValueCompareColumn.GetValueAt(0, default);
+                    }
+                }
+                else
+                {
+                    if (currentVal.IsNull || DataValueComparer.Instance.Compare(compareVal, currentVal) > 0)
+                    {
+                        _minValueColumn.UpdateAt(0, val);
+                        _minValueCompareColumn.UpdateAt(0, compareVal);
+                        // Use reference from the column instead of the fetched value since it can leave memory
+                        currentVal = _minValueCompareColumn.GetValueAt(0, default);
+                    }
+                }
+                
+            }
+        }
+
+        public ValueTask<IDataValue> ComputeRow(KeyValuePair<ColumnRowReference, WindowStateReference> row, long partitionRowIndex)
+        {
+            Debug.Assert(_minValueColumn != null);
+            return ValueTask.FromResult(_minValueColumn.GetValueAt(0, default));
+        }
+
+        public ValueTask EndPartition(ColumnRowReference partitionValues)
+        {
+            Debug.Assert(_minValueColumn != null);
+            Debug.Assert(_minValueCompareColumn != null);
+
+            _minValueColumn.UpdateAt(0, NullValue.Instance);
+            _minValueCompareColumn.UpdateAt(0, NullValue.Instance);
+            return ValueTask.CompletedTask;
+        }
+
+        public Task Initialize(IBPlusTree<ColumnRowReference, WindowValue, ColumnKeyStorageContainer, WindowValueContainer>? persistentTree, List<int> partitionColumns, IMemoryAllocator memoryAllocator, IStateManagerClient stateManagerClient)
+        {
+            if (persistentTree == null)
+            {
+                throw new ArgumentNullException(nameof(persistentTree));
+            }
+            _windowIterator = persistentTree.CreateIterator();
+
+            _windowPartitionIterator = new PartitionIterator(_windowIterator, partitionColumns);
+
+            _minValueCompareColumn = Column.Create(memoryAllocator);
+            _minValueColumn = Column.Create(memoryAllocator);
+
+            // Add null to both
+            _minValueCompareColumn.Add(NullValue.Instance);
+            _minValueColumn.Add(NullValue.Instance);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/Queue/IFlowtideQueue.cs
+++ b/src/FlowtideDotNet.Storage/Queue/IFlowtideQueue.cs
@@ -28,6 +28,20 @@ namespace FlowtideDotNet.Storage.Queue
 
         ValueTask<V> Pop();
 
+        /// <summary>
+        /// Peeks the latest enqueued value, returns an action which if set disposes the value after its been used.
+        /// This is required if the value is in another page.
+        /// </summary>
+        /// <returns></returns>
+        ValueTask<(V value, Action? returnFunc)> PeekPop();
+
+        /// <summary>
+        /// Peeks the first value in the queue, returns an action which if set disposes the value after its been used.
+        /// This is required if the value is in another page.
+        /// </summary>
+        /// <returns></returns>
+        ValueTask<(V value, Action? returnFunc)> Peek();
+
         ValueTask Commit();
 
         ValueTask Clear();


### PR DESCRIPTION
This fixes #793

This PR also adds Peek and PeekPop to the queue to allow looking at the values which is required by the min_by and max_by functions.