### PR TITLE
Fix so its possible to recurse at stop types with zanzibar denormalization

### DIFF
--- a/src/FlowtideDotNet.Connector.OpenFGA/OpenFgaToFlowtide.cs
+++ b/src/FlowtideDotNet.Connector.OpenFGA/OpenFgaToFlowtide.cs
@@ -37,7 +37,7 @@ namespace FlowtideDotNet.Connector.OpenFGA
             };
 
             var convertedSchema = OpenFgaToZanzibarSchema.Convert(authorizationModel);
-            var zanzibarRelations = ZanzibarSchemaToQueryPlan.GenerateQueryPlan(convertedSchema, type, relation, stopTypes.ToHashSet());
+            var zanzibarRelations = ZanzibarSchemaToQueryPlan.GenerateQueryPlan(convertedSchema, type, relation, false, stopTypes.ToHashSet());
 
             var visitor = new ZanzibarToFlowtideVisitor(
                 inputTypeName,

--- a/src/FlowtideDotNet.Connector.SpiceDB/SpiceDbToFlowtide.cs
+++ b/src/FlowtideDotNet.Connector.SpiceDB/SpiceDbToFlowtide.cs
@@ -19,7 +19,7 @@ namespace FlowtideDotNet.Connector.SpiceDB
 {
     public static class SpiceDbToFlowtide
     {
-        public static Plan Convert(string schemaText, string type, string relation, string inputTypeName, params string[]? stopAtTypes)
+        public static Plan Convert(string schemaText, string type, string relation, string inputTypeName, bool recurseAtStopType = false, params string[]? stopAtTypes)
         {
             HashSet<string> stopTypes = new HashSet<string>();
             if (stopAtTypes != null)
@@ -31,7 +31,7 @@ namespace FlowtideDotNet.Connector.SpiceDB
             }
 
             var schema = SpiceDbParser.ParseSchema(schemaText);
-            var zanzibarRelations = ZanzibarSchemaToQueryPlan.GenerateQueryPlan(schema, type, relation, stopTypes);
+            var zanzibarRelations = ZanzibarSchemaToQueryPlan.GenerateQueryPlan(schema, type, relation, recurseAtStopType, stopTypes);
 
             var visitor = new ZanzibarToFlowtideVisitor(
                 inputTypeName,

--- a/src/FlowtideDotNet.Zanzibar/QueryPlanner/Models/ZanzibarCopyResourceToSubjectDistinct.cs
+++ b/src/FlowtideDotNet.Zanzibar/QueryPlanner/Models/ZanzibarCopyResourceToSubjectDistinct.cs
@@ -12,17 +12,13 @@
 
 namespace FlowtideDotNet.Zanzibar.QueryPlanner.Models
 {
-    public class ZanzibarReadLoop : ZanzibarRelation
+    public class ZanzibarCopyResourceToSubjectDistinct : ZanzibarRelation
     {
-        public required string Type { get; set; }
-
-        public required string Relation { get; set; }
-
-        public string LoopId => $"{Type}_{Relation}";
+        public required ZanzibarRelation Input { get; set; }
 
         public override T Accept<T, TState>(ZanzibarVisitor<T, TState> visitor, TState state)
         {
-            return visitor.VisitZanzibarReadLoop(this, state);
+            return visitor.VisitZanzibarCopyResourceToSubjectDistinct(this, state);
         }
     }
 }

--- a/src/FlowtideDotNet.Zanzibar/QueryPlanner/Models/ZanzibarVisitor.cs
+++ b/src/FlowtideDotNet.Zanzibar/QueryPlanner/Models/ZanzibarVisitor.cs
@@ -74,5 +74,10 @@ namespace FlowtideDotNet.Zanzibar.QueryPlanner.Models
         {
             throw new NotImplementedException();
         }
+
+        public virtual T VisitZanzibarCopyResourceToSubjectDistinct(ZanzibarCopyResourceToSubjectDistinct copyResourceToSubject, TState state)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Zanzibar/QueryPlanner/ZanzibarSchemaToQueryPlan.cs
+++ b/src/FlowtideDotNet.Zanzibar/QueryPlanner/ZanzibarSchemaToQueryPlan.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Zanzibar.QueryPlanner
 {
     public static class ZanzibarSchemaToQueryPlan
     {
-        public static List<ZanzibarRelation> GenerateQueryPlan(ZanzibarSchema schema, string type, string relation, HashSet<string> stopTypes)
+        public static List<ZanzibarRelation> GenerateQueryPlan(ZanzibarSchema schema, string type, string relation, bool recurseAtStopType, HashSet<string> stopTypes)
         {
             if (!schema.Types.ContainsKey(type))
             {
@@ -32,7 +32,9 @@ namespace FlowtideDotNet.Zanzibar.QueryPlanner
                     }
                 }
             }
-            return new ZanzibarFlowtideConvertVisitor(schema, stopTypes).Parse(type, relation);
+            var result = new ZanzibarFlowtideConvertVisitor(schema, stopTypes, recurseAtStopType, false, default).Parse(type, relation);
+
+            return result;
         }
     }
 }

--- a/src/FlowtideDotNet.Zanzibar/QueryPlanner/ZanzibarToFlowtideVisitor.cs
+++ b/src/FlowtideDotNet.Zanzibar/QueryPlanner/ZanzibarToFlowtideVisitor.cs
@@ -740,5 +740,31 @@ namespace FlowtideDotNet.Zanzibar.QueryPlanner
                 RelationId = relationReference.ReferenceId
             };
         }
+
+        public override Relation VisitZanzibarCopyResourceToSubjectDistinct(ZanzibarCopyResourceToSubjectDistinct copyResourceToSubject, object? state)
+        {
+            var input = copyResourceToSubject.Input.Accept(this, state);
+
+            var projectRel = new ProjectRelation()
+            {
+                Input = input,
+                Emit = new List<int>()
+                {
+                    ObjectTypeColumn,
+                    ObjectIdColumn,
+                    UserRelationColumn,
+                    RelationColumn,
+                    ObjectTypeColumn,
+                    ObjectIdColumn
+                },
+                Expressions = new List<Expression>()
+            };
+
+            return new SetRelation()
+            {
+                Inputs = [projectRel],
+                Operation = SetOperation.UnionDistinct
+            };
+        }
     }
 }

--- a/tests/FlowtideDotNet.Connector.SpiceDB.Tests/SpiceDbTests.cs
+++ b/tests/FlowtideDotNet.Connector.SpiceDB.Tests/SpiceDbTests.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using Authzed.Api.V1;
+using FlowtideDotNet.AcceptanceTests.Entities;
 using Grpc.Core;
 using System.Diagnostics;
 
@@ -484,6 +485,28 @@ namespace FlowtideDotNet.Connector.SpiceDB.Tests
                     }
                 }
             });
+
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "project",
+                        ObjectId = "123"
+                    },
+                    Relation = "organization",
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "organization",
+                            ObjectId = "1"
+                        }
+                    }
+                }
+            });
             await permissionClient.WriteRelationshipsAsync(writeRequest, metadata);
             var viewPermissionPlan = SpiceDbToFlowtide.Convert(schemaText, "organization", "can_view", "spicedb");
 
@@ -532,6 +555,374 @@ namespace FlowtideDotNet.Connector.SpiceDB.Tests
             await stream.WaitForUpdate();
             var actual2 = stream.GetActualRowsAsVectors();
             Assert.Single(actual2);
+        }
+
+        [Fact]
+        public async Task TestReadPermissionsStopTypeRecurse()
+        {
+            var schemaText = File.ReadAllText("recursiveschema.txt");
+            SchemaService.SchemaServiceClient schemaServiceClient = new SchemaService.SchemaServiceClient(spiceDbFixture.GetChannel());
+
+            var metadata = new Metadata
+            {
+                { "Authorization", $"Bearer {nameof(TestReadPermissionsStopTypeRecurse)}" }
+            };
+            await schemaServiceClient.WriteSchemaAsync(new WriteSchemaRequest()
+            {
+                Schema = schemaText
+            }, metadata);
+            var permissionClient = new PermissionsService.PermissionsServiceClient(spiceDbFixture.GetChannel());
+
+            var writeRequest = new WriteRelationshipsRequest();
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "user",
+                            ObjectId = "*"
+                        }
+                    },
+                    Relation = "can_view",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "role",
+                        ObjectId = "1"
+                    }
+                }
+            });
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "user",
+                            ObjectId = "user1"
+                        }
+                    },
+                    Relation = "user",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "role_binding",
+                        ObjectId = "1_1"
+                    }
+                }
+            });
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "role",
+                            ObjectId = "1"
+                        }
+                    },
+                    Relation = "role",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "role_binding",
+                        ObjectId = "1_1"
+                    }
+                }
+            });
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "role_binding",
+                            ObjectId = "1_1"
+                        }
+                    },
+                    Relation = "role_binding",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "organization",
+                        ObjectId = "2"
+                    }
+                }
+            });
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "organization",
+                            ObjectId = "2"
+                        }
+                    },
+                    Relation = "parent",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "organization",
+                        ObjectId = "1"
+                    }
+                }
+            });
+
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "project",
+                        ObjectId = "123"
+                    },
+                    Relation = "organization",
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "organization",
+                            ObjectId = "1"
+                        }
+                    }
+                }
+            });
+            await permissionClient.WriteRelationshipsAsync(writeRequest, metadata);
+            var viewPermissionPlan = SpiceDbToFlowtide.Convert(schemaText, "project", "can_view", "spicedb", true, "organization");
+
+            var stream = new SpiceDbTestStream(nameof(TestReadPermissionsStopTypeRecurse), spiceDbFixture.GetChannel(), false, true);
+            stream.SqlPlanBuilder.AddPlanAsView("authdata", viewPermissionPlan);
+
+            await stream.StartStream(@"
+                INSERT INTO testverify
+                SELECT 
+                    subject_type,
+                    subject_id,
+                    relation,
+                    resource_type,
+                    resource_id
+                FROM authdata
+            ");
+
+            await stream.WaitForUpdate();
+
+            stream.AssertCurrentDataEqual([
+                new { subjectType = "organization", subjectId = "2", relation = "can_view", resourceType = "project", resourceId = "123"}
+                ]);
+
+            // Remove the parent connection
+            writeRequest = new WriteRelationshipsRequest();
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Delete,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "organization",
+                            ObjectId = "2"
+                        }
+                    },
+                    Relation = "parent",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "organization",
+                        ObjectId = "1"
+                    }
+                }
+            });
+            await permissionClient.WriteRelationshipsAsync(writeRequest, metadata);
+            await stream.WaitForUpdate();
+            var actual2 = stream.GetActualRowsAsVectors();
+            Assert.Empty(actual2);
+        }
+
+        /// <summary>
+        /// This test makes sure that when using a starting type as stop type and it has a recursive permission
+        /// it does not resolve the recursive of the current type
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task TestReadPermissionsStopTypeSameAsStartType()
+        {
+            var schemaText = File.ReadAllText("recursiveschema.txt");
+            SchemaService.SchemaServiceClient schemaServiceClient = new SchemaService.SchemaServiceClient(spiceDbFixture.GetChannel());
+
+            var metadata = new Metadata
+            {
+                { "Authorization", $"Bearer {nameof(TestReadPermissionsStopTypeSameAsStartType)}" }
+            };
+            await schemaServiceClient.WriteSchemaAsync(new WriteSchemaRequest()
+            {
+                Schema = schemaText
+            }, metadata);
+            var permissionClient = new PermissionsService.PermissionsServiceClient(spiceDbFixture.GetChannel());
+
+            var writeRequest = new WriteRelationshipsRequest();
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "user",
+                            ObjectId = "*"
+                        }
+                    },
+                    Relation = "can_view",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "role",
+                        ObjectId = "1"
+                    }
+                }
+            });
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "user",
+                            ObjectId = "user1"
+                        }
+                    },
+                    Relation = "user",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "role_binding",
+                        ObjectId = "1_1"
+                    }
+                }
+            });
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "role",
+                            ObjectId = "1"
+                        }
+                    },
+                    Relation = "role",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "role_binding",
+                        ObjectId = "1_1"
+                    }
+                }
+            });
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "role_binding",
+                            ObjectId = "1_1"
+                        }
+                    },
+                    Relation = "role_binding",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "organization",
+                        ObjectId = "2"
+                    }
+                }
+            });
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "organization",
+                            ObjectId = "2"
+                        }
+                    },
+                    Relation = "parent",
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "organization",
+                        ObjectId = "1"
+                    }
+                }
+            });
+
+            writeRequest.Updates.Add(new RelationshipUpdate()
+            {
+                Operation = RelationshipUpdate.Types.Operation.Touch,
+                Relationship = new Relationship()
+                {
+                    Resource = new ObjectReference()
+                    {
+                        ObjectType = "project",
+                        ObjectId = "123"
+                    },
+                    Relation = "organization",
+                    Subject = new SubjectReference()
+                    {
+                        Object = new ObjectReference()
+                        {
+                            ObjectType = "organization",
+                            ObjectId = "1"
+                        }
+                    }
+                }
+            });
+            await permissionClient.WriteRelationshipsAsync(writeRequest, metadata);
+            var viewPermissionPlan = SpiceDbToFlowtide.Convert(schemaText, "organization", "can_view", "spicedb", false, "organization");
+
+            var stream = new SpiceDbTestStream(nameof(TestReadPermissionsStopTypeSameAsStartType), spiceDbFixture.GetChannel(), false, true);
+            stream.SqlPlanBuilder.AddPlanAsView("authdata", viewPermissionPlan);
+
+            await stream.StartStream(@"
+                INSERT INTO testverify
+                SELECT 
+                    subject_type,
+                    subject_id,
+                    relation,
+                    resource_type,
+                    resource_id
+                FROM authdata
+            ");
+
+            await stream.WaitForUpdate();
+            stream.AssertCurrentDataEqual([
+                new { subjectType = "user", subjectId = "user1", relation = "can_view", resourceType = "organization", resourceId = "2"}
+                ]);
         }
 
         [Fact]
@@ -660,7 +1051,7 @@ namespace FlowtideDotNet.Connector.SpiceDB.Tests
         public void NonExistingStopTypeThrowsError()
         {
             var schemaText = File.ReadAllText("schema.txt");
-            Assert.Throws<ArgumentException>(() => SpiceDbToFlowtide.Convert(schemaText, "document", "view", "spicedb", "nonexisting"));
+            Assert.Throws<ArgumentException>(() => SpiceDbToFlowtide.Convert(schemaText, "document", "view", "spicedb", false, "nonexisting"));
         }
 
         [Fact]

--- a/tests/FlowtideDotNet.Connector.SpiceDB.Tests/recursiveschema.txt
+++ b/tests/FlowtideDotNet.Connector.SpiceDB.Tests/recursiveschema.txt
@@ -17,3 +17,10 @@ definition organization {
 
   permission can_view = role_binding->can_view + parent->can_view
 }
+
+definition project {
+  relation role_binding: role_binding
+  relation organization: organization
+
+  permission can_view = role_binding->can_view + organization->can_view
+}


### PR DESCRIPTION
This change allows building a flat list of recursive objects when used as a stop type. It also includes a change so when a stoptype is the initial starting type, recursion is ignored to only get a users explicit access list of that type.