### PR TITLE
Improve substring and trim performance

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/BinaryValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/BinaryValue.cs
@@ -29,7 +29,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/BoolValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/BoolValue.cs
@@ -32,7 +32,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => value;
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/DataValueContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/DataValueContainer.cs
@@ -39,7 +39,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => _int64Value.AsLong;
 
-        public FlxString AsString => _stringValue.AsString;
+        public StringValue AsString => _stringValue;
 
         public bool AsBool => _boolValue.AsBool;
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/DecimalValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/DecimalValue.cs
@@ -31,7 +31,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/DoubleValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/DoubleValue.cs
@@ -30,7 +30,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/IDataValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/IDataValue.cs
@@ -22,7 +22,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         long AsLong { get; }
 
-        FlxString AsString { get; }
+        StringValue AsString { get; }
 
         bool AsBool { get; }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/Int64Value.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/Int64Value.cs
@@ -32,7 +32,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => _value;
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/ListValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/ListValue.cs
@@ -36,7 +36,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataValues
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/MapValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/MapValue.cs
@@ -38,7 +38,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/NullValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/NullValue.cs
@@ -23,7 +23,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataValues
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/ReferenceListValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/ReferenceListValue.cs
@@ -33,7 +33,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/ReferenceMapValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/ReferenceMapValue.cs
@@ -32,7 +32,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/ReferenceStructValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/ReferenceStructValue.cs
@@ -37,7 +37,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataValues
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/StringValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/StringValue.cs
@@ -26,7 +26,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => new FlxString(_utf8.Span);
+        public StringValue AsString => this;
 
         public bool AsBool => throw new NotImplementedException();
 
@@ -45,6 +45,10 @@ namespace FlowtideDotNet.Core.ColumnStore
         public TimestampTzValue AsTimestamp => throw new NotImplementedException();
 
         public IStructValue AsStruct => throw new NotSupportedException();
+
+        public ReadOnlySpan<byte> Span => _utf8.Span;
+
+        public ReadOnlyMemory<byte> Memory => _utf8;
 
         public StringValue(byte[] utf8)
         {
@@ -75,6 +79,21 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void Accept(in DataValueVisitor visitor)
         {
             visitor.VisitStringValue(in this);
+        }
+
+        public int CompareTo(in StringValue other)
+        {
+            return Compare(this, other);
+        }
+
+        public static int Compare(in StringValue v1, in StringValue v2)
+        {
+            return v1.Span.SequenceCompareTo(v2.Span);
+        }
+
+        public static int CompareIgnoreCase(in FlxString v1, in FlxString v2)
+        {
+            return Utf8Utility.CompareToOrdinalIgnoreCaseUtf8(v1.Span, v2.Span);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/StructValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/StructValue.cs
@@ -160,7 +160,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataValues
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataValues/TimestampTzValue.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataValues/TimestampTzValue.cs
@@ -61,7 +61,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataValues
 
         public long AsLong => throw new NotImplementedException();
 
-        public FlxString AsString => throw new NotImplementedException();
+        public StringValue AsString => throw new NotImplementedException();
 
         public bool AsBool => throw new NotImplementedException();
 

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/CheckFunctions/BuiltInCheckFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/CheckFunctions/BuiltInCheckFunctions.cs
@@ -128,7 +128,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.CheckFunctions
                     var createSpan = Expression.New(createSpanCtor, staticArray);
 
                     var notificationReceiverMethod = typeof(ICheckNotificationReceiver).GetMethod(nameof(ICheckNotificationReceiver.OnCheckFailure), BindingFlags.Public | BindingFlags.Instance);
-                    var flxStringToStringMethod = typeof(FlxString).GetMethod(nameof(FlxString.ToString), BindingFlags.Public | BindingFlags.Instance);
+                    var flxStringToStringMethod = typeof(StringValue).GetMethod(nameof(StringValue.ToString), BindingFlags.Public | BindingFlags.Instance);
                     var messageAsStringProp = checkMessage.Type.GetProperty(nameof(IDataValue.AsString));
 
                     if (notificationReceiverMethod == null)
@@ -137,7 +137,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.CheckFunctions
                     }
                     if (flxStringToStringMethod == null)
                     {
-                        throw new InvalidOperationException("FlxString.ToString method not found");
+                        throw new InvalidOperationException("StringValue.ToString method not found");
                     }
                     if (messageAsStringProp == null)
                     {
@@ -257,7 +257,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.CheckFunctions
                     var createSpan = Expression.New(createSpanCtor, staticArray);
 
                     var notificationReceiverMethod = typeof(ICheckNotificationReceiver).GetMethod(nameof(ICheckNotificationReceiver.OnCheckFailure), BindingFlags.Public | BindingFlags.Instance);
-                    var flxStringToStringMethod = typeof(FlxString).GetMethod(nameof(FlxString.ToString), BindingFlags.Public | BindingFlags.Instance);
+                    var flxStringToStringMethod = typeof(StringValue).GetMethod(nameof(StringValue.ToString), BindingFlags.Public | BindingFlags.Instance);
                     var messageAsStringProp = checkMessage.Type.GetProperty(nameof(IDataValue.AsString));
 
                     if (notificationReceiverMethod == null)
@@ -266,7 +266,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.CheckFunctions
                     }
                     if (flxStringToStringMethod == null)
                     {
-                        throw new InvalidOperationException("FlxString.ToString method not found");
+                        throw new InvalidOperationException("StringValue.ToString method not found");
                     }
                     if (messageAsStringProp == null)
                     {

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StringFunctions/Utf8GraphemeReader.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StringFunctions/Utf8GraphemeReader.cs
@@ -1,0 +1,74 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StringFunctions
+{
+    internal ref struct Utf8GraphemeReader
+    {
+        private ReadOnlySpan<byte> _utf8;
+        private int _position;
+
+        public int CurrentStart { get; private set; }
+
+        public Utf8GraphemeReader(ReadOnlySpan<byte> utf8)
+        {
+            _utf8 = utf8;
+            _position = 0;
+            CurrentStart = 0;
+        }
+
+        public bool MoveNext()
+        {
+            if (_position >= _utf8.Length)
+                return false;
+
+            CurrentStart = _position;
+
+            // First rune
+            var status = Rune.DecodeFromUtf8(_utf8.Slice(_position), out Rune rune, out int bytesConsumed);
+            
+            if (status != System.Buffers.OperationStatus.Done)
+                throw new InvalidOperationException("Invalid UTF-8 sequence.");
+
+            _position += bytesConsumed;
+
+            // Consume following runes that are combining marks
+            while (_position < _utf8.Length)
+            {
+                status = Rune.DecodeFromUtf8(_utf8.Slice(_position), out Rune nextRune, out int nextBytes);
+                
+                if (status != System.Buffers.OperationStatus.Done)
+                    break;
+
+                var cat = CharUnicodeInfo.GetUnicodeCategory(nextRune.Value);
+                if (cat != UnicodeCategory.NonSpacingMark &&
+                    cat != UnicodeCategory.SpacingCombiningMark &&
+                    cat != UnicodeCategory.EnclosingMark)
+                {
+                    break;
+                }
+
+                _position += nextBytes;
+            }
+
+            return true;
+        }
+    }
+
+}

--- a/src/FlowtideDotNet.Core/Compute/Internal/BuiltinFunctions.cs
+++ b/src/FlowtideDotNet.Core/Compute/Internal/BuiltinFunctions.cs
@@ -24,7 +24,7 @@ namespace FlowtideDotNet.Core.Compute.Internal
             Columnar.Functions.BuiltInComparisonFunctions.AddComparisonFunctions(functionsRegister);
             BuiltInGenericFunctions.AddBuiltInAggregateGenericFunctions(functionsRegister);
             ArithmaticStreamingFunctions.AddBuiltInArithmaticFunctions(functionsRegister);
-            Columnar.Functions.BuiltInStringFunctions.RegisterFunctions(functionsRegister);
+            Columnar.Functions.StringFunctions.BuiltInStringFunctions.RegisterFunctions(functionsRegister);
             Columnar.Functions.BuiltInBooleanFunctions.AddBooleanFunctions(functionsRegister);
             Columnar.Functions.BuiltInDatetimeFunctions.AddBuiltInDatetimeFunctions(functionsRegister);
             Columnar.Functions.BuiltInRoundingFunctions.AddRoundingFunctions(functionsRegister);


### PR DESCRIPTION
This change removes the need of FlxString on the stringvalue and allows functions to access ReadOnlyMemory and ReadOnlySpan of the string value. This allows them to use slices to do their operations without allocating new memory.