### PR TITLE
Add support for vertices in the stream to call FailAndRollback

### DIFF
--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletedStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletedStreamState.cs
@@ -40,10 +40,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         {
         }
 
-        public override void Initialize(StreamStateValue previousState)
+        public override Task Initialize(StreamStateValue previousState)
         {
             Debug.Assert(_context != null, nameof(_context));
             _context.SetStatus(StreamStatus.Deleted);
+            return Task.CompletedTask;
         }
 
         public override Task OnFailure()

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletingStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/DeletingStreamState.cs
@@ -39,7 +39,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             // Ignore
         }
 
-        public override void Initialize(StreamStateValue previousState)
+        public override Task Initialize(StreamStateValue previousState)
         {
             Debug.Assert(_context != null, nameof(_context));
             _context.CheckForPause();
@@ -48,7 +48,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 _context.SetStatus(StreamStatus.Deleting);
                 if (_deleteTask != null && !_deleteTask.IsCompleted)
                 {
-                    return;
+                    return Task.CompletedTask;
                 }
                 _deleteTask = Task.Factory.StartNew(async () =>
                 {
@@ -62,11 +62,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                         // Wait a while before trying to delete again
                         await Task.Delay(TimeSpan.FromMilliseconds(500));
 
-                        Initialize(StreamStateValue.Deleting);
+                        await Initialize(StreamStateValue.Deleting);
                     }
                 });
             }
-
+            return Task.CompletedTask;
         }
 
         private async Task DeleteEntireStream()

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/FailureStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/FailureStreamState.cs
@@ -11,6 +11,8 @@
 // limitations under the License.
 
 using FlowtideDotNet.Base.Exceptions;
+using FlowtideDotNet.Base.Utils;
+using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 
 namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
@@ -43,8 +45,9 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 // and have recieved correct restore checkpoint version before going to starting.
                 await StopAndDispose();
             }
-            catch(Exception)
+            catch(Exception e)
             {
+                _context._logger.FailedStopAndDispose(e, _context.streamName);
                 _isFailing = false;
                 await Initialize(previousState);
                 return;

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/FailureStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/FailureStreamState.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base.Exceptions;
 using System.Diagnostics;
 
 namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
@@ -100,7 +101,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
             _context.ForEachBlock((key, block) =>
             {
-                block.Fault(new Exception($"Faulting block due to stream failure."));
+                block.Fault(new BlockStopException($"Faulting block due to stream failure."));
             });
 
             await Task.WhenAll(_context.GetCompletionTasks()).ContinueWith(t => { });

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/NotStartedStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/NotStartedStreamState.cs
@@ -49,10 +49,11 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
 
         }
 
-        public override void Initialize(StreamStateValue previousState)
+        public override Task Initialize(StreamStateValue previousState)
         {
             Debug.Assert(_context != null, nameof(_context));
             _context.SetStatus(StreamStatus.Stopped);
+            return Task.CompletedTask;
         }
 
         public override Task OnFailure()

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/RunningStreamState.cs
@@ -21,7 +21,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         private Task? _initialBatchTask;
         private readonly object _lock = new object();
         private HashSet<string>? nonCheckpointedEgresses;
-        private HashSet<string>? waitingForDependenciesEgresses;
+        private HashSet<string>? waitingForDependencies;
         private Checkpoint? _currentCheckpoint;
         private bool _doingCheckpoint = false;
         private bool _initialCheckpointTaken = false;
@@ -47,13 +47,13 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         public override void EgressDependenciesDone(string name)
         {
             Debug.Assert(_context != null, nameof(_context));
-            Debug.Assert(waitingForDependenciesEgresses != null, nameof(waitingForDependenciesEgresses));
+            Debug.Assert(waitingForDependencies != null, nameof(waitingForDependencies));
             lock (_context._checkpointLock)
             {
-                waitingForDependenciesEgresses.Remove(name);
+                waitingForDependencies.Remove(name);
 
                 // Check if all egresses has done their dependencies
-                if (waitingForDependenciesEgresses.Count > 0 || !_initialCheckpointTaken || _compactionStarted)
+                if (waitingForDependencies.Count > 0 || !_initialCheckpointTaken || _compactionStarted)
                 {
                     return;
                 }
@@ -92,7 +92,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 var run = (RunningStreamState)state!;
                 Debug.Assert(run._context != null, nameof(_context));
                 Debug.Assert(run._currentCheckpoint != null, nameof(_context));
-                Debug.Assert(run.waitingForDependenciesEgresses != null);
+                Debug.Assert(run.waitingForDependencies != null);
 
                 // Write the latest state
                 run._context._lastState = new StreamState(
@@ -131,7 +131,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                  .ContinueWith(async (t, state) =>
                  {
                      RunningStreamState @this = (RunningStreamState)state!;
-                     Debug.Assert(@this.waitingForDependenciesEgresses != null);
+                     Debug.Assert(@this.waitingForDependencies != null);
                      if (t.IsFaulted)
                      {
                          await _context.OnFailure(t.Exception);
@@ -143,7 +143,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                          _initialCheckpointTaken = true;
                          // Check if all egresses has done their dependencies
                          // if not return
-                         if (@this.waitingForDependenciesEgresses.Count > 0 || _compactionStarted)
+                         if (@this.waitingForDependencies.Count > 0 || _compactionStarted)
                          {
                              return;
                          }
@@ -333,12 +333,17 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 _initialCheckpointTaken = false;
                 _compactionStarted = false;
                 nonCheckpointedEgresses = new HashSet<string>();
-                waitingForDependenciesEgresses = new HashSet<string>();
+                waitingForDependencies = new HashSet<string>();
                 foreach (var key in _context.egressBlocks.Keys)
                 {
                     nonCheckpointedEgresses.Add(key);
-                    waitingForDependenciesEgresses.Add(key);
+                    waitingForDependencies.Add(key);
                 }
+                foreach(var key in _context.ingressBlocks.Keys)
+                {
+                    waitingForDependencies.Add(key);
+                }
+
                 _context.checkpointTask = new TaskCompletionSource();
                 var newTime = _context.producingTime + 1;
                 checkpoint = new Checkpoint(_context.producingTime, newTime);

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
@@ -175,7 +175,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             }
 
             // Initialize state
-            await _context._stateManager.InitializeAsync(_context._streamVersionInformation);
+            await _context._stateManager.InitializeAsync(_context._streamVersionInformation, restoreVersion);
             _context._lastState = _context._stateManager.Metadata;
             _context._startCheckpointVersion = _context._stateManager.CurrentVersion;
             if (_context._lastState == null)

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StoppingStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StoppingStreamState.cs
@@ -169,13 +169,14 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             }
         }
 
-        public override void Initialize(StreamStateValue previousState)
+        public override Task Initialize(StreamStateValue previousState)
         {
             Debug.Assert(_context != null);
             _context.CheckForPause();
             _context.SetStatus(StreamStatus.Stopping);
             _context._logger.StoppingStream(_context.streamName);
             _context.TryScheduleCheckpointIn(TimeSpan.FromMilliseconds(1));
+            return Task.CompletedTask;
         }
 
         public override async Task OnFailure()

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -816,7 +816,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                         _restoreCheckpointVersion = restoreVersion.Value;
                     }
                 }
-                else if (!_restoreCheckpointVersion.HasValue || _restoreCheckpointVersion > _stateManager.LastCompletedCheckpointVersion)
+                else if (!_restoreCheckpointVersion.HasValue || _restoreCheckpointVersion.Value > _stateManager.LastCompletedCheckpointVersion)
                 {
                     _restoreCheckpointVersion = _stateManager.LastCompletedCheckpointVersion;
                 }

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -606,6 +606,14 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                 activity.Stop();
                 activity.Dispose();
             }
+
+            lock (_checkpointLock)
+            {
+                if (!_restoreCheckpointVersion.HasValue || _restoreCheckpointVersion.Value > _stateManager.LastCompletedCheckpointVersion)
+                {
+                    _restoreCheckpointVersion = _stateManager.LastCompletedCheckpointVersion;
+                }
+            }
             
             _logger.StreamError(e, streamName);
             lock (_contextLock)
@@ -783,6 +791,10 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
                     {
                         _restoreCheckpointVersion = restoreVersion.Value;
                     }
+                }
+                else if (_restoreCheckpointVersion == null || _restoreCheckpointVersion > _stateManager.LastCompletedCheckpointVersion)
+                {
+                    _restoreCheckpointVersion = _stateManager.LastCompletedCheckpointVersion;
                 }
             }
             

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamStateMachineState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamStateMachineState.cs
@@ -23,7 +23,7 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
             _context = context;
         }
 
-        public abstract void Initialize(StreamStateValue previousState);
+        public abstract Task Initialize(StreamStateValue previousState);
 
         public abstract Task OnFailure();
 

--- a/src/FlowtideDotNet.Base/Engine/Internal/VertexHandler.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/VertexHandler.cs
@@ -22,7 +22,7 @@ namespace FlowtideDotNet.Base.Engine.Internal
         private readonly string operatorName;
         private readonly Action<TimeSpan> checkpointFunc;
         private readonly Func<string, string, TimeSpan?, Task> registerTrigger;
-        private readonly Func<Exception, long?, Task> failRollbackFunc;
+        private readonly Func<Exception?, long?, Task> failRollbackFunc;
 
         public VertexHandler(
             string streamName,
@@ -33,7 +33,7 @@ namespace FlowtideDotNet.Base.Engine.Internal
             IStateManagerClient stateClient,
             ILoggerFactory loggerFactory,
             IOperatorMemoryManager memoryManager,
-            Func<Exception, long?, Task> failRollbackFunc)
+            Func<Exception?, long?, Task> failRollbackFunc)
         {
             StreamName = streamName;
             this.operatorName = operatorName;
@@ -58,7 +58,7 @@ namespace FlowtideDotNet.Base.Engine.Internal
 
         public string OperatorId => operatorName;
 
-        public Task FailAndRollback(Exception exception, long? restoreVersion = null)
+        public Task FailAndRollback(Exception? exception, long? restoreVersion = null)
         {
             return failRollbackFunc(exception, restoreVersion);
         }

--- a/src/FlowtideDotNet.Base/Exceptions/BlockStopException.cs
+++ b/src/FlowtideDotNet.Base/Exceptions/BlockStopException.cs
@@ -10,16 +10,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace FlowtideDotNet.Base.Vertices.Ingress
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Base.Exceptions
 {
-    public interface IStreamIngressVertex : IStreamVertex
+    internal class BlockStopException : Exception
     {
-        Task InitializationCompleted();
+        public BlockStopException()
+        {
+        }
 
-        internal void DoLockingEvent(ILockingEvent lockingEvent);
+        public BlockStopException(string? message) : base(message)
+        {
+        }
 
-        Task CheckpointDone(long checkpointVersion);
-
-        internal void SetDependenciesDoneFunction(Action<string> dependenciesDone);
+        public BlockStopException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/IVertexHandler.cs
+++ b/src/FlowtideDotNet.Base/IVertexHandler.cs
@@ -44,5 +44,7 @@ namespace FlowtideDotNet.Base
         /// <param name="name"></param>
         /// <param name="schedule"></param>
         Task RegisterTrigger(string name, TimeSpan? scheduledInterval = null);
+
+        Task FailAndRollback(Exception? exception, long? restoreVersion = default);
     }
 }

--- a/src/FlowtideDotNet.Base/Utils/Log.cs
+++ b/src/FlowtideDotNet.Base/Utils/Log.cs
@@ -189,5 +189,11 @@ namespace FlowtideDotNet.Base.Utils
            Level = LogLevel.Information,
            Message = "Shutdown checkpoint done in stream `{stream}`.")]
         public static partial void ShutdownCheckpointDone(this ILogger logger, string stream);
+
+        [LoggerMessage(
+          EventId = 30,
+          Level = LogLevel.Error,
+          Message = "Failed to stop and dispose stream during failure state initialization., stream: `{stream}`")]
+        public static partial void FailedStopAndDispose(this ILogger logger, Exception? e, string stream);
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/Egress/EgressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Egress/EgressVertex.cs
@@ -14,7 +14,6 @@ using DataflowStream.dataflow.Internal.Extensions;
 using FlowtideDotNet.Base.Metrics;
 using FlowtideDotNet.Base.Utils;
 using FlowtideDotNet.Base.Vertices.Egress.Internal;
-using FlowtideDotNet.Base.Vertices.Ingress;
 using FlowtideDotNet.Storage;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.StateManager;

--- a/src/FlowtideDotNet.Base/Vertices/Egress/EgressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Egress/EgressVertex.cs
@@ -321,5 +321,10 @@ namespace FlowtideDotNet.Base.Vertices.Egress
             }
             return _vertexHandler.FailAndRollback(exception, restoreVersion);
         }
+
+        public Task OnFailure(long rollbackVersion)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointSource.cs
+++ b/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointSource.cs
@@ -160,5 +160,10 @@ namespace FlowtideDotNet.Base.Vertices.FixedPoint
         {
             return Task.CompletedTask;
         }
+
+        public virtual Task OnFailure(long rollbackVersion)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/FixedPoint/FixedPointVertex.cs
@@ -536,5 +536,10 @@ namespace FlowtideDotNet.Base.Vertices.FixedPoint
         {
             return Task.CompletedTask;
         }
+
+        public virtual Task OnFailure(long rollbackVersion)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/IStreamVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/IStreamVertex.cs
@@ -61,5 +61,7 @@ namespace FlowtideDotNet.Base.Vertices
         /// </summary>
         /// <returns></returns>
         Task BeforeSaveCheckpoint();
+
+        Task OnFailure(long rollbackVersion);
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
@@ -506,5 +506,16 @@ namespace FlowtideDotNet.Base.Vertices.Ingress
         {
             return Task.CompletedTask;
         }
+
+        protected Task FailAndRollback(Exception? exception = null, long? restoreVersion = null)
+        {
+            Debug.Assert(_ingressState?._vertexHandler != null, nameof(_ingressState._vertexHandler));
+
+            if (_ingressState._vertexHandler == null)
+            {
+                throw new NotSupportedException("Cannot fail and rollback before initialize is called");
+            }
+            return _ingressState._vertexHandler.FailAndRollback(exception, restoreVersion);
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Ingress/IngressVertex.cs
@@ -542,5 +542,10 @@ namespace FlowtideDotNet.Base.Vertices.Ingress
         {
             _dependenciesDone = dependenciesDone;
         }
+
+        public virtual Task OnFailure(long rollbackVersion)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
@@ -810,5 +810,10 @@ namespace FlowtideDotNet.Base.Vertices.MultipleInput
         {
             return Task.CompletedTask;
         }
+
+        public virtual Task OnFailure(long rollbackVersion)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/PartitionVertices/PartitionVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/PartitionVertices/PartitionVertex.cs
@@ -395,5 +395,16 @@ namespace FlowtideDotNet.Base.Vertices.PartitionVertices
         {
             return Task.CompletedTask;
         }
+
+        protected Task FailAndRollback(Exception? exception = null, long? restoreVersion = null)
+        {
+            Debug.Assert(_vertexHandler != null, nameof(_vertexHandler));
+
+            if (_vertexHandler == null)
+            {
+                throw new NotSupportedException("Cannot fail and rollback before initialize is called");
+            }
+            return _vertexHandler.FailAndRollback(exception, restoreVersion);
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/PartitionVertices/PartitionVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/PartitionVertices/PartitionVertex.cs
@@ -406,5 +406,10 @@ namespace FlowtideDotNet.Base.Vertices.PartitionVertices
             }
             return _vertexHandler.FailAndRollback(exception, restoreVersion);
         }
+
+        public virtual Task OnFailure(long rollbackVersion)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Base/Vertices/Unary/UnaryVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Unary/UnaryVertex.cs
@@ -474,5 +474,10 @@ namespace FlowtideDotNet.Base.Vertices.Unary
         {
             return Task.CompletedTask;
         }
+
+        public virtual Task OnFailure(long rollbackVersion)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentStorage.cs
+++ b/src/FlowtideDotNet.Storage/Persistence/CacheStorage/FileCachePersistentStorage.cs
@@ -23,6 +23,8 @@ namespace FlowtideDotNet.Storage.Persistence.CacheStorage
 
         public FileCachePersistentStorage(FileCacheOptions fileCacheOptions, bool ignoreDispose = false)
         {
+            // Start at version 1, since version 0 is reserved for empty state
+            _version = 1;
             m_fileCache = new FlowtideDotNet.Storage.FileCache.FileCache(fileCacheOptions, "persitent", GlobalMemoryManager.Instance);
             this._ignoreDispose = ignoreDispose;
         }

--- a/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/StateManagerSync.cs
@@ -405,7 +405,9 @@ namespace FlowtideDotNet.Storage.StateManager
             m_lruTable.Clear();
             await m_persistentStorage.InitializeAsync(new StorageInitializationMetadata(streamName, streamVersionInformation)).ConfigureAwait(false);
 
-            if (m_persistentStorage.TryGetValue(1, out var metadataBytes))
+            // Check that metadata exist, also that the checkpoint version is larger than 0
+            // If zero we revert back to an empty state
+            if (m_persistentStorage.TryGetValue(1, out var metadataBytes) && (!checkpointVersion.HasValue || (checkpointVersion.HasValue && checkpointVersion.Value > 0)))
             {
                 lock (m_lock)
                 {

--- a/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/FlowtideAcceptanceBase.cs
@@ -108,6 +108,21 @@ namespace FlowtideDotNet.AcceptanceTests
             return flowtideTestStream.Crash();
         }
 
+        protected Task StopMockIngressAutocompleteDependencies()
+        {
+            return flowtideTestStream.StopMockIngressAutocompleteDependencies();
+        }
+
+        protected Task MockIngressFailAndRollback(long restoreVersion)
+        {
+            return flowtideTestStream.MockIngressFailAndRollback(restoreVersion);
+        }
+
+        protected Task MockIngressSetDependenciesDone()
+        {
+            return flowtideTestStream.MockIngressSetDependenciesDone();
+        }
+
         protected void EgressCrashOnCheckpoint(int times)
         {
             flowtideTestStream.EgressCrashOnCheckpoint(times);
@@ -143,12 +158,18 @@ namespace FlowtideDotNet.AcceptanceTests
             flowtideTestStream.DeleteOrder(order);
         }
 
-        public FlowtideAcceptanceBase(ITestOutputHelper testOutputHelper)
+        public FlowtideAcceptanceBase(ITestOutputHelper testOutputHelper, bool usePersistentStorage = false)
         {
             var baseType = this.GetType();
             var testName = GetTestClassName(testOutputHelper);
-            flowtideTestStream = new FlowtideTestStream($"{baseType.Name}/{testName}");
-            //flowtideTestStream.CachePageCount = 10;
+            if (usePersistentStorage)
+            {
+                flowtideTestStream = new PersistentFlowtideTestStream($"{baseType.Name}/{testName}");
+            }
+            else
+            {
+                flowtideTestStream = new FlowtideTestStream($"{baseType.Name}/{testName}");
+            }
         }
 
         private static string GetTestClassName(ITestOutputHelper output)

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/FlowtideTestStream.cs
@@ -331,6 +331,21 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             }
         }
 
+        public async Task StopMockIngressAutocompleteDependencies()
+        {
+            await _stream!.CallTrigger("ingress_no_autocomplete_dependencies", default);
+        }
+
+        public async Task MockIngressFailAndRollback(long restoreVersion)
+        {
+            await _stream!.CallTrigger("ingress_fail_and_rollback", restoreVersion);
+        }
+
+        public async Task MockIngressSetDependenciesDone()
+        {
+            await _stream!.CallTrigger("ingress_dependencies_done", default);
+        }
+
         public async Task HealthyFor(TimeSpan time)
         {
             Debug.Assert(_stream != null);

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/PersistentFlowtideTestStream.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/PersistentFlowtideTestStream.cs
@@ -1,0 +1,41 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Persistence;
+using FlowtideDotNet.Storage.Persistence.FasterStorage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.AcceptanceTests.Internal
+{
+    internal class PersistentFlowtideTestStream : FlowtideTestStream
+    {
+        public PersistentFlowtideTestStream(string testName) : base(testName)
+        {
+        }
+
+        protected override IPersistentStorage CreatePersistentStorage(string testName, bool ignoreSameDataCheck)
+        {
+            if (Directory.Exists($"./data/tempFiles/faster/{testName}/persist"))
+            {
+                Directory.Delete($"./data/tempFiles/faster/{testName}/persist", true);
+            }
+            return new FasterKvPersistentStorage(new FASTER.core.FasterKVSettings<long, FASTER.core.SpanByte>($"./data/tempFiles/faster/{testName}/persist")
+            {
+                RemoveOutdatedCheckpoints = false
+            });
+        }
+    }
+}

--- a/tests/FlowtideDotNet.AcceptanceTests/RollbackTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/RollbackTests.cs
@@ -1,0 +1,100 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace FlowtideDotNet.AcceptanceTests
+{
+    public class RollbackTests : FlowtideAcceptanceBase
+    {
+        public RollbackTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper, true)
+        {
+        }
+
+        /// <summary>
+        /// This test will not be able to complete the last wait for update if rolling back does not work.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task RollbackTwoVersionsFromIngress()
+        {
+            GenerateData(10);
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT userkey FROM users
+            ");
+
+            // Do a normal checkpoint first
+            await WaitForUpdate();
+
+            // Stop dependencies auto complete to not allow any compaction of checkpoints
+            // to happen after checkpoint
+            await StopMockIngressAutocompleteDependencies();
+
+            GenerateUsers(10);
+
+            await WaitForUpdate();
+
+            // Rollback to the version before these ten events have been read.
+            await MockIngressFailAndRollback(1);
+
+            // This will not complete if rolling back two versions do not work
+            await WaitForUpdate();
+
+            // Set dependencies done to allow checkpoints to continue
+            await MockIngressSetDependenciesDone();
+
+            GenerateUsers(10);
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(Users.Select(x => new { x.UserKey }));
+        }
+
+        /// <summary>
+        /// This test makes sure that it is possible to return back to an empty state
+        /// if the stream fails before the first checkpoint
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task RollbackToEmptyVersion()
+        {
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT userkey FROM users
+            ");
+
+            // Stop dependencies auto complete to not allow any compaction of checkpoints
+            // to happen after checkpoint
+            await StopMockIngressAutocompleteDependencies();
+
+            GenerateData(10);
+
+            // Do a normal checkpoint first
+            await WaitForUpdate();
+
+            await MockIngressFailAndRollback(0);
+
+            // This will not complete if it was not possible to rollback
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(Users.Select(x => new { x.UserKey }));
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Core.Tests/OperatorTestBase.cs
+++ b/tests/FlowtideDotNet.Core.Tests/OperatorTestBase.cs
@@ -60,7 +60,7 @@ namespace FlowtideDotNet.Core.Tests
                 metrics.GetOrCreateVertexMeter("1", () => ""), 
                 _stateManager.GetOrCreateClient("1"), 
                 new LoggerFactory(), 
-                new OperatorMemoryManager("sream", "op", new Meter("stream")),
+                new OperatorMemoryManager("stream", "op", new Meter("stream")),
                 (exception, version) => Task.CompletedTask);
             await @operator.Initialize("1", 0, 0, vertexHandler, null);
         }

--- a/tests/FlowtideDotNet.Core.Tests/OperatorTestBase.cs
+++ b/tests/FlowtideDotNet.Core.Tests/OperatorTestBase.cs
@@ -52,7 +52,16 @@ namespace FlowtideDotNet.Core.Tests
             var statemanagermeter = new Meter("statemanager");
             _stateManager = new StateManagerSync<StreamState>(new StateManagerOptions(), new DebugLoggerProvider().CreateLogger("state"), statemanagermeter, "stream");
             await _stateManager.InitializeAsync();
-            var vertexHandler = new VertexHandler("stream", "1", (time) => { }, (p1, p2, t) => Task.CompletedTask, metrics.GetOrCreateVertexMeter("1", () => ""), _stateManager.GetOrCreateClient("1"), new LoggerFactory(), new OperatorMemoryManager("sream", "op", new Meter("stream")));
+            var vertexHandler = new VertexHandler(
+                "stream", 
+                "1", 
+                (time) => { }, 
+                (p1, p2, t) => Task.CompletedTask, 
+                metrics.GetOrCreateVertexMeter("1", () => ""), 
+                _stateManager.GetOrCreateClient("1"), 
+                new LoggerFactory(), 
+                new OperatorMemoryManager("sream", "op", new Meter("stream")),
+                (exception, version) => Task.CompletedTask);
             await @operator.Initialize("1", 0, 0, vertexHandler, null);
         }
 

--- a/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/Acceptance/SqlServerSmokeTests.cs
@@ -223,7 +223,13 @@ namespace FlowtideDotNet.SqlServer.Tests.Acceptance
             }, (v1, v2, time) =>
             {
                 return Task.CompletedTask;
-            }, nodeMetrics, stateClient, new NullLoggerFactory(), memoryManager);
+            }, 
+            nodeMetrics, 
+            stateClient, 
+            new NullLoggerFactory(), 
+            memoryManager,
+            (exception, version) => Task.CompletedTask);
+
             var sink = new ColumnSqlServerSink(new Connector.SqlServer.SqlServerSinkOptions() { ConnectionStringFunc = () => sqlServerFixture.ConnectionString }, writeRel, new System.Threading.Tasks.Dataflow.ExecutionDataflowBlockOptions());
 
             sink.Setup("mergejoinstream", "op");

--- a/tests/FlowtideDotNet.Storage.Tests/CheckpointTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/CheckpointTests.cs
@@ -217,7 +217,7 @@ namespace FlowtideDotNet.Storage.Tests
                     PersistentStorage = new FasterKvPersistentStorage(new FasterKVSettings<long, SpanByte>()
                     {
                         LogDevice = device,
-                        CheckpointDir = "./data/tmp/persistent",
+                        CheckpointDir = "./data/tmp/persistentrestoretwo",
                         RemoveOutdatedCheckpoints = false
                     })
                 }, NullLogger.Instance, new Meter($"storage"), "storage");


### PR DESCRIPTION
This feature is added for distributed execution, where one vertex can force the stream to do a rollback operation.

This is useful if an exchange operator for instance talks with a substream, if the substream fails, it can notify the exchange operator which version should be used to recover to.

This makes sure both substreams start from the same version.

This PR also makes sure that all operators get a new event called OnFailure which can be used to communicate to other dependent substreams to fail as well.