### PR TITLE
Add a new event method before checkpoint is saved for operators

### DIFF
--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
@@ -68,6 +68,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                     await run._context._stateManager.Compact();
                 }
 
+                await _context.ForEachBlockAsync(static async (key, block) =>
+                {
+                    await block.BeforeSaveCheckpoint();
+                });
+
                 // Take state checkpoint
                 _context._logger.StartingStateManagerCheckpoint(_context.streamName);
                 await run._context._stateManager.CheckpointAsync(false);

--- a/src/FlowtideDotNet.Base/Vertices/Egress/EgressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Egress/EgressVertex.cs
@@ -287,5 +287,10 @@ namespace FlowtideDotNet.Base.Vertices.Egress
                 _pauseSource = null;
             }
         }
+
+        public virtual Task BeforeSaveCheckpoint()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointSource.cs
+++ b/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointSource.cs
@@ -155,5 +155,10 @@ namespace FlowtideDotNet.Base.Vertices.FixedPoint
         public void Resume()
         {
         }
+
+        public virtual Task BeforeSaveCheckpoint()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointVertex.cs
@@ -531,5 +531,10 @@ namespace FlowtideDotNet.Base.Vertices.FixedPoint
                 _pauseSource = null;
             }
         }
+
+        public virtual Task BeforeSaveCheckpoint()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/IStreamVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/IStreamVertex.cs
@@ -49,5 +49,17 @@ namespace FlowtideDotNet.Base.Vertices
         void Pause();
 
         void Resume();
+
+        /// <summary>
+        /// This method is called directly before saving persistent data checkpoint.
+        /// This method should be used sparringly since the vertex might have handled data
+        /// that is after the checkpoint, so the vertex need to take that into consideration.
+        /// 
+        /// One use case is if a source has an offset (such as Kafka), and only a subset of events are in the result set.
+        /// If no new event has been sent into the stream after the checkpoint event, this method can be used to update the offset
+        /// to the latest one to skip loading in unnecessary data in the case of a crash.
+        /// </summary>
+        /// <returns></returns>
+        Task BeforeSaveCheckpoint();
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/IStreamVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/IStreamVertex.cs
@@ -52,7 +52,7 @@ namespace FlowtideDotNet.Base.Vertices
 
         /// <summary>
         /// This method is called directly before saving persistent data checkpoint.
-        /// This method should be used sparringly since the vertex might have handled data
+        /// This method should be used sparingly since the vertex might have handled data
         /// that is after the checkpoint, so the vertex need to take that into consideration.
         /// 
         /// One use case is if a source has an offset (such as Kafka), and only a subset of events are in the result set.

--- a/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
@@ -501,5 +501,10 @@ namespace FlowtideDotNet.Base.Vertices.Ingress
             Debug.Assert(_ingressState?._output != null, nameof(_ingressState._output));
             _ingressState._output.Resume();
         }
+
+        public virtual Task BeforeSaveCheckpoint()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
@@ -805,5 +805,10 @@ namespace FlowtideDotNet.Base.Vertices.MultipleInput
                 _pauseSource = null;
             }
         }
+
+        public virtual Task BeforeSaveCheckpoint()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/PartitionVertices/PartitionVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/PartitionVertices/PartitionVertex.cs
@@ -390,5 +390,10 @@ namespace FlowtideDotNet.Base.Vertices.PartitionVertices
                 _pauseSource = null;
             }
         }
+
+        public virtual Task BeforeSaveCheckpoint()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/Unary/UnaryVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Unary/UnaryVertex.cs
@@ -469,5 +469,10 @@ namespace FlowtideDotNet.Base.Vertices.Unary
                 _pauseSource = null;
             }
         }
+
+        public virtual Task BeforeSaveCheckpoint()
+        {
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
One use case is if a source has an offset (such as Kafka), and only a subset of events are in the result set. If no new event has been sent into the stream after the checkpoint event, this method can be used to update the offset to the latest one to skip loading in unnecessary data in the case of a crash.