### PR TITLE
Fix so initial data flag does not change until the first checkpoint

### DIFF
--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ColumnGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ColumnGroupedWriteOperator.cs
@@ -161,6 +161,11 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
             {
                 await SendData();
             }
+            if (m_hasSentInitialData.Value == false)
+            {
+                await OnInitialDataSent();
+                m_hasSentInitialData.Value = true;
+            }
             Checkpoint(checkpointTime);
             await m_hasSentInitialData.Commit();
             await m_tree.Commit();
@@ -311,11 +316,6 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
                 await UploadChanges(changedRows, m_latestWatermark, !m_hasSentInitialData.Value, CancellationToken);
                 await m_modified.Clear();
                 m_hasModified = false;
-            }
-            if (m_hasSentInitialData.Value == false)
-            {
-                await OnInitialDataSent();
-                m_hasSentInitialData.Value = true;
             }
         }
 


### PR DESCRIPTION
With the change of watermarks being allowed to be sent multiple times to allow quicker time to first event, this change is required to mark that the data is still in the initial data.