### PR TITLE
Flatten columnwithoffset to reduce recursion

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -23,7 +23,7 @@ using System.Text.Json;
 
 namespace FlowtideDotNet.Core.ColumnStore
 {
-    internal class ColumnWithOffset : IColumn
+    internal sealed class ColumnWithOffset : IColumn
     {
         private readonly IColumn innerColumn;
         private readonly PrimitiveList<int> offsets;
@@ -109,17 +109,17 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public IDataValue GetValueAt(in int index, in ReferenceSegment? child)
         {
-            var offset = offsets[index];
+            var offset = offsets.Get(index);
             if (includeNullValueAtEnd && offset == innerColumn.Count)
             {
                 return NullValue.Instance;
             }
-            return innerColumn.GetValueAt(offset, child);
+            return innerColumn.GetValueAt(offset, child); 
         }
 
         public void GetValueAt(in int index, in DataValueContainer dataValueContainer, in ReferenceSegment? child)
         {
-            var offset = offsets[index];
+            var offset = offsets.Get(index);
             if (includeNullValueAtEnd && offset == innerColumn.Count)
             {
                 dataValueContainer._type = ArrowTypeId.Null;
@@ -228,6 +228,44 @@ namespace FlowtideDotNet.Core.ColumnStore
         void IColumn.WriteDataToBuffer(ref ArrowDataWriter dataWriter)
         {
             throw new NotSupportedException();
+        }
+
+        public static ColumnWithOffset CreateFlattened(
+            IColumn column, 
+            PrimitiveList<int> offsets, 
+            bool includeNullValueAtEnd, 
+            IMemoryAllocator memoryAllocator,
+            out bool usedOffset)
+        {
+            if (column is ColumnWithOffset columnWithOffset)
+            {
+                PrimitiveList<int> newOffsets = new PrimitiveList<int>(memoryAllocator);
+                var otherOffsets = columnWithOffset.offsets;
+                for (int i = 0; i < offsets.Count; i++)
+                {
+                    var offset = offsets.Get(i);
+                    if (includeNullValueAtEnd && offset == column.Count)
+                    {
+                        newOffsets.Add(columnWithOffset.innerColumn.Count);
+                    }
+                    else
+                    {
+                        var otherOffset = otherOffsets.Get(offset);
+                        if (columnWithOffset.includeNullValueAtEnd && otherOffset == columnWithOffset.innerColumn.Count)
+                        {
+                            newOffsets.Add(columnWithOffset.innerColumn.Count);
+                        }
+                        else
+                        {
+                            newOffsets.Add(otherOffset);
+                        }
+                    }
+                }
+                usedOffset = false;
+                return new ColumnWithOffset(columnWithOffset.innerColumn, newOffsets, includeNullValueAtEnd);
+            }
+            usedOffset = true;
+            return new ColumnWithOffset(column, offsets, includeNullValueAtEnd);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Exchange/StandardOutputTarget.cs
+++ b/src/FlowtideDotNet.Core/Operators/Exchange/StandardOutputTarget.cs
@@ -65,14 +65,24 @@ namespace FlowtideDotNet.Core.Operators.Exchange
             Debug.Assert(_currentBatch != null);
             Debug.Assert(_weights != null);
             Debug.Assert(_iterations != null);
+            Debug.Assert(_memoryAllocator != null);
 
             if (_weights.Count > 0)
             {
                 IColumn[] outputColumns = new IColumn[_columnCount];
 
+                bool shouldDisposeOffsets = true;
                 for (int i = 0; i < _columnCount; i++)
                 {
-                    outputColumns[i] = new ColumnWithOffset(_currentBatch.EventBatchData.Columns[i], _offsets, false);
+                    outputColumns[i] = ColumnWithOffset.CreateFlattened(_currentBatch.EventBatchData.Columns[i], _offsets, false, _memoryAllocator, out var usedOffset);
+                    if (usedOffset)
+                    {
+                        shouldDisposeOffsets = false;
+                    }
+                }
+                if (shouldDisposeOffsets)
+                {
+                    _offsets.Dispose();
                 }
 
                 var batch = new EventBatchWeighted(_weights, _iterations, new EventBatchData(outputColumns));

--- a/src/FlowtideDotNet.Core/Operators/Filter/ColumnFilterOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Filter/ColumnFilterOperator.cs
@@ -53,14 +53,14 @@ namespace FlowtideDotNet.Core.Operators.Filter
         public override IAsyncEnumerable<StreamEventBatch> OnRecieve(StreamEventBatch msg, long time)
         {
 
-            PrimitiveList<int>[] offsets = new PrimitiveList<int>[_filterRelation.OutputLength];
+            PrimitiveList<int> offsets = new PrimitiveList<int>(MemoryAllocator); // [_filterRelation.OutputLength];
             PrimitiveList<int> weights = new PrimitiveList<int>(MemoryAllocator);
             PrimitiveList<uint> iterations = new PrimitiveList<uint>(MemoryAllocator);
 
-            for (int i = 0; i < offsets.Length; i++)
-            {
-                offsets[i] = new PrimitiveList<int>(MemoryAllocator);
-            }
+            //for (int i = 0; i < offsets.Length; i++)
+            //{
+            //    offsets[i] = new PrimitiveList<int>(MemoryAllocator);
+            //}
 
             var data = msg.Data;
             for (int i = 0; i < data.Count; i++)
@@ -69,20 +69,26 @@ namespace FlowtideDotNet.Core.Operators.Filter
                 {
                     weights.Add(data.Weights[i]);
                     iterations.Add(data.Iterations[i]);
-                    for (int j = 0; j < offsets.Length; j++)
-                    {
-                        offsets[j].Add(i);
-                    }
+                    offsets.Add(i);
                 }
             }
 
             if (_filterRelation.EmitSet)
             {
+                bool shouldDisposeOffset = true;
                 var outputColumns = new IColumn[_filterRelation.OutputLength];
                 for (int i = 0; i < _filterRelation.Emit.Count; i++)
                 {
                     var emitIndex = _filterRelation.Emit[i];
-                    outputColumns[i] = new ColumnWithOffset(data.EventBatchData.Columns[emitIndex], offsets[i], false);
+                    outputColumns[i] = ColumnWithOffset.CreateFlattened(data.EventBatchData.Columns[emitIndex], offsets, false, MemoryAllocator, out var offsetUsed);
+                    if (offsetUsed)
+                    {
+                        shouldDisposeOffset = false;
+                    }
+                }
+                if (shouldDisposeOffset)
+                {
+                    offsets.Dispose();
                 }
 
                 var outputData = new EventBatchData(outputColumns);
@@ -90,10 +96,19 @@ namespace FlowtideDotNet.Core.Operators.Filter
             }
             else
             {
+                bool shouldDisposeOffset = true;
                 var outputColumns = new IColumn[_filterRelation.OutputLength];
                 for (int i = 0; i < data.EventBatchData.Columns.Count; i++)
                 {
-                    outputColumns[i] = new ColumnWithOffset(data.EventBatchData.Columns[i], offsets[i], false);
+                    outputColumns[i] = ColumnWithOffset.CreateFlattened(data.EventBatchData.Columns[i], offsets, false, MemoryAllocator, out var offsetUsed);
+                    if (offsetUsed)
+                    {
+                        shouldDisposeOffset = false;
+                    }
+                }
+                if (shouldDisposeOffset)
+                {
+                    offsets.Dispose();
                 }
                 var outputData = new EventBatchData(outputColumns);
                 return new SingleAsyncEnumerable<StreamEventBatch>(new StreamEventBatch(new EventBatchWeighted(weights, iterations, outputData)));

--- a/src/FlowtideDotNet.Core/Operators/Filter/ColumnFilterOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Filter/ColumnFilterOperator.cs
@@ -53,14 +53,9 @@ namespace FlowtideDotNet.Core.Operators.Filter
         public override IAsyncEnumerable<StreamEventBatch> OnRecieve(StreamEventBatch msg, long time)
         {
 
-            PrimitiveList<int> offsets = new PrimitiveList<int>(MemoryAllocator); // [_filterRelation.OutputLength];
+            PrimitiveList<int> offsets = new PrimitiveList<int>(MemoryAllocator);
             PrimitiveList<int> weights = new PrimitiveList<int>(MemoryAllocator);
             PrimitiveList<uint> iterations = new PrimitiveList<uint>(MemoryAllocator);
-
-            //for (int i = 0; i < offsets.Length; i++)
-            //{
-            //    offsets[i] = new PrimitiveList<int>(MemoryAllocator);
-            //}
 
             var data = msg.Data;
             for (int i = 0; i < data.Count; i++)

--- a/src/FlowtideDotNet.Core/Operators/Iteration/ColumnIterationOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Iteration/ColumnIterationOperator.cs
@@ -96,10 +96,19 @@ namespace FlowtideDotNet.Core.Operators.Iteration
             if (offsetsEgress.Count > 0)
             {
                 IColumn[] egressColumns = new IColumn[data.Data.EventBatchData.Columns.Count];
-
+                bool shouldDisposeOffsets = true;
                 for (int i = 0; i < data.Data.EventBatchData.Columns.Count; i++)
                 {
-                    egressColumns[i] = new ColumnWithOffset(data.Data.EventBatchData.Columns[i], offsetsEgress, false);
+                    egressColumns[i] = ColumnWithOffset.CreateFlattened(data.Data.EventBatchData.Columns[i], offsetsEgress, false, MemoryAllocator, out var offsetUsed);
+                    if (offsetUsed)
+                    {
+                        shouldDisposeOffsets = false;
+                    }
+                }
+
+                if (shouldDisposeOffsets)
+                {
+                    offsetsEgress.Dispose();
                 }
 
                 var egressBatch = new EventBatchWeighted(weightsEgress, iterationsEgress, new EventBatchData(egressColumns));
@@ -114,10 +123,19 @@ namespace FlowtideDotNet.Core.Operators.Iteration
             if (offsetsLoop.Count > 0)
             {
                 IColumn[] loopColumns = new IColumn[data.Data.EventBatchData.Columns.Count];
-
+                bool shouldDisposeOffsets = true;
                 for (int i = 0; i < data.Data.EventBatchData.Columns.Count; i++)
                 {
-                    loopColumns[i] = new ColumnWithOffset(data.Data.EventBatchData.Columns[i], offsetsLoop, false);
+                    loopColumns[i] = ColumnWithOffset.CreateFlattened(data.Data.EventBatchData.Columns[i], offsetsLoop, false, MemoryAllocator, out var offsetUsed);
+                    if (offsetUsed)
+                    {
+                        shouldDisposeOffsets = false;
+                    }
+                }
+
+                if (shouldDisposeOffsets)
+                {
+                    offsetsLoop.Dispose();
                 }
 
                 var loopBatch = new EventBatchWeighted(weightsLoop, iterationsLoop, new EventBatchData(loopColumns));

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnStoreMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnStoreMergeJoin.cs
@@ -245,9 +245,19 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                 IColumn[] outputColumns = new IColumn[_leftOutputColumns.Count + rightColumns.Count];
                                 if (_leftOutputColumns.Count > 0)
                                 {
+                                    bool shouldDisposeOffsets = true;
                                     for (int l = 0; l < _leftOutputColumns.Count; l++)
                                     {
-                                        outputColumns[_leftOutputIndices[l]] = new ColumnWithOffset(msg.Data.EventBatchData.Columns[_leftOutputColumns[l]], foundOffsets, true);
+                                        outputColumns[_leftOutputIndices[l]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[l]], foundOffsets, true, MemoryAllocator, out var offsetUsed);
+                                        if (offsetUsed)
+                                        {
+                                            shouldDisposeOffsets = false;
+                                        }
+                                    }
+
+                                    if (shouldDisposeOffsets)
+                                    {
+                                        foundOffsets.Dispose();
                                     }
                                 }
                                 else
@@ -325,9 +335,18 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 IColumn[] outputColumns = new IColumn[_leftOutputColumns.Count + rightColumns.Count];
                 if (_leftOutputColumns.Count > 0)
                 {
+                    bool shouldDisposeOffsets = true;
                     for (int i = 0; i < _leftOutputColumns.Count; i++)
                     {
-                        outputColumns[_leftOutputIndices[i]] = new ColumnWithOffset(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, true);
+                        outputColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, true, MemoryAllocator, out var offsetUsed);
+                        if (offsetUsed)
+                        {
+                            shouldDisposeOffsets = false;
+                        }
+                    }
+                    if (shouldDisposeOffsets)
+                    {
+                        foundOffsets.Dispose();
                     }
                 }
                 else
@@ -454,9 +473,18 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                 }
                                 if (_rightOutputColumns.Count > 0)
                                 {
+                                    bool shouldDisposeOffsets = true;
                                     for (int l = 0; l < _rightOutputColumns.Count; l++)
                                     {
-                                        outputColumns[_rightOutputIndices[l]] = new ColumnWithOffset(msg.Data.EventBatchData.Columns[_rightOutputColumns[l]], foundOffsets, true);
+                                        outputColumns[_rightOutputIndices[l]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_rightOutputColumns[l]], foundOffsets, true, MemoryAllocator, out var offsetUsed);
+                                        if (offsetUsed)
+                                        {
+                                            shouldDisposeOffsets = false;
+                                        }
+                                    }
+                                    if (shouldDisposeOffsets)
+                                    {
+                                        foundOffsets.Dispose();
                                     }
                                 }
                                 else
@@ -535,9 +563,18 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 }
                 if (_rightOutputColumns.Count > 0)
                 {
+                    bool shouldDisposeOffsets = true;
                     for (int i = 0; i < _rightOutputColumns.Count; i++)
                     {
-                        outputColumns[_rightOutputIndices[i]] = new ColumnWithOffset(msg.Data.EventBatchData.Columns[_rightOutputColumns[i]], foundOffsets, true);
+                        outputColumns[_rightOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_rightOutputColumns[i]], foundOffsets, true, MemoryAllocator, out var offsetUsed);
+                        if (offsetUsed)
+                        {
+                            shouldDisposeOffsets = false;
+                        }
+                    }
+                    if (shouldDisposeOffsets)
+                    {
+                        foundOffsets.Dispose();
                     }
                 }
                 else

--- a/src/FlowtideDotNet.Core/Operators/Normalization/ColumnNormalizationOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/ColumnNormalizationOperator.cs
@@ -164,10 +164,18 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             if (weights.Count > 0)
             {
                 IColumn[] columns = new IColumn[_emitList.Count];
-
+                bool shouldDisposeOffsets = true;
                 for (int i = 0; i < _emitList.Count; i++)
                 {
-                    columns[i] = new ColumnWithOffset(msg.Data.EventBatchData.Columns[_emitList[i]], toEmitOffsets, false);
+                    columns[i] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_emitList[i]], toEmitOffsets, false, MemoryAllocator, out var offsetUsed);
+                    if (offsetUsed)
+                    {
+                        shouldDisposeOffsets = false;
+                    }
+                }
+                if (shouldDisposeOffsets)
+                {
+                    toEmitOffsets.Dispose();
                 }
 
                 yield return new StreamEventBatch(new EventBatchWeighted(weights, iterations, new EventBatchData(columns)));
@@ -184,15 +192,23 @@ namespace FlowtideDotNet.Core.Operators.Normalization
                     deleteWeights.Add(-1);
                     deleteIterations.Add(0);
                 }
-
+                bool shouldDisposeOffsets = true;
                 IColumn[] deleteColumns = new IColumn[_normalizationRelation.OutputLength];
                 for (int i = 0; i < _keyColumns.Count; i++)
                 {
                     var emitIndex = _emitList.IndexOf(_keyColumns[i]);
                     if (emitIndex >= 0)
                     {
-                        deleteColumns[emitIndex] = new ColumnWithOffset(msg.Data.EventBatchData.Columns[_keyColumns[i]], deleteBatchKeyOffsets, false);
+                        deleteColumns[emitIndex] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_keyColumns[i]], deleteBatchKeyOffsets, false, MemoryAllocator, out var offsetUsed);
+                        if (offsetUsed)
+                        {
+                            shouldDisposeOffsets = false;
+                        }
                     }
+                }
+                if (shouldDisposeOffsets)
+                {
+                    deleteBatchKeyOffsets.Dispose();
                 }
                 for (int i = 0; i < _otherColumns.Count; i++)
                 {

--- a/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
@@ -414,16 +414,16 @@ namespace FlowtideDotNet.Core.Operators.Read
                     if (weights.Count > 0)
                     {
                         IColumn[] columns = new IColumn[_emitList.Count];
-                        bool shouldDiposeOffsets = true;
+                        bool shouldDisposeOffsets = true;
                         for (int k = 0; k < _emitList.Count; k++)
                         {
                             columns[k] = ColumnWithOffset.CreateFlattened(e.BatchData.EventBatchData.Columns[_emitList[k]], toEmitOffsets, false, MemoryAllocator, out var offsetUsed);
                             if (offsetUsed)
                             {
-                                shouldDiposeOffsets = false;
+                                shouldDisposeOffsets = false;
                             }
                         }
-                        if (shouldDiposeOffsets)
+                        if (shouldDisposeOffsets)
                         {
                             toEmitOffsets.Dispose();
                         }
@@ -449,7 +449,7 @@ namespace FlowtideDotNet.Core.Operators.Read
                             deleteWeights.Add(-1);
                             deleteIterations.Add(0);
                         }
-                        bool shouldDiposeOffsets = true;
+                        bool shouldDisposeOffsets = true;
                         IColumn[] deleteColumns = new IColumn[_readRelation.OutputLength];
                         for (int i = 0; i < _primaryKeyColumns.Count; i++)
                         {
@@ -459,11 +459,11 @@ namespace FlowtideDotNet.Core.Operators.Read
                                 deleteColumns[emitIndex] = ColumnWithOffset.CreateFlattened(e.BatchData.EventBatchData.Columns[_primaryKeyColumns[i]], deleteBatchKeyOffsets, false, MemoryAllocator, out var offsetUsed);
                                 if (offsetUsed)
                                 {
-                                    shouldDiposeOffsets = false;
+                                    shouldDisposeOffsets = false;
                                 }
                             }
                         }
-                        if (shouldDiposeOffsets)
+                        if (shouldDisposeOffsets)
                         {
                             deleteBatchKeyOffsets.Dispose();
                         }
@@ -601,16 +601,16 @@ namespace FlowtideDotNet.Core.Operators.Read
                 if (weights.Count > 0)
                 {
                     IColumn[] columns = new IColumn[_emitList.Count];
-                    bool shouldDiposeOffsets = true;
+                    bool shouldDisposeOffsets = true;
                     for (int k = 0; k < _emitList.Count; k++)
                     {
                         columns[k] = ColumnWithOffset.CreateFlattened(columnReadEvent.BatchData.EventBatchData.Columns[_emitList[k]], toEmitOffsets, false, MemoryAllocator, out var offsetUsed);
                         if (offsetUsed)
                         {
-                            shouldDiposeOffsets = false;
+                            shouldDisposeOffsets = false;
                         }
                     }
-                    if (shouldDiposeOffsets)
+                    if (shouldDisposeOffsets)
                     {
                         toEmitOffsets.Dispose();
                     }
@@ -643,7 +643,7 @@ namespace FlowtideDotNet.Core.Operators.Read
                         deleteWeights.Add(-1);
                         deleteIterations.Add(0);
                     }
-                    bool shouldDiposeOffsets = true;
+                    bool shouldDisposeOffsets = true;
                     IColumn[] deleteColumns = new IColumn[_readRelation.OutputLength];
                     for (int i = 0; i < _primaryKeyColumns.Count; i++)
                     {
@@ -653,11 +653,11 @@ namespace FlowtideDotNet.Core.Operators.Read
                             deleteColumns[emitIndex] = ColumnWithOffset.CreateFlattened(columnReadEvent.BatchData.EventBatchData.Columns[_primaryKeyColumns[i]], deleteBatchKeyOffsets, false, MemoryAllocator, out var offsetUsed);
                             if (offsetUsed)
                             {
-                                shouldDiposeOffsets = false;
+                                shouldDisposeOffsets = false;
                             }
                         }
                     }
-                    if (shouldDiposeOffsets)
+                    if (shouldDisposeOffsets)
                     {
                         deleteBatchKeyOffsets.Dispose();
                     }

--- a/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
@@ -414,10 +414,18 @@ namespace FlowtideDotNet.Core.Operators.Read
                     if (weights.Count > 0)
                     {
                         IColumn[] columns = new IColumn[_emitList.Count];
-
+                        bool shouldDiposeOffsets = true;
                         for (int k = 0; k < _emitList.Count; k++)
                         {
-                            columns[k] = new ColumnWithOffset(e.BatchData.EventBatchData.Columns[_emitList[k]], toEmitOffsets, false);
+                            columns[k] = ColumnWithOffset.CreateFlattened(e.BatchData.EventBatchData.Columns[_emitList[k]], toEmitOffsets, false, MemoryAllocator, out var offsetUsed);
+                            if (offsetUsed)
+                            {
+                                shouldDiposeOffsets = false;
+                            }
+                        }
+                        if (shouldDiposeOffsets)
+                        {
+                            toEmitOffsets.Dispose();
                         }
                         // Send out the data
                         _eventsCounter.Add(weights.Count);
@@ -441,15 +449,23 @@ namespace FlowtideDotNet.Core.Operators.Read
                             deleteWeights.Add(-1);
                             deleteIterations.Add(0);
                         }
-
+                        bool shouldDiposeOffsets = true;
                         IColumn[] deleteColumns = new IColumn[_readRelation.OutputLength];
                         for (int i = 0; i < _primaryKeyColumns.Count; i++)
                         {
                             var emitIndex = _emitList.IndexOf(_primaryKeyColumns[i]);
                             if (emitIndex >= 0)
                             {
-                                deleteColumns[emitIndex] = new ColumnWithOffset(e.BatchData.EventBatchData.Columns[_primaryKeyColumns[i]], deleteBatchKeyOffsets, false);
+                                deleteColumns[emitIndex] = ColumnWithOffset.CreateFlattened(e.BatchData.EventBatchData.Columns[_primaryKeyColumns[i]], deleteBatchKeyOffsets, false, MemoryAllocator, out var offsetUsed);
+                                if (offsetUsed)
+                                {
+                                    shouldDiposeOffsets = false;
+                                }
                             }
+                        }
+                        if (shouldDiposeOffsets)
+                        {
+                            deleteBatchKeyOffsets.Dispose();
                         }
                         for (int i = 0; i < _otherColumns.Count; i++)
                         {
@@ -585,10 +601,18 @@ namespace FlowtideDotNet.Core.Operators.Read
                 if (weights.Count > 0)
                 {
                     IColumn[] columns = new IColumn[_emitList.Count];
-
+                    bool shouldDiposeOffsets = true;
                     for (int k = 0; k < _emitList.Count; k++)
                     {
-                        columns[k] = new ColumnWithOffset(columnReadEvent.BatchData.EventBatchData.Columns[_emitList[k]], toEmitOffsets, false);
+                        columns[k] = ColumnWithOffset.CreateFlattened(columnReadEvent.BatchData.EventBatchData.Columns[_emitList[k]], toEmitOffsets, false, MemoryAllocator, out var offsetUsed);
+                        if (offsetUsed)
+                        {
+                            shouldDiposeOffsets = false;
+                        }
+                    }
+                    if (shouldDiposeOffsets)
+                    {
+                        toEmitOffsets.Dispose();
                     }
                     // Send out the data
                     _eventsCounter.Add(weights.Count);
@@ -619,15 +643,23 @@ namespace FlowtideDotNet.Core.Operators.Read
                         deleteWeights.Add(-1);
                         deleteIterations.Add(0);
                     }
-
+                    bool shouldDiposeOffsets = true;
                     IColumn[] deleteColumns = new IColumn[_readRelation.OutputLength];
                     for (int i = 0; i < _primaryKeyColumns.Count; i++)
                     {
                         var emitIndex = _emitList.IndexOf(_primaryKeyColumns[i]);
                         if (emitIndex >= 0)
                         {
-                            deleteColumns[emitIndex] = new ColumnWithOffset(columnReadEvent.BatchData.EventBatchData.Columns[_primaryKeyColumns[i]], deleteBatchKeyOffsets, false);
+                            deleteColumns[emitIndex] = ColumnWithOffset.CreateFlattened(columnReadEvent.BatchData.EventBatchData.Columns[_primaryKeyColumns[i]], deleteBatchKeyOffsets, false, MemoryAllocator, out var offsetUsed);
+                            if (offsetUsed)
+                            {
+                                shouldDiposeOffsets = false;
+                            }
                         }
+                    }
+                    if (shouldDiposeOffsets)
+                    {
+                        deleteBatchKeyOffsets.Dispose();
                     }
                     for (int i = 0; i < _otherColumns.Count; i++)
                     {

--- a/src/FlowtideDotNet.Core/Operators/Set/ColumnSetOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Set/ColumnSetOperator.cs
@@ -245,10 +245,19 @@ namespace FlowtideDotNet.Core.Operators.Set
 
             if (outputWeights.Count > 0)
             {
+                bool shouldDisposeOffsets = true;
                 IColumn[] outputColumns = new IColumn[_emit.Length];
                 for (int i = 0; i < _emit.Length; i++)
                 {
-                    outputColumns[i] = new ColumnWithOffset(msg.Data.EventBatchData.Columns[_emit[i]], foundOffsets, false);
+                    outputColumns[i] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_emit[i]], foundOffsets, false, MemoryAllocator, out var offsetUsed);
+                    if (offsetUsed)
+                    {
+                        shouldDisposeOffsets = false;
+                    }
+                }
+                if (shouldDisposeOffsets)
+                {
+                    foundOffsets.Dispose();
                 }
                 var batch = new EventBatchData(outputColumns);
                 _eventsProcessed.Add(outputWeights.Count);

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOperator.cs
@@ -192,12 +192,22 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
 
             if (foundOffsets.Count > 0)
             {
+                
                 IColumn[] emitColumns = new IColumn[_leftOutputColumns.Count + _rightOutputIndices.Count];
                 if (_leftOutputColumns.Count > 0)
                 {
+                    bool shouldDisposeOffsets = true;
                     for (int i = 0; i < _leftOutputColumns.Count; i++)
                     {
-                        emitColumns[_leftOutputIndices[i]] = new ColumnWithOffset(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, true);
+                        emitColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, true, MemoryAllocator, out var offsetUsed);
+                        if (offsetUsed)
+                        {
+                            shouldDisposeOffsets = false;
+                        }
+                    }
+                    if (shouldDisposeOffsets)
+                    {
+                        foundOffsets.Dispose();
                     }
                 }
                 else

--- a/src/FlowtideDotNet.Core/Operators/TopN/TopNOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TopN/TopNOperator.cs
@@ -127,10 +127,18 @@ namespace FlowtideDotNet.Core.Operators.TopN
                 _eventsOutCounter.Add(foundOffsets.Count);
 
                 IColumn[] outputColumns = new IColumn[_outputLength];
-
+                bool shouldDisposeOffsets = true;
                 for (int i = 0; i < outputColumns.Length; i++)
                 {
-                    outputColumns[i] = new ColumnWithOffset(inputBatch.Columns[i], foundOffsets, false);
+                    outputColumns[i] = ColumnWithOffset.CreateFlattened(inputBatch.Columns[i], foundOffsets, false, MemoryAllocator, out var offsetUsed);
+                    if (offsetUsed)
+                    {
+                        shouldDisposeOffsets = false;
+                    }
+                }
+                if (shouldDisposeOffsets)
+                {
+                    foundOffsets.Dispose();
                 }
 
                 yield return new StreamEventBatch(new EventBatchWeighted(inBatchWeights, inBatchIterations, new EventBatchData(outputColumns)));


### PR DESCRIPTION
In streams with many joins, columnwithoffset could contain columnwithoffset, this change flattens them so its always one level which will help incease performance in those streams.