### PR TITLE
Delta lake: use delta write stream when writing delete vector

### DIFF
--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/DeletionVectors/DeletionVectorWriter.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/DeletionVectors/DeletionVectorWriter.cs
@@ -38,7 +38,7 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.DeletionVectors
                 throw new Exception("Failed to open stream");
             }
 
-            var writeStream = new DeltaWriteStream(stream);
+            using var writeStream = new DeltaWriteStream(stream);
 
             using MemoryStream memoryStream = new MemoryStream();
             using var writer = new BinaryWriter(memoryStream);
@@ -61,9 +61,6 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.DeletionVectors
             await writeStream.FlushAsync();
 
             int fileSize = (int)writeStream.Position;
-
-            writer.Close();
-            stream.Close();
 
             return fileSize;
         }

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/DeletionVectors/DeletionVectorWriter.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/Delta/DeletionVectors/DeletionVectorWriter.cs
@@ -38,6 +38,8 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.DeletionVectors
                 throw new Exception("Failed to open stream");
             }
 
+            var writeStream = new DeltaWriteStream(stream);
+
             using MemoryStream memoryStream = new MemoryStream();
             using var writer = new BinaryWriter(memoryStream);
 
@@ -46,19 +48,19 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal.Delta.DeletionVectors
             var bytes = new byte[4];
             BinaryPrimitives.WriteInt32BigEndian(bytes, (int)memoryStream.Position);
 
-            stream.WriteByte(1);
+            writeStream.WriteByte(1);
             // Write data size
-            stream.Write(bytes);
+            writeStream.Write(bytes);
 
             BinaryPrimitives.WriteInt32LittleEndian(bytes, 1681511377);
-            stream.Write(bytes);
+            writeStream.Write(bytes);
 
             memoryStream.Position = 0;
-            await memoryStream.CopyToAsync(stream);
+            await memoryStream.CopyToAsync(writeStream);
 
-            await stream.FlushAsync();
+            await writeStream.FlushAsync();
 
-            int fileSize = (int)stream.Position;
+            int fileSize = (int)writeStream.Position;
 
             writer.Close();
             stream.Close();

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/DeltaWriteStream.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/DeltaWriteStream.cs
@@ -82,6 +82,18 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal
             _position += buffer.Length;
         }
 
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await _inner.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            _position += count;
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await _inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            _position += buffer.Length;
+        }
+
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
             return _inner.FlushAsync(cancellationToken);

--- a/src/FlowtideDotNet.Connector.DeltaLake/Internal/DeltaWriteStream.cs
+++ b/src/FlowtideDotNet.Connector.DeltaLake/Internal/DeltaWriteStream.cs
@@ -69,5 +69,22 @@ namespace FlowtideDotNet.Connector.DeltaLake.Internal
             _inner.Write(buffer, offset, count);
             _position += count;
         }
+
+        public override void WriteByte(byte value)
+        {
+            _inner.WriteByte(value);
+            _position += 1;
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            _inner.Write(buffer);
+            _position += buffer.Length;
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return _inner.FlushAsync(cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
Some stowage file providers do not support getting stream position, this keeps track of number of bytes written.