### PR TITLE
Add IFileCacheFactory to allow different implementations of the cache

### DIFF
--- a/src/FlowtideDotNet.DependencyInjection/Internal/FlowtideStorageBuilder.cs
+++ b/src/FlowtideDotNet.DependencyInjection/Internal/FlowtideStorageBuilder.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Storage;
+using FlowtideDotNet.Storage.FileCache;
 using FlowtideDotNet.Storage.Persistence;
 using FlowtideDotNet.Storage.StateManager;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,6 +48,19 @@ namespace FlowtideDotNet.DependencyInjection.Internal
             return this;
         }
 
+        public IFlowtideStorageBuilder SetFileCacheFactory(IFileCacheFactory fileCacheFactory)
+        {
+            services.AddKeyedSingleton(name, fileCacheFactory);
+            return this;
+        }
+
+        public IFlowtideStorageBuilder SetFileCacheFactory<TFileCacheFactory>()
+            where TFileCacheFactory : class, IFileCacheFactory
+        {
+            services.AddKeyedSingleton<IFileCacheFactory, TFileCacheFactory>(name);
+            return this;
+        }
+
         public bool UseReadCache { get; set; }
 
         public long? MaxProcessMemory { get; set; }
@@ -64,6 +78,7 @@ namespace FlowtideDotNet.DependencyInjection.Internal
             var persistentStorage = serviceProvider.GetKeyedService<IPersistentStorage>(name);
             var serializeOptions = serviceProvider.GetKeyedService<StateSerializeOptions>(name);
             var fileCacheOptions = serviceProvider.GetKeyedService<FileCacheOptions>(name);
+            var fileCacheFactory = serviceProvider.GetKeyedService<IFileCacheFactory>(name);
 
             if (MaxProcessMemory == null && MaxPageCount == null)
             {
@@ -84,7 +99,7 @@ namespace FlowtideDotNet.DependencyInjection.Internal
                 TemporaryStorageOptions = fileCacheOptions,
                 MaxProcessMemory = MaxProcessMemory ?? -1,
                 MinCachePageCount = MinPageCount,
-
+                FileCacheFactory = fileCacheFactory,
                 CachePageCount = MaxPageCount ?? 1000
             };
         }

--- a/src/FlowtideDotNet.Storage/FileCache/DefaultFileCacheFactory.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/DefaultFileCacheFactory.cs
@@ -1,0 +1,36 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage.FileCache
+{
+    public class DefaultFileCacheFactory : IFileCacheFactory
+    {
+        private readonly FileCacheOptions fileCacheOptions;
+
+        public DefaultFileCacheFactory(FileCacheOptions fileCacheOptions)
+        {
+            this.fileCacheOptions = fileCacheOptions;
+        }
+
+        public IFileCache Create(string name, IMemoryAllocator memoryAllocator)
+        {
+            return new FileCache(fileCacheOptions, name, memoryAllocator);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/FileCache/IFileCache.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/IFileCache.cs
@@ -1,0 +1,45 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.StateManager.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage.FileCache
+{
+    public interface IFileCache : IDisposable
+    {
+        void Write(long id, SerializableObject serializableObject);
+
+        ReadOnlyMemory<byte> Read(long pageKey);
+
+        ValueTask<T> Read<T>(long pageKey, IStateSerializer<T> serializer)
+            where T : ICacheObject;
+
+        void Free(in long pageKey);
+
+        /// <summary>
+        /// Called when a state client wants to clear all its keys.
+        /// If one cache exist per client, then the keys does not need to be handled and
+        /// the entire cache can be cleared.
+        /// </summary>
+        /// <param name="keys"></param>
+        void FreeAll(IEnumerable<long> keys);
+
+        void Flush();
+
+        void ClearTemporaryAllocations();
+    }
+}

--- a/src/FlowtideDotNet.Storage/FileCache/IFileCacheFactory.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/IFileCacheFactory.cs
@@ -1,0 +1,26 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage.FileCache
+{
+    public interface IFileCacheFactory
+    {
+        IFileCache Create(string name, IMemoryAllocator memoryAllocator);
+    }
+}

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/FileCache.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/FileCache.cs
@@ -428,8 +428,13 @@ namespace FlowtideDotNet.Storage.FileCache
         public ValueTask<T> Read<T>(long pageKey, IStateSerializer<T> serializer)
             where T : ICacheObject
         {
-            var memory = Read(pageKey);
+            var memory = ReadSync(pageKey);
             return ValueTask.FromResult(serializer.Deserialize(memory, memory.Length));
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> Read(long pageKey)
+        {
+            return ValueTask.FromResult(ReadSync(pageKey));
         }
 
         /// <summary>
@@ -438,7 +443,7 @@ namespace FlowtideDotNet.Storage.FileCache
         /// <param name="pageKey"></param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public ReadOnlyMemory<byte> Read(long pageKey)
+        public ReadOnlyMemory<byte> ReadSync(long pageKey)
         {
             IFileCacheWriter? segmentWriter = default;
             long position = 0;

--- a/src/FlowtideDotNet.Storage/FileCache/Internal/FileCache.cs
+++ b/src/FlowtideDotNet.Storage/FileCache/Internal/FileCache.cs
@@ -18,10 +18,11 @@ using FlowtideDotNet.Storage.Utils;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Storage.FileCache
 {
-    internal class FileCache : IDisposable
+    internal class FileCache : IDisposable, IFileCache
     {
         private struct FreePage : IComparable<FreePage>
         {
@@ -274,7 +275,7 @@ namespace FlowtideDotNet.Storage.FileCache
             }
         }
 
-        public void FreeAll()
+        public void FreeAll(IEnumerable<long> keysToFree)
         {
             lock (m_lock)
             {
@@ -424,11 +425,11 @@ namespace FlowtideDotNet.Storage.FileCache
             }
         }
 
-        public T Read<T>(long pageKey, IStateSerializer<T> serializer)
+        public ValueTask<T> Read<T>(long pageKey, IStateSerializer<T> serializer)
             where T : ICacheObject
         {
             var memory = Read(pageKey);
-            return serializer.Deserialize(memory, memory.Length);
+            return ValueTask.FromResult(serializer.Deserialize(memory, memory.Length));
         }
 
         /// <summary>

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
@@ -46,7 +46,7 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
         public ValueTask<T> Read<T>(long key, IStateSerializer<T> serializer)
             where T : ICacheObject
         {
-            return ValueTask.FromResult(fileCache.Read(key, serializer));
+            return fileCache.Read(key, serializer);
         }
 
         public virtual Task Write(long key, SerializableObject value)

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentSession.cs
@@ -40,7 +40,7 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
 
         public ValueTask<ReadOnlyMemory<byte>> Read(long key)
         {
-            return ValueTask.FromResult(fileCache.Read(key));
+            return fileCache.Read(key);
         }
 
         public ValueTask<T> Read<T>(long key, IStateSerializer<T> serializer)

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentStorage.cs
@@ -80,7 +80,7 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
         {
             if (m_fileCache.Exists(key))
             {
-                value = m_fileCache.Read(key);
+                value = m_fileCache.ReadSync(key);
                 return true;
             }
             value = default;

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
@@ -187,7 +187,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
                     continue;
                 }
                 {
-                    var bytes = m_fileCache.Read(kv.Key);
+                    var bytes = await m_fileCache.Read(kv.Key);
 
                     // Write to persistence
                     await session.Write(kv.Key, new SerializableObject(bytes));

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Storage.Exceptions;
+using FlowtideDotNet.Storage.FileCache;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Persistence;
 using FlowtideDotNet.Storage.Utils;
@@ -38,7 +39,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
         private readonly IMemoryAllocator memoryAllocator;
         private readonly Dictionary<long, int> m_modified;
         private readonly object m_lock = new object();
-        private readonly FlowtideDotNet.Storage.FileCache.FileCache m_fileCache;
+        private readonly FlowtideDotNet.Storage.FileCache.IFileCache m_fileCache;
         private readonly ConcurrentDictionary<long, int> m_fileCacheVersion;
         private readonly Histogram<float>? m_persistenceReadMsHistogram;
         private readonly Histogram<float>? m_temporaryReadMsHistogram;
@@ -64,7 +65,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             StateClientMetadata<TMetadata> metadata,
             IPersistentStorageSession session,
             StateClientOptions<V> options,
-            FileCacheOptions fileCacheOptions,
+            IFileCacheFactory fileCacheFactory,
             Meter meter,
             bool useReadCache,
             int bplusTreePageSize,
@@ -81,7 +82,7 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             this.m_bplusTreePageSize = bplusTreePageSize;
             this.m_bplusTreePageSizeBytes = bplusTreePageSizeBytes;
             this.memoryAllocator = memoryAllocator;
-            m_fileCache = new FlowtideDotNet.Storage.FileCache.FileCache(fileCacheOptions, name, memoryAllocator);
+            m_fileCache = fileCacheFactory.Create(name, memoryAllocator);
             m_modified = new Dictionary<long, int>();
             m_fileCacheVersion = new ConcurrentDictionary<long, int>();
             if (!string.IsNullOrEmpty(name))
@@ -215,12 +216,12 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             Interlocked.Add(ref stateManager.m_metadata.PageCount, newPages);
             newPages = 0;
 
-            m_modified.Clear();
             if (!useReadCache)
             {
-                m_fileCache.FreeAll();
+                m_fileCache.FreeAll(m_modified.Keys);
                 m_fileCacheVersion.Clear();
             }
+            m_modified.Clear();
 
             await WriteMetadata();
             await session.Commit();
@@ -269,7 +270,6 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
 
         public ValueTask<V?> GetValue(in long key)
         {
-            Debug.Assert(options.ValueSerializer != null);
             lock (m_lock)
             {
                 var modLookup = key % _lookupTable.Length;
@@ -300,24 +300,30 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
                 // Read from temporary file storage
                 if (m_fileCacheVersion.ContainsKey(key))
                 {
-                    var sw = ValueStopwatch.StartNew();
-                    var value = m_fileCache.Read<V>(key, options.ValueSerializer);
-                    if (!value.TryRent())
-                    {
-                        throw new InvalidOperationException("Could not rent value when fetched from storage.");
-                    }
-                    stateManager.AddOrUpdate(key, value, this);
-
-                    if (m_temporaryReadMsHistogram != null)
-                    {
-                        m_temporaryReadMsHistogram.Record((float)sw.GetElapsedTime().TotalMilliseconds, tagList);
-                    }
-
-                    return ValueTask.FromResult<V?>(value);
+                    return GetValue_FromCache(key);
                 }
                 // Read from persistent store
                 return GetValue_Persistent(key);
             }
+        }
+
+        private async ValueTask<V?> GetValue_FromCache(long key)
+        {
+            Debug.Assert(options.ValueSerializer != null);
+            var sw = ValueStopwatch.StartNew();
+            var value = await m_fileCache.Read<V>(key, options.ValueSerializer);
+            if (!value.TryRent())
+            {
+                throw new InvalidOperationException("Could not rent value when fetched from storage.");
+            }
+            stateManager.AddOrUpdate(key, value, this);
+
+            if (m_temporaryReadMsHistogram != null)
+            {
+                m_temporaryReadMsHistogram.Record((float)sw.GetElapsedTime().TotalMilliseconds, tagList);
+            }
+
+            return value;
         }
 
         private async ValueTask<V?> GetValue_Persistent(long key)
@@ -384,8 +390,8 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
                     _lookupTable[i].Value = default;
                     _lookupTable[i].Key = 0;
                 }
+                m_fileCache.FreeAll(m_modified.Keys);
                 m_modified.Clear();
-                m_fileCache.FreeAll();
                 m_fileCacheVersion.Clear();
             }
             if (clearMetadata || !metadata.CommitedOnce)

--- a/src/FlowtideDotNet.Storage/StateManager/StateManagerOptions.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/StateManagerOptions.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FASTER.core;
+using FlowtideDotNet.Storage.FileCache;
 using FlowtideDotNet.Storage.Persistence;
 
 namespace FlowtideDotNet.Storage.StateManager
@@ -47,7 +48,12 @@ namespace FlowtideDotNet.Storage.StateManager
         [Obsolete]
         public INamedDeviceFactory? TemporaryStorageFactory { get; set; }
 
+        /// <summary>
+        /// Used if file cache factory is not set, with the default file cache
+        /// </summary>
         public FileCacheOptions? TemporaryStorageOptions { get; set; }
+
+        public IFileCacheFactory? FileCacheFactory { get; set; }
 
         [Obsolete]
         public bool RemoveOutdatedCheckpoints { get; set; } = true;

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -69,7 +69,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
 
         public SqlPlanBuilder SqlPlanBuilder => sqlPlanBuilder;
 
-        public int CachePageCount { get; set; } = 1;
+        public int CachePageCount { get; set; } = 1000;
 
         public Watermark? LastWatermark => _lastWatermark;
 
@@ -242,7 +242,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
                     SerializeOptions = stateSerializeOptions,
                     PersistentStorage = _persistentStorage,
                     DefaultBPlusTreePageSize = pageSize,
-                    DefaultBPlusTreePageSizeBytes = 1,
+                    //DefaultBPlusTreePageSizeBytes = 1,
                     TemporaryStorageOptions = new Storage.FileCacheOptions()
                     {
                         DirectoryPath = $"./data/tempFiles/{testName}/tmp"

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -69,7 +69,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
 
         public SqlPlanBuilder SqlPlanBuilder => sqlPlanBuilder;
 
-        public int CachePageCount { get; set; } = 1000;
+        public int CachePageCount { get; set; } = 1;
 
         public Watermark? LastWatermark => _lastWatermark;
 
@@ -242,7 +242,7 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
                     SerializeOptions = stateSerializeOptions,
                     PersistentStorage = _persistentStorage,
                     DefaultBPlusTreePageSize = pageSize,
-                    //DefaultBPlusTreePageSizeBytes = 1,
+                    DefaultBPlusTreePageSizeBytes = 1,
                     TemporaryStorageOptions = new Storage.FileCacheOptions()
                     {
                         DirectoryPath = $"./data/tempFiles/{testName}/tmp"


### PR DESCRIPTION
This change also makes the read methods async.

The write methods are still sync since they require locking of the object when writing.
This might be possible to change in the future, but will not be included in this PR.