### PR TITLE
Add possibility to use custom destination table for bulk copy

### DIFF
--- a/src/FlowtideDotNet.Base/Vertices/Egress/EgressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Egress/EgressVertex.cs
@@ -49,6 +49,8 @@ namespace FlowtideDotNet.Base.Vertices.Egress
 
         public abstract string DisplayName { get; }
 
+        public long CurrentCheckpointId { get; private set; }
+
         public ILogger Logger => _logger ?? throw new InvalidOperationException("Logger can only be fetched after initialize or setup method calls");
 
         protected CancellationToken CancellationToken => _cancellationTokenSource?.Token ?? throw new InvalidOperationException("Cancellation token can only be fetched after initialization.");
@@ -119,6 +121,7 @@ namespace FlowtideDotNet.Base.Vertices.Egress
 
         private async Task HandleCheckpoint(ICheckpointEvent checkpointEvent)
         {
+            CurrentCheckpointId = checkpointEvent.CheckpointTime;
             await OnCheckpoint(checkpointEvent.CheckpointTime);
         }
 
@@ -163,6 +166,7 @@ namespace FlowtideDotNet.Base.Vertices.Egress
             _streamName = vertexHandler.StreamName;
             _metrics = vertexHandler.Metrics;
             _logger = vertexHandler.LoggerFactory.CreateLogger(DisplayName);
+            CurrentCheckpointId = newTime;
 
             Metrics.CreateObservableGauge("busy", () =>
             {

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServerSinkOptions.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServerSinkOptions.cs
@@ -10,7 +10,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base;
 using FlowtideDotNet.Core.Operators.Write;
+using Microsoft.Data.SqlClient;
+using System.Data;
 
 namespace FlowtideDotNet.Connector.SqlServer
 {
@@ -30,5 +33,31 @@ namespace FlowtideDotNet.Connector.SqlServer
         public bool UseDatabaseDefinedInConnectionStringOnly { get; set; }
 
         public ExecutionMode ExecutionMode { get; set; } = ExecutionMode.Hybrid;
+
+        /// <summary>
+        /// If set, the sink writes data to the custom table and does not trigger any merge into to another table.
+        /// For custom merge into logic with custom destination table you can use OnDataUploaded event to run any sql code.
+        /// When using a custom destination table, the metadata if its an upsert or delete is not sent, that can be
+        /// added manually using ModifyRow.
+        /// </summary>
+        public string? CustomBulkCopyDestinationTable { get; set; }
+
+        /// <summary>
+        /// Allows adding extra columns to the data table that will be bulk uploaded
+        /// </summary>
+        public Func<DataTable, ValueTask>? OnDataTableCreation { get; set; }
+
+        /// <summary>
+        /// Allows modifying a data row adding extra metadata columns if required.
+        /// First argument is the actual data row, the second is if it is a deletion row, third is the watermark, fourth is the checkpointId.
+        /// The last argument is if this is the initial data upload.
+        /// </summary>
+        public Action<DataRow, bool, Watermark, long, bool>? ModifyRow { get; set; }
+
+        /// <summary>
+        /// Called when all data in a batch has been uploaded.
+        /// First argument is the sql connection, second the watermark, third the checkpointId, fourth if it is the initial data upload or not.
+        /// </summary>
+        public Func<SqlConnection, Watermark, long, bool, ValueTask>? OnDataUploaded { get; set; }
     }
 }

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServerSinkOptions.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServerSinkOptions.cs
@@ -37,7 +37,7 @@ namespace FlowtideDotNet.Connector.SqlServer
         /// <summary>
         /// If set, the sink writes data to the custom table and does not trigger any merge into to another table.
         /// For custom merge into logic with custom destination table you can use OnDataUploaded event to run any sql code.
-        /// When using a custom destination table, the metadata if its an upsert or delete is not sent, that can be
+        /// When using a custom destination table, the metadata if it's an upsert or delete is not sent, that can be
         /// added manually using ModifyRow.
         /// </summary>
         public string? CustomBulkCopyDestinationTable { get; set; }

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ColumnGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ColumnGroupedWriteOperator.cs
@@ -50,7 +50,7 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
         {
             this.m_executionMode = executionMode;
             this.m_writeRelation = writeRelation;
-
+            
             // Create the event batch used for delete, this is used to give the user the same amount of columns
             // if it is an upsert or a delete
             _deleteBatchColumns = new IColumn[writeRelation.OutputLength];

--- a/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerTestStream.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerTestStream.cs
@@ -22,6 +22,7 @@ namespace FlowtideDotNet.SqlServer.Tests.e2e
         private readonly string connectionString;
         private readonly List<string>? customPrimaryKeys;
         private readonly SqlServerSourceOptions? options;
+        private readonly SqlServerSinkOptions? sinkOptions;
 
         public SqlServerTestStream(string testName, string connectionString, List<string>? customPrimaryKeys = null) : base(testName)
         {
@@ -29,10 +30,11 @@ namespace FlowtideDotNet.SqlServer.Tests.e2e
             this.customPrimaryKeys = customPrimaryKeys;
         }
 
-        public SqlServerTestStream(string testName, SqlServerSourceOptions options) : base(testName)
+        public SqlServerTestStream(string testName, SqlServerSourceOptions options, SqlServerSinkOptions? sinkOptions = default) : base(testName)
         {
             this.options = options;
             this.connectionString = options.ConnectionStringFunc();
+            this.sinkOptions = sinkOptions;
         }
 
         protected override void AddReadResolvers(IConnectorManager factory)
@@ -50,11 +52,18 @@ namespace FlowtideDotNet.SqlServer.Tests.e2e
 
         protected override void AddWriteResolvers(IConnectorManager factory)
         {
-            factory.AddSqlServerSink(new SqlServerSinkOptions()
+            if (sinkOptions != null)
             {
-                ConnectionStringFunc = options?.ConnectionStringFunc != null ? options.ConnectionStringFunc : () => connectionString,
-                CustomPrimaryKeys = customPrimaryKeys
-            });
+                factory.AddSqlServerSink(sinkOptions);
+            }
+            else
+            {
+                factory.AddSqlServerSink(new SqlServerSinkOptions()
+                {
+                    ConnectionStringFunc = options?.ConnectionStringFunc != null ? options.ConnectionStringFunc : () => connectionString,
+                    CustomPrimaryKeys = customPrimaryKeys
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
This change allows custom implementations to merge data with custom logic, or just doing an append only insert into a table.

It also allows adding custom metadata to rows.