### PR TITLE
Sqlstorage retry

### DIFF
--- a/src/FlowtideDotNet.Storage.SqlServer/Data/BaseSqlRepository.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/Data/BaseSqlRepository.cs
@@ -15,6 +15,7 @@ using Microsoft.Data.SqlClient;
 using System.Buffers.Binary;
 using System.Data;
 using System.Text;
+using ZstdSharp.Unsafe;
 
 namespace FlowtideDotNet.Storage.SqlServer.Data
 {
@@ -130,7 +131,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             cmd.CommandText = query;
             await connection.OpenAsync();
 
-            var reader = await cmd.ExecuteReaderAsync();
+            var reader = await cmd.ExecuteReaderAsync().ExecutePipeline(Settings);
             if (await reader.ReadAsync())
             {
                 return await reader.GetFieldValueAsync<byte[]>(0);
@@ -156,7 +157,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             if (transaction == null)
             {
                 using var connection = new SqlConnection(Settings.ConnectionStringFunc());
-                await connection.OpenAsync();
+                await connection.OpenAsync().ExecutePipeline(Settings);
                 await SaveStreamPagesAsync(reader, connection);
             }
             else
@@ -173,7 +174,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
 
             if (connection.State != ConnectionState.Open)
             {
-                await connection.OpenAsync();
+                await connection.OpenAsync().ExecutePipeline(Settings);
             }
 
             using var bulkCopy = new SqlBulkCopy(connection)
@@ -194,7 +195,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
                 ColumnOrderHints = { { "PageKey", SortOrder.Ascending }, { "StreamKey", SortOrder.Ascending } }
             };
 
-            await bulkCopy.WriteToServerAsync(reader);
+            await bulkCopy.WriteToServerAsync(reader).ExecutePipeline(Settings);
             await reader.DisposeAsync();
             await connection.DisposeAsync();
         }
@@ -223,7 +224,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
                 ColumnOrderHints = { { "PageKey", SortOrder.Ascending }, { "StreamKey", SortOrder.Ascending } }
             };
 
-            await bulkCopy.WriteToServerAsync(reader);
+            await bulkCopy.WriteToServerAsync(reader).ExecutePipeline(Settings);
             await reader.DisposeAsync();
         }
 
@@ -237,8 +238,8 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             using var cmd = new SqlCommand($"DELETE FROM {Settings.StreamPageTableName} WHERE Version > @Version AND StreamKey = @StreamKey", connection);
             cmd.Parameters.AddWithValue("@Version", Stream.Metadata.CurrentVersion);
             cmd.Parameters.AddWithValue("@StreamKey", Stream.Metadata.StreamKey);
-            await connection.OpenAsync();
-            await cmd.ExecuteNonQueryAsync();
+            await connection.OpenAsync().ExecutePipeline(Settings);
+            await cmd.ExecuteNonQueryAsync().ExecutePipeline(Settings);
         }
 
         public async Task DeleteUnsuccessfulVersionsAsync(SqlTransaction transaction)
@@ -252,7 +253,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             cmd.Parameters.AddWithValue("@StreamKey", Stream.Metadata.StreamKey);
             cmd.Transaction = transaction;
             cmd.Connection = transaction.Connection;
-            await cmd.ExecuteNonQueryAsync();
+            await cmd.ExecuteNonQueryAsync().ExecutePipeline(Settings);
         }
 
         public async Task DeleteOldVersionsInDbAsync(SqlTransaction transaction)
@@ -272,7 +273,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             cmd.Parameters.AddWithValue("@StreamKey", Stream.Metadata.StreamKey);
             cmd.Transaction = transaction;
 
-            await cmd.ExecuteNonQueryAsync();
+            await cmd.ExecuteNonQueryAsync().ExecutePipeline(Settings);
         }
 
         public async Task DeleteOldVersionsInDbFromPagesAsync(IEnumerable<ManagedStreamPage> pages, SqlTransaction transaction)
@@ -307,7 +308,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             sb.Append(')');
 
             cmd.CommandText = sb.ToString();
-            await cmd.ExecuteNonQueryAsync();
+            await cmd.ExecuteNonQueryAsync().ExecutePipeline(Settings);
         }
 
         public static Guid ToPageKey(long pageId, int version)

--- a/src/FlowtideDotNet.Storage.SqlServer/Data/BaseSqlRepository.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/Data/BaseSqlRepository.cs
@@ -86,9 +86,9 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             }
 
             cmd.CommandText = query;
-            connection.Open();
+            SqlServerStorageExtensionsHelpers.ExecutePipeline(connection.Open, Settings);
+            var reader = SqlServerStorageExtensionsHelpers.ExecutePipeline(cmd.ExecuteReader, Settings);
 
-            var reader = cmd.ExecuteReader();
             if (reader.Read())
             {
                 return reader.GetFieldValue<byte[]>(0);

--- a/src/FlowtideDotNet.Storage.SqlServer/Data/SessionRepository.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/Data/SessionRepository.cs
@@ -133,7 +133,7 @@ namespace FlowtideDotNet.Storage.SqlServer.Data
             DebugWriter!.WriteCall();
             DebugWriter!.DumpObj(pages);
 #endif
-            foreach (var page in pages.Where(page => ManagedPages.TryGetValue(page.PageId, out var set)))
+            foreach (var page in pages.Where(page => ManagedPages.TryGetValue(page.PageId, out var _)))
             {
                 ManagedPages.Remove(page.PageId);
             }

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentSession.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerPersistentSession.cs
@@ -21,8 +21,8 @@ namespace FlowtideDotNet.Storage.SqlServer
     {
         private readonly SessionRepository _repo;
         private bool _disposedValue;
-        ArrayBufferWriter<byte> _bufferWriter = new ArrayBufferWriter<byte>();
-        private object _lock = new object();
+        private readonly ArrayBufferWriter<byte> _bufferWriter = new();
+        private readonly object _lock = new();
 
         internal SqlServerPersistentSession(SessionRepository repo)
         {
@@ -44,11 +44,11 @@ namespace FlowtideDotNet.Storage.SqlServer
             return await _repo.ReadAsync(key);
         }
 
-        public async ValueTask<T> Read<T>(long key, IStateSerializer<T> serializer)
+        public async ValueTask<T> Read<T>(long key, IStateSerializer<T> stateSerializer)
             where T : ICacheObject
         {
             var bytes = await _repo.ReadAsync(key);
-            return serializer.Deserialize(bytes, bytes.Length);
+            return stateSerializer.Deserialize(bytes, bytes.Length);
         }
 
         public Task Write(long key, SerializableObject value)

--- a/src/FlowtideDotNet.Storage.SqlServer/SqlServerStorageExtensionsHelpers.cs
+++ b/src/FlowtideDotNet.Storage.SqlServer/SqlServerStorageExtensionsHelpers.cs
@@ -1,0 +1,71 @@
+﻿using Polly;
+using System.Diagnostics;
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace FlowtideDotNet.Storage.SqlServer
+{
+    internal static class SqlServerStorageExtensionsHelpers
+    {
+        public static async Task<T> ExecutePipeline<T>(this Task<T> execute, SqlServerPersistentStorageSettings settings)
+        {
+            var context = ResilienceContextPool.Shared.Get();
+            var pipeline = settings.ResiliencePipeline;
+            var outcome = await pipeline.ExecuteOutcomeAsync(static async (ctx, state) =>
+            {
+                try
+                {
+                    var result = await state.Task;
+                    return Outcome.FromResult(result);
+                }
+                catch (Exception ex)
+                {
+                    return Outcome.FromException<T>(ex);
+                }
+            }, context, new PipelineState<T>(execute));
+
+            ResilienceContextPool.Shared.Return(context);
+            outcome.ThrowIfException();
+            Debug.Assert(outcome.Result != null);
+
+            return outcome.Result!;
+        }
+
+        public static async Task ExecutePipeline(this Task execute, SqlServerPersistentStorageSettings settings)
+        {
+            var context = ResilienceContextPool.Shared.Get();
+            var pipeline = settings.ResiliencePipeline;
+
+            var outcome = await pipeline.ExecuteOutcomeAsync(static async (ctx, state) =>
+            {
+                try
+                {
+                    await state.Task;
+                    return Outcome.FromResult(new PipelineResult(true));
+                }
+                catch (Exception ex)
+                {
+                    return Outcome.FromException<PipelineResult>(ex);
+                }
+            }, context, new PipelineState(execute));
+
+            ResilienceContextPool.Shared.Return(context);
+            outcome.ThrowIfException();
+            Debug.Assert(outcome.Result != null);
+            Debug.Assert(outcome.Result.Success);
+        }
+
+        private sealed record PipelineState<T>(Task<T> Task);
+        private sealed record PipelineState(Task Task);
+        private sealed record PipelineResult(bool Success);
+    }
+}


### PR DESCRIPTION
Adds resilience pipeline to `SqlServerPersistentStorageSettings`. Default value is the same incremental retry policy used for the sql server source. 

Adds two generic helper extensions to execute in the pipeline for any `Task`/`Task<T>`.  Did not add a sync version as outcome only supports at `Task` and `ValueTask`.

Generally retries are added to `connection.OpenAsync` and `transaction.CommitAsync()`/`transaction.RollbackAsync()`.

What do we think about it conceptually? A bit uncertain regarding the bulkcopy, if it's a good idea to run that in this way.