### PR TITLE
[SqlServer] Get primary keys based on their ordinal position

### DIFF
--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerUtils.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerUtils.cs
@@ -893,7 +893,7 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
             SELECT COLUMN_NAME
             FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
             WHERE OBJECTPROPERTY(OBJECT_ID(CONSTRAINT_SCHEMA + '.' + QUOTENAME(CONSTRAINT_NAME)), 'IsPrimaryKey') = 1
-            AND TABLE_NAME = @tableName AND TABLE_SCHEMA = @schema";
+            AND TABLE_NAME = @tableName AND TABLE_SCHEMA = @schema ORDER BY ORDINAL_POSITION";
 
             using var command = connection.CreateCommand();
             command.CommandText = cmd;


### PR DESCRIPTION
This fixes performance issues where the primary keys came in the wrong order when doing order by on selecting data.