### PR TITLE
Fix existing row comparer in column grouped sink

### DIFF
--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ColumnGroupedWriteOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ColumnGroupedWriteOperator.cs
@@ -113,8 +113,7 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
 
             if (FetchExistingData && !m_hasSentInitialData.Value)
             {
-                var primaryKeySelectorList = m_primaryKeyColumns.Select(x => new KeyValuePair<int, ReferenceSegment?>(x, default)).ToList();
-                m_existingRowComparer = new ExistingRowComparer(primaryKeySelectorList, primaryKeySelectorList);
+                m_existingRowComparer = new ExistingRowComparer(m_primaryKeyColumns.Count);
                 m_existingData = await stateManagerClient.GetOrCreateTree("existing",
                 new BPlusTreeOptions<ColumnRowReference, int, ModifiedKeyStorage, ListValueContainer<int>>()
                 {

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ExistingRowComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ExistingRowComparer.cs
@@ -21,28 +21,21 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
     {
         private readonly DataValueContainer _leftContainer;
         private readonly DataValueContainer _rightContainer;
-        private readonly List<KeyValuePair<int, ReferenceSegment?>> leftColumns;
-        private readonly List<KeyValuePair<int, ReferenceSegment?>> rightColumns;
+        private readonly int _columnCount;
 
-        public ExistingRowComparer(List<KeyValuePair<int, ReferenceSegment?>> leftColumns, List<KeyValuePair<int, ReferenceSegment?>> rightColumns)
+        public ExistingRowComparer(int columnCount)
         {
-            this.leftColumns = leftColumns;
-            this.rightColumns = rightColumns;
             _leftContainer = new DataValueContainer();
             _rightContainer = new DataValueContainer();
-
-            if (leftColumns.Count != rightColumns.Count)
-            {
-                throw new ArgumentException("The number of columns in the left and right columns must be the same.");
-            }
+            this._columnCount = columnCount;
         }
 
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
         {
-            for (int i = 0; i < leftColumns.Count; i++)
+            for (int i = 0; i < _columnCount; i++)
             {
-                x.referenceBatch.Columns[leftColumns[i].Key].GetValueAt(x.RowIndex, _leftContainer, leftColumns[i].Value);
-                y.referenceBatch.Columns[rightColumns[i].Key].GetValueAt(y.RowIndex, _rightContainer, rightColumns[i].Value);
+                x.referenceBatch.Columns[i].GetValueAt(x.RowIndex, _leftContainer, default);
+                y.referenceBatch.Columns[i].GetValueAt(y.RowIndex, _rightContainer, default);
                 int compareVal = DataValueComparer.CompareTo(_leftContainer, _rightContainer);
 
                 if (compareVal != 0)


### PR DESCRIPTION
There was a bug if columns came in the wrong order when comparing against existing data. This was only an issue for data sources that fetches existing data on stream startup.