### PR TITLE
Fix converting from column-based to dotnet ValueType with non null property

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/BatchConverter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ObjectConverter/BatchConverter.cs
@@ -253,6 +253,11 @@ namespace FlowtideDotNet.Core.ColumnStore.ObjectConverter
                     throw new InvalidOperationException("Cannot deserialize object without a set function");
                 }
 
+                if (value == null && property.TypeInfo.Type.IsValueType)
+                {
+                    value = Activator.CreateInstance(property.TypeInfo.Type); // Create default value for value types
+                }
+
                 property.SetFunc(obj, value);
             }
             return obj;


### PR DESCRIPTION
This fix removes a null exception if null is being assigned to say an integer, instead the default value 0 is assigned.