### PR TITLE
Fix delta lake sql provider to ignore 404 responses

### DIFF
--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/DeltaLakeSqlProvider.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/DeltaLakeSqlProvider.cs
@@ -92,7 +92,7 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal
             }
             catch (HttpRequestException ex)
             {
-                /// 404 is ok to ignore
+                // 404 is ok to ignore
                 if (ex.StatusCode != System.Net.HttpStatusCode.NotFound)
                 {
                     throw;


### PR DESCRIPTION
These can be ignored since the table is not handled then by this connector