### PR TITLE
Add support to create preallocated sizes for columns

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/AlwaysNullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/AlwaysNullColumn.cs
@@ -182,5 +182,13 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             throw new NotSupportedException();
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Null
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -113,29 +113,37 @@ namespace FlowtideDotNet.Core.ColumnStore
             {
                 case ArrowTypeId.Binary:
                     _dataColumn = new BinaryColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Binary;
                     break;
                 case ArrowTypeId.Boolean:
                     _dataColumn = new BoolColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Boolean;
                     break;
                 case ArrowTypeId.Decimal128:
                     _dataColumn = new DecimalColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Decimal128;
                     break;
                 case ArrowTypeId.Double:
                     _dataColumn = new DoubleColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Double;
                     break;
                 case ArrowTypeId.Int64:
                     _dataColumn = new IntegerColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Int64;
                     break;
                 case ArrowTypeId.List:
                     _dataColumn = new ListColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.List;
                     break;
                 case ArrowTypeId.Map:
                     _dataColumn = new MapColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Map;
                     break;
                 case ArrowTypeId.Null:
                     break;
                 case ArrowTypeId.String:
                     _dataColumn = new StringColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.String;
                     break;
                 case ArrowTypeId.Struct:
                     if (!columnSizeInfo.StructHeader.HasValue)
@@ -143,12 +151,15 @@ namespace FlowtideDotNet.Core.ColumnStore
                         throw new ArgumentException("Struct column size info must have struct header");
                     }
                     _dataColumn = new StructColumn(columnSizeInfo.StructHeader.Value, memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Struct;
                     break;
                 case ArrowTypeId.Timestamp:
                     _dataColumn = new TimestampTzColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Timestamp;
                     break;
                 case ArrowTypeId.Union:
                     _dataColumn = new UnionColumn(memoryAllocator, columnSizeInfo);
+                    _type = ArrowTypeId.Union;
                     break;
             }
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -147,6 +147,9 @@ namespace FlowtideDotNet.Core.ColumnStore
                 case ArrowTypeId.Timestamp:
                     _dataColumn = new TimestampTzColumn(memoryAllocator, columnSizeInfo);
                     break;
+                case ArrowTypeId.Union:
+                    _dataColumn = new UnionColumn(memoryAllocator, columnSizeInfo);
+                    break;
             }
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -1393,5 +1393,18 @@ namespace FlowtideDotNet.Core.ColumnStore
                 _dataColumn.DeleteBatch(targets);
             }
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            if (_dataColumn == null)
+            {
+                return new ColumnSizeInfo
+                {
+                    DataType = ArrowTypeId.Null,
+                    TotalRows = Count,
+                };
+            }
+            return _dataColumn.GetColumnSizeInfo();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -21,6 +21,7 @@ using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Relations;
 using System.Collections;
 using System.Diagnostics;
 using System.IO.Hashing;
@@ -102,6 +103,51 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             _memoryAllocator = memoryAllocator;
             _validityList = BitmapListFactory.Get(memoryAllocator);
+        }
+
+        public Column(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            _memoryAllocator = memoryAllocator;
+            _validityList = new BitmapList(memoryAllocator, columnSizeInfo.TotalRows);
+            switch (columnSizeInfo.DataType)
+            {
+                case ArrowTypeId.Binary:
+                    _dataColumn = new BinaryColumn(memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.Boolean:
+                    _dataColumn = new BoolColumn(memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.Decimal128:
+                    _dataColumn = new DecimalColumn(memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.Double:
+                    _dataColumn = new DoubleColumn(memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.Int64:
+                    _dataColumn = new IntegerColumn(memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.List:
+                    _dataColumn = new ListColumn(memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.Map:
+                    _dataColumn = new MapColumn(memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.Null:
+                    break;
+                case ArrowTypeId.String:
+                    _dataColumn = new StringColumn(memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.Struct:
+                    if (!columnSizeInfo.StructHeader.HasValue)
+                    {
+                        throw new ArgumentException("Struct column size info must have struct header");
+                    }
+                    _dataColumn = new StructColumn(columnSizeInfo.StructHeader.Value, memoryAllocator, columnSizeInfo);
+                    break;
+                case ArrowTypeId.Timestamp:
+                    _dataColumn = new TimestampTzColumn(memoryAllocator, columnSizeInfo);
+                    break;
+            }
         }
 
         internal Column(int nullCounter, IDataColumn? dataColumn, BitmapList validityList, ArrowTypeId type, IMemoryAllocator memoryAllocator)

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnSizeInfo.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnSizeInfo.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -58,7 +58,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                 {
                     MergeUnionChildren(other);
                 }
-                if (this.Children != null && other.Children != null)
+                else if (this.Children != null && other.Children != null)
                 {
                     var minChildCount = Math.Min(this.Children.Count, other.Children.Count);
                     for (int i = 0; i < minChildCount; i++)

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnSizeInfo.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnSizeInfo.cs
@@ -58,6 +58,14 @@ namespace FlowtideDotNet.Core.ColumnStore
                 {
                     MergeUnionChildren(other);
                 }
+                if (this.Children != null && other.Children != null)
+                {
+                    var minChildCount = Math.Min(this.Children.Count, other.Children.Count);
+                    for (int i = 0; i < minChildCount; i++)
+                    {
+                        this.Children[i].Merge(other.Children[i]);
+                    }
+                }
                 return;
             }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnSizeInfo.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnSizeInfo.cs
@@ -1,0 +1,138 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using SqlParser.Ast;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.ColumnStore
+{
+    public class ColumnSizeInfo
+    {
+        public ArrowTypeId DataType { get; set; }
+
+        public StructHeader? StructHeader { get; set; }
+        
+        public int TotalRows { get; set; }
+
+        public int BitWidth { get; set; }
+
+        public int TotalVariableBytes { get; set; }
+        
+        public List<ColumnSizeInfo>? Children { get; set; }
+
+        private static bool StructHeaderEqual(StructHeader? x, StructHeader? y)
+        {
+            if (x == null && y == null) return true;
+            if (x == null || y == null) return false;
+            return x.Value.Equals(y.Value);
+        }
+
+        public void Merge(ColumnSizeInfo other)
+        {
+            if (this.BitWidth > 0 && other.BitWidth > 0)
+            {
+                // Up bithwidth if required
+                this.BitWidth = Math.Max(this.BitWidth, other.BitWidth);
+            }
+
+            if (this.DataType == other.DataType && StructHeaderEqual(StructHeader, other.StructHeader))
+            {
+                this.TotalRows += other.TotalRows;
+                this.TotalVariableBytes += other.TotalVariableBytes;
+
+                if (this.DataType == ArrowTypeId.Union)
+                {
+                    MergeUnionChildren(other);
+                }
+                return;
+            }
+
+            if (this.DataType != ArrowTypeId.Union)
+            {
+                PromoteToUnion();
+            }
+
+            this.TotalRows += other.TotalRows;
+
+            if (other.DataType == ArrowTypeId.Union)
+            {
+                MergeUnionChildren(other);
+            }
+            else
+            {
+                var matchingChild = this.Children!.FirstOrDefault(c => c.DataType == other.DataType && StructHeaderEqual(c.StructHeader, other.StructHeader));
+                if (matchingChild != null)
+                {
+                    matchingChild.Merge(other);
+                }
+                else
+                {
+                    this.Children!.Add(other.Clone());
+                }
+            }
+        }
+
+        private void PromoteToUnion()
+        {
+            var snapshotChild = new ColumnSizeInfo
+            {
+                DataType = this.DataType,
+                StructHeader = this.StructHeader,
+                TotalRows = this.TotalRows,
+                TotalVariableBytes = this.TotalVariableBytes,
+                BitWidth = this.BitWidth,
+                Children = this.Children
+            };
+
+            this.DataType = ArrowTypeId.Union;
+            this.StructHeader = default;
+            this.BitWidth = 0;
+            this.Children = new List<ColumnSizeInfo> { snapshotChild };
+
+            this.TotalVariableBytes = 0;
+        }
+
+        private void MergeUnionChildren(ColumnSizeInfo otherUnion)
+        {
+            foreach (var otherChild in otherUnion.Children!)
+            {
+                var myChild = this.Children!.FirstOrDefault(c => c.DataType == otherChild.DataType && StructHeaderEqual(c.StructHeader, otherChild.StructHeader));
+                if (myChild != null)
+                {
+                    myChild.Merge(otherChild);
+                }
+                else
+                {
+                    this.Children!.Add(otherChild.Clone());
+                }
+            }
+        }
+
+        public ColumnSizeInfo Clone()
+        {
+            return new ColumnSizeInfo
+            {
+                DataType = this.DataType,
+                TotalRows = this.TotalRows,
+                TotalVariableBytes = this.TotalVariableBytes,
+                StructHeader = this.StructHeader,
+                BitWidth = this.BitWidth,
+                Children = this.Children?.Select(c => c.Clone()).ToList()
+            };
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -277,5 +277,12 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             throw new NotSupportedException("Column with offset does not support DeleteBatch.");
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            // Give the inner size, this is not an exact number, but it gives a good estimate of the size of the data,
+            // without needing to calculate the exact size of the offsets which is more expensive.
+            return innerColumn.GetColumnSizeInfo();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -287,5 +287,15 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             _data.DeleteBatch(targets);
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                TotalRows = Count,
+                DataType = ArrowTypeId.Binary,
+                TotalVariableBytes = _data.DataMemory.Length,
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -41,6 +41,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             _data = new BinaryList(memoryAllocator);
         }
 
+        public BinaryColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            _data = new BinaryList(memoryAllocator, columnSizeInfo.TotalRows, columnSizeInfo.TotalVariableBytes);
+        }
+
         public BinaryColumn(IMemoryOwner<byte> offsetMemory, int offsetLength, IMemoryOwner<byte>? dataMemory, IMemoryAllocator memoryAllocator)
         {
             _data = new BinaryList(offsetMemory, offsetLength, dataMemory, memoryAllocator);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -316,5 +316,14 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             _data.DeleteBatch(targets);
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Boolean,
+                TotalRows = Count
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -38,6 +38,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             _data = BitmapListFactory.Get(memoryAllocator);
         }
 
+        public BoolColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            _data = new BitmapList(memoryAllocator, columnSizeInfo.TotalRows);
+        }
+
         public BoolColumn(IMemoryOwner<byte> memory, int count, IMemoryAllocator memoryAllocator)
         {
             _data = BitmapListFactory.Get(memory, count, memoryAllocator);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -49,6 +49,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             _values = new PrimitiveList<decimal>(memoryAllocator);
         }
 
+        public DecimalColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            _values = new PrimitiveList<decimal>(memoryAllocator, columnSizeInfo.TotalRows);
+        }
+
         public DecimalColumn(IMemoryOwner<byte> memory, int length, IMemoryAllocator memoryAllocator)
         {
             _values = new PrimitiveList<decimal>(memory, length, memoryAllocator);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -293,5 +293,14 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             _values.DeleteBatch(targets);
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Decimal128,
+                TotalRows = Count
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -287,5 +287,14 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             _data.DeleteBatch(targets);
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Double,
+                TotalRows = Count,
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -44,6 +44,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             _data = new PrimitiveList<double>(memoryAllocator);
         }
 
+        public DoubleColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            _data = new PrimitiveList<double>(memoryAllocator, columnSizeInfo.TotalRows);
+        }
+
         public DoubleColumn(IMemoryOwner<byte> memory, int count, IMemoryAllocator memoryAllocator)
         {
             _data = new PrimitiveList<double>(memory, count, memoryAllocator);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
@@ -103,5 +103,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions);
 
         void DeleteBatch(ReadOnlySpan<int> targets);
+
+        ColumnSizeInfo GetColumnSizeInfo();
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -348,5 +348,14 @@ namespace FlowtideDotNet.Core.ColumnStore
             // Int64 column is not in use right now
             throw new NotImplementedException();
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Int64,
+                TotalRows = Count
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -1101,5 +1101,15 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 _data.DeleteBatch(targets);
             }
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Int64,
+                TotalRows = Count,
+                BitWidth = _data?.BitWidth ?? 8
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -88,6 +88,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 _list = new PrimitiveList<sbyte>(memoryAllocator);
             }
 
+            public Int8Data(IMemoryAllocator memoryAllocator, int initialCapacity)
+            {
+                _list = new PrimitiveList<sbyte>(memoryAllocator, initialCapacity);
+            }
+
             public Int8Data(PrimitiveList<sbyte> list)
             {
                 _list = list;
@@ -237,6 +242,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 _list = new PrimitiveList<short>(memoryAllocator);
             }
 
+            public Int16Data(IMemoryAllocator memoryAllocator, int initialCapacity)
+            {
+                _list = new PrimitiveList<short>(memoryAllocator, initialCapacity);
+            }
+
             public Int16Data(PrimitiveList<short> list)
             {
                 _list = list;
@@ -383,6 +393,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
 
             public Int32Data(IMemoryAllocator memoryAllocator)
+            {
+                _list = new PrimitiveList<int>(memoryAllocator);
+            }
+
+            public Int32Data(IMemoryAllocator memoryAllocator, int initialCapacity)
             {
                 _list = new PrimitiveList<int>(memoryAllocator);
             }
@@ -536,6 +551,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 _list = new PrimitiveList<long>(memoryAllocator);
             }
 
+            public Int64Data(IMemoryAllocator memoryAllocator, int initialCapacity)
+            {
+                _list = new PrimitiveList<long>(memoryAllocator, initialCapacity);
+            }
+
             public Int64Data(PrimitiveList<long> list)
             {
                 _list = list;
@@ -682,6 +702,28 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         public IntegerColumn(IMemoryAllocator memoryAllocator)
         {
             this._memoryAllocator = memoryAllocator;
+        }
+
+        public IntegerColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            this._memoryAllocator = memoryAllocator;
+            switch (columnSizeInfo.BitWidth)
+            {
+                case 8:
+                    _data = new Int8Data(memoryAllocator, columnSizeInfo.TotalRows);
+                    break;
+                case 16:
+                    _data = new Int16Data(memoryAllocator, columnSizeInfo.TotalRows);
+                    break;
+                case 32:
+                    _data = new Int32Data(memoryAllocator, columnSizeInfo.TotalRows);
+                    break;
+                case 64:
+                    _data = new Int64Data(memoryAllocator, columnSizeInfo.TotalRows);
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
         }
 
         public IntegerColumn(IMemoryAllocator memoryAllocator, IMemoryOwner<byte> memory, int length, int bitWidth)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
@@ -47,6 +47,17 @@ namespace FlowtideDotNet.Core.ColumnStore
             _offsets.Add(0);
         }
 
+        public ListColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            if (columnSizeInfo.Children == null || columnSizeInfo.Children.Count != 1)
+            {
+                throw new ArgumentException("Column size info did not contain child information");
+            }
+            _internalColumn = new Column(memoryAllocator, columnSizeInfo.Children[0]);
+            _offsets = new IntList(memoryAllocator, columnSizeInfo.TotalRows + 1);
+            _offsets.Add(0);
+        }
+
         public ListColumn(Column internalColumn, IMemoryOwner<byte> offsetMemory, int offsetCount, IMemoryAllocator memoryAllocator)
         {
             _offsets = new IntList(offsetMemory, offsetCount, memoryAllocator);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
@@ -577,5 +577,18 @@ namespace FlowtideDotNet.Core.ColumnStore
                 RemoveAt(targets[i]);
             }
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.List,
+                TotalRows = Count,
+                Children = new List<ColumnSizeInfo>()
+                 {
+                     _internalColumn.GetColumnSizeInfo()
+                 }
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -57,6 +57,18 @@ namespace FlowtideDotNet.Core.ColumnStore
             _offsets.Add(0);
         }
 
+        public MapColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            if (columnSizeInfo.Children == null || columnSizeInfo.Children.Count != 2)
+            {
+                throw new ArgumentException("Column size info did not contain child information");
+            }
+            _keyColumn = new Column(memoryAllocator, columnSizeInfo.Children[0]);
+            _valueColumn = new Column(memoryAllocator, columnSizeInfo.Children[1]);
+            _offsets = new IntList(memoryAllocator, columnSizeInfo.TotalRows + 1);
+            _offsets.Add(0);
+        }
+
         internal MapColumn(Column keyColumn, Column valueColumn, IMemoryOwner<byte> offsetMemory, int offsetLength, IMemoryAllocator memoryAllocator)
         {
             _keyColumn = keyColumn;

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -720,5 +720,19 @@ namespace FlowtideDotNet.Core.ColumnStore
                 RemoveAt(targets[i]);
             }
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Map,
+                TotalRows = Count,
+                Children = new List<ColumnSizeInfo>()
+                {
+                    _keyColumn.GetColumnSizeInfo(),
+                    _valueColumn.GetColumnSizeInfo()
+                }
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
@@ -190,5 +190,14 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
             _count -= targets.Length;
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Null,
+                TotalRows = _count,
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -45,6 +45,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             _binaryList = new BinaryList(memoryAllocator);
         }
 
+        public StringColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            _binaryList = new BinaryList(memoryAllocator, columnSizeInfo.TotalRows, columnSizeInfo.TotalVariableBytes);
+        }
+
         public StringColumn(IMemoryOwner<byte> offsetMemory, int offsetLength, IMemoryOwner<byte>? dataMemory, IMemoryAllocator memoryAllocator)
         {
             _binaryList = new BinaryList(offsetMemory, offsetLength, dataMemory, memoryAllocator);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -300,5 +300,15 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             _binaryList.DeleteBatch(targets);
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.String,
+                TotalRows = Count,
+                TotalVariableBytes = _binaryList.DataMemory.Length
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
@@ -42,6 +42,22 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             _count = 0;
         }
 
+        public StructColumn(StructHeader structHeader, IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            if (columnSizeInfo.Children == null || columnSizeInfo.Children.Count != structHeader.Count)
+            {
+                throw new ArgumentException("Column size info does not match struct header.");
+            }
+            _header = structHeader;
+            _columns = new Column[structHeader.Count];
+            for (int i = 0; i < _columns.Length; i++)
+            {
+                var childSizeInfo = columnSizeInfo.Children[i];
+                _columns[i] = new Column(memoryAllocator, childSizeInfo);
+            }
+            _count = 0;
+        }
+
         internal StructColumn(StructHeader header, Column[] columns, int count)
         {
             _header = header;

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
@@ -614,5 +614,24 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 RemoveAt(targets[i]);
             }
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            List<ColumnSizeInfo> childrenSizeInfo = new List<ColumnSizeInfo>();
+
+            for (int i = 0; i < _columns.Length; i++)
+            {
+                var childSizeInfo = _columns[i].GetColumnSizeInfo();
+                childrenSizeInfo.Add(childSizeInfo);
+            }
+
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Struct,
+                StructHeader = _header,
+                Children = childrenSizeInfo,
+                TotalRows = Count,
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
@@ -48,6 +48,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             _values = new PrimitiveList<TimestampTzValue>(memoryAllocator);
         }
 
+        public TimestampTzColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            _values = new PrimitiveList<TimestampTzValue>(memoryAllocator, columnSizeInfo.TotalRows);
+        }
+
         public TimestampTzColumn(IMemoryOwner<byte> memory, int length, IMemoryAllocator memoryAllocator)
         {
             _values = new PrimitiveList<TimestampTzValue>(memory, length, memoryAllocator);

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
@@ -305,5 +305,14 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
             _values.DeleteBatch(targets);
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            return new ColumnSizeInfo()
+            {
+                DataType = ArrowTypeId.Timestamp,
+                TotalRows = Count,
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -66,6 +66,21 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             };
         }
 
+        public UnionColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
+        {
+            _memoryAllocator = memoryAllocator;
+            _typeIds = new sbyte[35]; //35 types exist
+            _typeList = new TypeList(memoryAllocator, columnSizeInfo.TotalRows);
+            _offsets = new IntList(memoryAllocator, columnSizeInfo.TotalRows);
+            _valueColumns = new List<IDataColumn>();
+
+            for (int i = 0; i < columnSizeInfo.Children.Count; i++)
+            {
+                // Add children
+            }
+
+        }
+
         internal UnionColumn(List<IDataColumn> columns, IMemoryOwner<byte> typeListMemory, IMemoryOwner<byte> offsetMemory, int count, IMemoryAllocator memoryAllocator)
         {
             _memoryAllocator = memoryAllocator;

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -943,5 +943,26 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 RemoveAt(targets[i]);
             }
         }
+
+        public ColumnSizeInfo GetColumnSizeInfo()
+        {
+            List<ColumnSizeInfo> children = new List<ColumnSizeInfo>();
+
+            for (int i = 0; i < _valueColumns.Count; i++)
+            {
+                if (_valueColumns[i] != null)
+                {
+                    var columnSizeInfo = _valueColumns[i].GetColumnSizeInfo();
+                    children.Add(columnSizeInfo);
+                }
+            }
+    
+            return new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Union,
+                TotalRows = Count,
+                Children = children
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -68,6 +68,10 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
         public UnionColumn(IMemoryAllocator memoryAllocator, ColumnSizeInfo columnSizeInfo)
         {
+            if (columnSizeInfo.Children == null)
+            {
+                throw new ArgumentException("ColumnSizeInfo for UnionColumn must have children");
+            }
             _memoryAllocator = memoryAllocator;
             _typeIds = new sbyte[35]; //35 types exist
             _typeList = new TypeList(memoryAllocator, columnSizeInfo.TotalRows);
@@ -77,6 +81,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             for (int i = 0; i < columnSizeInfo.Children.Count; i++)
             {
                 // Add children
+
             }
 
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -76,12 +76,19 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             _typeIds = new sbyte[35]; //35 types exist
             _typeList = new TypeList(memoryAllocator, columnSizeInfo.TotalRows);
             _offsets = new IntList(memoryAllocator, columnSizeInfo.TotalRows);
-            _valueColumns = new List<IDataColumn>();
+            _valueColumns = new List<IDataColumn>()
+            {
+                new NullColumn()
+            };
 
             for (int i = 0; i < columnSizeInfo.Children.Count; i++)
             {
                 // Add children
                 var child = columnSizeInfo.Children[i];
+                if (child.DataType == ArrowTypeId.Null)
+                {
+                    continue;
+                }
                 var childDataColumn = CreateColumnFromSizeInfo(child);
                 var newIndex = (sbyte)_valueColumns.Count;
                 _valueColumns.Add(childDataColumn);
@@ -111,6 +118,8 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                     return new DecimalColumn(_memoryAllocator, columnSizeInfo);
                 case ArrowTypeId.Timestamp:
                     return new TimestampTzColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.Null:
+                    return new NullColumn();
                 default:
                     throw new NotImplementedException();
             }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -81,9 +81,39 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             for (int i = 0; i < columnSizeInfo.Children.Count; i++)
             {
                 // Add children
-
+                var child = columnSizeInfo.Children[i];
+                var childDataColumn = CreateColumnFromSizeInfo(child);
+                var newIndex = (sbyte)_valueColumns.Count;
+                _valueColumns.Add(childDataColumn);
+                _typeIds[(int)child.DataType] = newIndex;
             }
+        }
 
+        private IDataColumn CreateColumnFromSizeInfo(ColumnSizeInfo columnSizeInfo)
+        {
+            switch (columnSizeInfo.DataType)
+            {
+                case ArrowTypeId.Int64:
+                    return new IntegerColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.String:
+                    return new StringColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.Boolean:
+                    return new BoolColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.Double:
+                    return new DoubleColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.List:
+                    return new ListColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.Binary:
+                    return new BinaryColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.Map:
+                    return new MapColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.Decimal128:
+                    return new DecimalColumn(_memoryAllocator, columnSizeInfo);
+                case ArrowTypeId.Timestamp:
+                    return new TimestampTzColumn(_memoryAllocator, columnSizeInfo);
+                default:
+                    throw new NotImplementedException();
+            }
         }
 
         internal UnionColumn(List<IDataColumn> columns, IMemoryOwner<byte> typeListMemory, IMemoryOwner<byte> offsetMemory, int count, IMemoryAllocator memoryAllocator)

--- a/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
@@ -90,5 +90,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         void InsertFrom(IColumn column, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions);
 
         void DeleteBatch(ReadOnlySpan<int> targets);
+
+        ColumnSizeInfo GetColumnSizeInfo();
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
@@ -68,6 +68,15 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             _memoryAllocator = memoryAllocator;
         }
 
+        public BinaryList(IMemoryAllocator memoryAllocator, int initialRowCapacity, int initialDataCapacity)
+        {
+            _memoryAllocator = memoryAllocator;
+            _offsets = new IntList(memoryAllocator, initialRowCapacity + 1);
+            _memoryOwner = _memoryAllocator.Allocate(initialDataCapacity, 64);
+            _data = _memoryOwner.Memory.Pin().Pointer;
+            _dataLength = initialDataCapacity;
+        }
+
         /// <summary>
         /// Create a binary list from existing memory.
         /// If any changes are made to the list that exceeds the current memory, a new memory block will be allocated that is used only for the list.

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
@@ -72,6 +72,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
         {
             _memoryAllocator = memoryAllocator;
             _offsets = new IntList(memoryAllocator, initialRowCapacity + 1);
+            _offsets.Add(0);
             _memoryOwner = _memoryAllocator.Allocate(initialDataCapacity, 64);
             _data = _memoryOwner.Memory.Pin().Pointer;
             _dataLength = initialDataCapacity;

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
@@ -41,6 +41,14 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             this.memoryAllocator = memoryAllocator;
         }
 
+        public IntList(IMemoryAllocator memoryAllocator, int initialCapacity)
+        {
+            this.memoryAllocator = memoryAllocator;
+            _memoryOwner = memoryAllocator.Allocate(initialCapacity * sizeof(int), 64);
+            _dataLength = initialCapacity;
+            _data = (int*)_memoryOwner.Memory.Pin().Pointer;
+        }
+
         public IntList(IMemoryOwner<byte> memory, int length, IMemoryAllocator memoryAllocator)
         {
             _memoryOwner = memory;

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/TypeList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/TypeList.cs
@@ -34,6 +34,13 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             _memoryAllocator = memoryAllocator;
         }
 
+        public TypeList(IMemoryAllocator memoryAllocator, int initialCapacity)
+        {
+            _data = null;
+            _memoryAllocator = memoryAllocator;
+            EnsureCapacity(initialCapacity);
+        }
+
         public TypeList(IMemoryOwner<byte> memory, int length, IMemoryAllocator memoryAllocator)
         {
             _memoryOwner = memory;

--- a/src/FlowtideDotNet.Storage/DataStructures/BitmapList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/BitmapList.cs
@@ -151,6 +151,12 @@ namespace FlowtideDotNet.Storage.DataStructures
             this.memoryAllocator = memoryAllocator;
         }
 
+        public BitmapList(IMemoryAllocator memoryAllocator, int initialCapacity)
+        {
+            this.memoryAllocator = memoryAllocator;
+            EnsureSize((initialCapacity + 31) / 32);
+        }
+
         public BitmapList(IMemoryOwner<byte> memoryOwner, int length, IMemoryAllocator memoryAllocator)
         {
             _memoryOwner = memoryOwner;

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -34,6 +34,12 @@ namespace FlowtideDotNet.Storage.DataStructures
             _memoryAllocator = memoryAllocator;
         }
 
+        public PrimitiveList(IMemoryAllocator memoryAllocator, int initialCapacity)
+        {
+            _memoryAllocator = memoryAllocator;
+            EnsureCapacity(initialCapacity);
+        }
+
         public PrimitiveList(IMemoryOwner<byte> memory, int length, IMemoryAllocator memoryAllocator)
         {
             _memoryOwner = memory;

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnSizeInfoTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnSizeInfoTests.cs
@@ -1,0 +1,1280 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Storage.Memory;
+using Xunit;
+
+namespace FlowtideDotNet.Core.Tests.ColumnStore
+{
+    public class ColumnSizeInfoTests
+    {
+        [Fact]
+        public void MergeSameTypeAccumulatesRowsAndVariableBytes()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 10, TotalVariableBytes = 200 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 5, TotalVariableBytes = 100 };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.String, a.DataType);
+            Assert.Equal(15, a.TotalRows);
+            Assert.Equal(300, a.TotalVariableBytes);
+        }
+
+        [Fact]
+        public void MergeSameIntTypePicksLargerBitWidth()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 10, BitWidth = 8 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5, BitWidth = 32 };
+
+            a.Merge(b);
+
+            Assert.Equal(32, a.BitWidth);
+            Assert.Equal(15, a.TotalRows);
+        }
+
+        [Fact]
+        public void MergeSameIntTypeBitWidthDoesNotDecrease()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 10, BitWidth = 64 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5, BitWidth = 16 };
+
+            a.Merge(b);
+
+            Assert.Equal(64, a.BitWidth);
+        }
+
+        [Fact]
+        public void MergeDifferentTypesPromotesToUnion()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 10, TotalVariableBytes = 100 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5, BitWidth = 32 };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(15, a.TotalRows);
+            Assert.NotNull(a.Children);
+            Assert.Equal(2, a.Children!.Count);
+            Assert.Equal(ArrowTypeId.String, a.Children[0].DataType);
+            Assert.Equal(10, a.Children[0].TotalRows);
+            Assert.Equal(100, a.Children[0].TotalVariableBytes);
+            Assert.Equal(ArrowTypeId.Int64, a.Children[1].DataType);
+            Assert.Equal(5, a.Children[1].TotalRows);
+            Assert.Equal(32, a.Children[1].BitWidth);
+        }
+
+        [Fact]
+        public void MergeUnionWithNewTypeAddsChild()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 10 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5 };
+            var c = new ColumnSizeInfo { DataType = ArrowTypeId.Double, TotalRows = 3 };
+
+            a.Merge(b);
+            a.Merge(c);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(18, a.TotalRows);
+            Assert.Equal(3, a.Children!.Count);
+            Assert.Equal(ArrowTypeId.Double, a.Children[2].DataType);
+            Assert.Equal(3, a.Children[2].TotalRows);
+        }
+
+        [Fact]
+        public void MergeUnionWithExistingTypeMergesIntoChild()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 10, TotalVariableBytes = 100 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5 };
+            var c = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 3, TotalVariableBytes = 50 };
+
+            a.Merge(b);
+            a.Merge(c);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(18, a.TotalRows);
+            Assert.Equal(2, a.Children!.Count);
+            Assert.Equal(ArrowTypeId.String, a.Children[0].DataType);
+            Assert.Equal(13, a.Children[0].TotalRows);
+            Assert.Equal(150, a.Children[0].TotalVariableBytes);
+        }
+
+        [Fact]
+        public void MergeTwoUnionsMergesChildren()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 10 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5 };
+            a.Merge(b);
+
+            var c = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 3 };
+            var d = new ColumnSizeInfo { DataType = ArrowTypeId.Double, TotalRows = 7 };
+            c.Merge(d);
+
+            a.Merge(c);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(25, a.TotalRows);
+            Assert.Equal(3, a.Children!.Count);
+
+            var stringChild = a.Children.First(x => x.DataType == ArrowTypeId.String);
+            Assert.Equal(10, stringChild.TotalRows);
+
+            var intChild = a.Children.First(x => x.DataType == ArrowTypeId.Int64);
+            Assert.Equal(8, intChild.TotalRows);
+
+            var doubleChild = a.Children.First(x => x.DataType == ArrowTypeId.Double);
+            Assert.Equal(7, doubleChild.TotalRows);
+        }
+
+        [Fact]
+        public void MergeSameTypeWithChildrenMergesRecursively()
+        {
+            var a = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.List,
+                TotalRows = 10,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 30, TotalVariableBytes = 500 }
+                }
+            };
+            var b = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.List,
+                TotalRows = 5,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 20, TotalVariableBytes = 300 }
+                }
+            };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.List, a.DataType);
+            Assert.Equal(15, a.TotalRows);
+            Assert.Single(a.Children!);
+            Assert.Equal(50, a.Children[0].TotalRows);
+            Assert.Equal(800, a.Children[0].TotalVariableBytes);
+        }
+
+        [Fact]
+        public void MergeSameStructWithSameHeaderMergesChildren()
+        {
+            var header = StructHeader.Create("a", "b");
+
+            var a = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Struct,
+                StructHeader = header,
+                TotalRows = 10,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 10, BitWidth = 8 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 10, TotalVariableBytes = 100 },
+                }
+            };
+            var b = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Struct,
+                StructHeader = header,
+                TotalRows = 5,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5, BitWidth = 32 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 5, TotalVariableBytes = 50 },
+                }
+            };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.Struct, a.DataType);
+            Assert.Equal(15, a.TotalRows);
+            Assert.Equal(2, a.Children!.Count);
+            Assert.Equal(15, a.Children[0].TotalRows);
+            Assert.Equal(32, a.Children[0].BitWidth);
+            Assert.Equal(15, a.Children[1].TotalRows);
+            Assert.Equal(150, a.Children[1].TotalVariableBytes);
+        }
+
+        [Fact]
+        public void MergeDifferentStructHeadersPromotesToUnion()
+        {
+            var headerA = StructHeader.Create("x", "y");
+            var headerB = StructHeader.Create("a", "b");
+
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Struct, StructHeader = headerA, TotalRows = 10 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Struct, StructHeader = headerB, TotalRows = 5 };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(15, a.TotalRows);
+            Assert.Equal(2, a.Children!.Count);
+        }
+
+        [Fact]
+        public void MergeNullIntoNullAccumulatesRows()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Null, TotalRows = 5 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Null, TotalRows = 3 };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.Null, a.DataType);
+            Assert.Equal(8, a.TotalRows);
+        }
+
+        [Fact]
+        public void MergeTypeIntoNullPromotesToUnion()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Null, TotalRows = 5 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 3 };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(8, a.TotalRows);
+            Assert.NotNull(a.Children);
+        }
+
+        [Fact]
+        public void MergeNullIntoTypePromotesToUnion()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Null, TotalRows = 3 };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(8, a.TotalRows);
+        }
+
+        [Fact]
+        public void MergeZeroBitWidthDoesNotAffectResult()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Double, TotalRows = 10, BitWidth = 0 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Double, TotalRows = 5, BitWidth = 0 };
+
+            a.Merge(b);
+
+            Assert.Equal(0, a.BitWidth);
+            Assert.Equal(15, a.TotalRows);
+        }
+
+        [Fact]
+        public void CloneCopiesAllFields()
+        {
+            var original = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.String,
+                TotalRows = 42,
+                TotalVariableBytes = 500,
+                BitWidth = 0,
+            };
+
+            var clone = original.Clone();
+
+            Assert.Equal(original.DataType, clone.DataType);
+            Assert.Equal(original.TotalRows, clone.TotalRows);
+            Assert.Equal(original.TotalVariableBytes, clone.TotalVariableBytes);
+        }
+
+        [Fact]
+        public void CloneDeepCopiesChildren()
+        {
+            var original = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.List,
+                TotalRows = 10,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 30, TotalVariableBytes = 300 }
+                }
+            };
+
+            var clone = original.Clone();
+
+            original.Children[0].TotalRows = 999;
+
+            Assert.Single(clone.Children!);
+            Assert.Equal(30, clone.Children[0].TotalRows);
+        }
+
+        [Fact]
+        public void ClonePreservesBitWidth()
+        {
+            var original = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Int64,
+                TotalRows = 10,
+                BitWidth = 32
+            };
+
+            var clone = original.Clone();
+
+            Assert.Equal(32, clone.BitWidth);
+        }
+
+        [Fact]
+        public void ClonePreservesStructHeader()
+        {
+            var header = StructHeader.Create("col1", "col2");
+            var original = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Struct,
+                StructHeader = header,
+                TotalRows = 5
+            };
+
+            var clone = original.Clone();
+
+            Assert.Equal(header, clone.StructHeader);
+        }
+
+        [Fact]
+        public void CloneWithNullChildren()
+        {
+            var original = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Int64,
+                TotalRows = 10,
+                Children = null
+            };
+
+            var clone = original.Clone();
+
+            Assert.Null(clone.Children);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromNullOnlyColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Null, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromInt64Column()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Int64, info.DataType);
+            Assert.Equal(3, info.TotalRows);
+            Assert.True(info.BitWidth > 0);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromStringColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new StringValue("hello"));
+            column.Add(new StringValue("world"));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.String, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+            Assert.True(info.TotalVariableBytes > 0);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromBoolColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(false));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Boolean, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromDoubleColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new DoubleValue(1.5));
+            column.Add(new DoubleValue(2.5));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Double, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromDecimalColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new DecimalValue(1.23m));
+            column.Add(new DecimalValue(4.56m));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Decimal128, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromTimestampColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new TimestampTzValue(DateTime.UtcNow.Ticks, 0));
+            column.Add(new TimestampTzValue(DateTime.UtcNow.Ticks + 1000, 0));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Timestamp, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromBinaryColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new BinaryValue(new byte[] { 1, 2, 3 }));
+            column.Add(new BinaryValue(new byte[] { 4, 5, 6, 7 }));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Binary, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+            Assert.True(info.TotalVariableBytes > 0);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromListColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new ListValue(new IDataValue[] { new Int64Value(1), new Int64Value(2) }));
+            column.Add(new ListValue(new IDataValue[] { new Int64Value(3) }));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.List, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+            Assert.NotNull(info.Children);
+            Assert.Single(info.Children!);
+            Assert.Equal(3, info.Children[0].TotalRows);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromMapColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new MapValue(
+                new List<KeyValuePair<IDataValue, IDataValue>>
+                {
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("k1"), new Int64Value(1))
+                }
+            ));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Map, info.DataType);
+            Assert.Equal(1, info.TotalRows);
+            Assert.NotNull(info.Children);
+            Assert.Equal(2, info.Children!.Count);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromStructColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            var header = StructHeader.Create("name", "age");
+            column.Add(new StructValue(header, new IDataValue[] { new StringValue("Alice"), new Int64Value(30) }));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Struct, info.DataType);
+            Assert.Equal(1, info.TotalRows);
+            Assert.NotNull(info.StructHeader);
+            Assert.Equal(header, info.StructHeader!.Value);
+            Assert.NotNull(info.Children);
+            Assert.Equal(2, info.Children!.Count);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromUnionColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new StringValue("hello"));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Union, info.DataType);
+            Assert.Equal(2, info.TotalRows);
+            Assert.NotNull(info.Children);
+            Assert.True(info.Children!.Count >= 2);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromEmptyColumn()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Null, info.DataType);
+            Assert.Equal(0, info.TotalRows);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromIntWithNullsMatchesCount()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(NullValue.Instance);
+            column.Add(new Int64Value(3));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Int64, info.DataType);
+            Assert.Equal(3, info.TotalRows);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromAlwaysNullColumn()
+        {
+            var info = AlwaysNullColumn.Instance.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Null, info.DataType);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoInt64()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 100, BitWidth = 64 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new Int64Value(42));
+            column.Add(new Int64Value(99));
+
+            Assert.Equal(2, column.Count);
+            Assert.Equal(42, column.GetValueAt(0, default).AsLong);
+            Assert.Equal(99, column.GetValueAt(1, default).AsLong);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoString()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 100, TotalVariableBytes = 5000 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new StringValue("hello"));
+            column.Add(new StringValue("world"));
+
+            Assert.Equal(2, column.Count);
+            Assert.Equal("hello", column.GetValueAt(0, default).AsString.ToString());
+            Assert.Equal("world", column.GetValueAt(1, default).AsString.ToString());
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoBool()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Boolean, TotalRows = 50 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(false));
+
+            Assert.Equal(2, column.Count);
+            Assert.True(column.GetValueAt(0, default).AsBool);
+            Assert.False(column.GetValueAt(1, default).AsBool);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoDouble()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Double, TotalRows = 50 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new DoubleValue(3.14));
+
+            Assert.Single(column);
+            Assert.Equal(3.14, column.GetValueAt(0, default).AsDouble);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoDecimal()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Decimal128, TotalRows = 50 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new DecimalValue(1.23m));
+
+            Assert.Single(column);
+            Assert.Equal(1.23m, column.GetValueAt(0, default).AsDecimal);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoTimestamp()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Timestamp, TotalRows = 50 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            var ts = new TimestampTzValue(123456789L, 60);
+            column.Add(ts);
+
+            Assert.Single(column);
+            Assert.Equal(123456789L, column.GetValueAt(0, default).AsTimestamp.ticks);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoBinary()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Binary, TotalRows = 50, TotalVariableBytes = 1000 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new BinaryValue(new byte[] { 1, 2, 3 }));
+
+            Assert.Single(column);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoNull()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Null, TotalRows = 0 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(NullValue.Instance);
+            Assert.Single(column);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoList()
+        {
+            var sizeInfo = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.List,
+                TotalRows = 50,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 200, BitWidth = 64 }
+                }
+            };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new ListValue(new IDataValue[] { new Int64Value(1), new Int64Value(2) }));
+
+            Assert.Single(column);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoMap()
+        {
+            var sizeInfo = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Map,
+                TotalRows = 50,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 100, TotalVariableBytes = 2000 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 100, BitWidth = 64 },
+                }
+            };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new MapValue(
+                new List<KeyValuePair<IDataValue, IDataValue>>
+                {
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("key"), new Int64Value(42))
+                }
+            ));
+
+            Assert.Single(column);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoStruct()
+        {
+            var header = StructHeader.Create("name", "age");
+            var sizeInfo = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Struct,
+                StructHeader = header,
+                TotalRows = 50,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 50, TotalVariableBytes = 1000 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 50, BitWidth = 8 },
+                }
+            };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new StructValue(header, new IDataValue[] { new StringValue("Bob"), new Int64Value(25) }));
+
+            Assert.Single(column);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoStructThrowsWithoutHeader()
+        {
+            var sizeInfo = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Struct,
+                TotalRows = 50,
+            };
+
+            Assert.Throws<ArgumentException>(() => new Column(GlobalMemoryManager.Instance, sizeInfo));
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoUnion()
+        {
+            var sizeInfo = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Union,
+                TotalRows = 100,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Null, TotalRows = 0 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 50, BitWidth = 32 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 50, TotalVariableBytes = 1000 },
+                }
+            };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new Int64Value(1));
+            column.Add(new StringValue("hello"));
+
+            Assert.Equal(2, column.Count);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoUnionThrowsWithoutChildren()
+        {
+            var sizeInfo = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Union,
+                TotalRows = 100,
+            };
+
+            Assert.Throws<ArgumentException>(() => new Column(GlobalMemoryManager.Instance, sizeInfo));
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoListThrowsWithoutChildren()
+        {
+            var sizeInfo = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.List,
+                TotalRows = 50,
+            };
+
+            Assert.Throws<ArgumentException>(() => new Column(GlobalMemoryManager.Instance, sizeInfo));
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoMapThrowsWithWrongChildCount()
+        {
+            var sizeInfo = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Map,
+                TotalRows = 50,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 50 }
+                }
+            };
+
+            Assert.Throws<ArgumentException>(() => new Column(GlobalMemoryManager.Instance, sizeInfo));
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoInt8()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 100, BitWidth = 8 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new Int64Value(5));
+            Assert.Equal(1, column.Count);
+            Assert.Equal(5, column.GetValueAt(0, default).AsLong);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoInt16()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 100, BitWidth = 16 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new Int64Value(1000));
+            Assert.Single(column);
+            Assert.Equal(1000, column.GetValueAt(0, default).AsLong);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoInt32()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 100, BitWidth = 32 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new Int64Value(100_000));
+            Assert.Single(column);
+            Assert.Equal(100_000, column.GetValueAt(0, default).AsLong);
+        }
+
+        [Fact]
+        public void RoundTripInt64Column()
+        {
+            using var original = new Column(GlobalMemoryManager.Instance);
+            for (int i = 0; i < 100; i++)
+            {
+                original.Add(new Int64Value(i));
+            }
+
+            var sizeInfo = original.GetColumnSizeInfo();
+
+            using var preallocated = new Column(GlobalMemoryManager.Instance, sizeInfo);
+            for (int i = 0; i < 100; i++)
+            {
+                preallocated.Add(new Int64Value(i));
+            }
+
+            Assert.Equal(original.Count, preallocated.Count);
+            for (int i = 0; i < 100; i++)
+            {
+                Assert.Equal(original.GetValueAt(i, default).AsLong, preallocated.GetValueAt(i, default).AsLong);
+            }
+        }
+
+        [Fact]
+        public void RoundTripStringColumn()
+        {
+            using var original = new Column(GlobalMemoryManager.Instance);
+            for (int i = 0; i < 50; i++)
+            {
+                original.Add(new StringValue($"value_{i}"));
+            }
+
+            var sizeInfo = original.GetColumnSizeInfo();
+
+            using var preallocated = new Column(GlobalMemoryManager.Instance, sizeInfo);
+            for (int i = 0; i < 50; i++)
+            {
+                preallocated.Add(new StringValue($"value_{i}"));
+            }
+
+            Assert.Equal(original.Count, preallocated.Count);
+            for (int i = 0; i < 50; i++)
+            {
+                Assert.Equal(
+                    original.GetValueAt(i, default).AsString.ToString(),
+                    preallocated.GetValueAt(i, default).AsString.ToString());
+            }
+        }
+
+        [Fact]
+        public void RoundTripListColumn()
+        {
+            using var original = new Column(GlobalMemoryManager.Instance);
+            original.Add(new ListValue(new IDataValue[] { new Int64Value(1), new Int64Value(2) }));
+            original.Add(new ListValue(new IDataValue[] { new Int64Value(3) }));
+
+            var sizeInfo = original.GetColumnSizeInfo();
+
+            using var preallocated = new Column(GlobalMemoryManager.Instance, sizeInfo);
+            preallocated.Add(new ListValue(new IDataValue[] { new Int64Value(1), new Int64Value(2) }));
+            preallocated.Add(new ListValue(new IDataValue[] { new Int64Value(3) }));
+
+            Assert.Equal(2, preallocated.Count);
+        }
+
+        [Fact]
+        public void RoundTripMapColumn()
+        {
+            using var original = new Column(GlobalMemoryManager.Instance);
+            original.Add(new MapValue(
+                new List<KeyValuePair<IDataValue, IDataValue>>
+                {
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("k1"), new Int64Value(1)),
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("k2"), new Int64Value(2)),
+                }
+            ));
+
+            var sizeInfo = original.GetColumnSizeInfo();
+
+            using var preallocated = new Column(GlobalMemoryManager.Instance, sizeInfo);
+            preallocated.Add(new MapValue(
+                new List<KeyValuePair<IDataValue, IDataValue>>
+                {
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("k1"), new Int64Value(1)),
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("k2"), new Int64Value(2)),
+                }
+            ));
+
+            Assert.Single(preallocated);
+        }
+
+        [Fact]
+        public void RoundTripStructColumn()
+        {
+            var header = StructHeader.Create("x", "y");
+            using var original = new Column(GlobalMemoryManager.Instance);
+            original.Add(new StructValue(header, new IDataValue[] { new Int64Value(1), new StringValue("a") }));
+            original.Add(new StructValue(header, new IDataValue[] { new Int64Value(2), new StringValue("b") }));
+
+            var sizeInfo = original.GetColumnSizeInfo();
+
+            using var preallocated = new Column(GlobalMemoryManager.Instance, sizeInfo);
+            preallocated.Add(new StructValue(header, new IDataValue[] { new Int64Value(1), new StringValue("a") }));
+            preallocated.Add(new StructValue(header, new IDataValue[] { new Int64Value(2), new StringValue("b") }));
+
+            Assert.Equal(2, preallocated.Count);
+        }
+
+        [Fact]
+        public void MergeSizeInfosThenCreateColumn()
+        {
+            using var batch1 = new Column(GlobalMemoryManager.Instance);
+            for (int i = 0; i < 50; i++)
+            {
+                batch1.Add(new StringValue($"batch1_{i}"));
+            }
+
+            using var batch2 = new Column(GlobalMemoryManager.Instance);
+            for (int i = 0; i < 30; i++)
+            {
+                batch2.Add(new StringValue($"batch2_{i}"));
+            }
+
+            var info1 = batch1.GetColumnSizeInfo();
+            var info2 = batch2.GetColumnSizeInfo();
+
+            info1.Merge(info2);
+
+            Assert.Equal(80, info1.TotalRows);
+            Assert.True(info1.TotalVariableBytes > 0);
+
+            using var merged = new Column(GlobalMemoryManager.Instance, info1);
+
+            for (int i = 0; i < 50; i++)
+            {
+                merged.Add(new StringValue($"batch1_{i}"));
+            }
+            for (int i = 0; i < 30; i++)
+            {
+                merged.Add(new StringValue($"batch2_{i}"));
+            }
+
+            Assert.Equal(80, merged.Count);
+        }
+
+        [Fact]
+        public void MergeSizeInfosDifferentTypesThenCreateColumn()
+        {
+            using var batch1 = new Column(GlobalMemoryManager.Instance);
+            batch1.Add(new Int64Value(1));
+            batch1.Add(new Int64Value(2));
+
+            using var batch2 = new Column(GlobalMemoryManager.Instance);
+            batch2.Add(new StringValue("hello"));
+
+            var info1 = batch1.GetColumnSizeInfo();
+            var info2 = batch2.GetColumnSizeInfo();
+
+            info1.Merge(info2);
+
+            Assert.Equal(ArrowTypeId.Union, info1.DataType);
+            Assert.Equal(3, info1.TotalRows);
+
+            using var merged = new Column(GlobalMemoryManager.Instance, info1);
+            merged.Add(new Int64Value(1));
+            merged.Add(new StringValue("hello"));
+
+            Assert.Equal(2, merged.Count);
+        }
+
+        [Fact]
+        public void MergeMultipleBatchSizeInfosBitWidthGrows()
+        {
+            using var batch1 = new Column(GlobalMemoryManager.Instance);
+            for (int i = 0; i < 10; i++)
+            {
+                batch1.Add(new Int64Value(i));
+            }
+
+            using var batch2 = new Column(GlobalMemoryManager.Instance);
+            batch2.Add(new Int64Value(100_000));
+
+            var info1 = batch1.GetColumnSizeInfo();
+            var info2 = batch2.GetColumnSizeInfo();
+
+            info1.Merge(info2);
+
+            Assert.Equal(ArrowTypeId.Int64, info1.DataType);
+            Assert.Equal(11, info1.TotalRows);
+            Assert.True(info1.BitWidth >= info2.BitWidth);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoAddNullsToTypedColumn()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 50, BitWidth = 8 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new Int64Value(1));
+            column.Add(NullValue.Instance);
+            column.Add(new Int64Value(3));
+
+            Assert.Equal(3, column.Count);
+            Assert.Equal(1, column.GetValueAt(0, default).AsLong);
+            Assert.Equal(ArrowTypeId.Null, column.GetValueAt(1, default).Type);
+            Assert.Equal(3, column.GetValueAt(2, default).AsLong);
+        }
+
+        [Fact]
+        public void CreateFromSizeInfoTypePromotionToUnion()
+        {
+            var sizeInfo = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 50, BitWidth = 8 };
+            using var column = new Column(GlobalMemoryManager.Instance, sizeInfo);
+
+            column.Add(new Int64Value(1));
+            column.Add(new StringValue("hello"));
+
+            Assert.Equal(2, column.Count);
+            Assert.Equal(1, column.GetValueAt(0, default).AsLong);
+            Assert.Equal("hello", column.GetValueAt(1, default).AsString.ToString());
+        }
+
+        [Fact]
+        public void MergeListWithDifferentChildTypes()
+        {
+            var a = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.List,
+                TotalRows = 10,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 30, TotalVariableBytes = 500 }
+                }
+            };
+            var b = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.List,
+                TotalRows = 5,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 20, BitWidth = 32 }
+                }
+            };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.List, a.DataType);
+            Assert.Equal(15, a.TotalRows);
+            Assert.Single(a.Children!);
+            Assert.Equal(ArrowTypeId.Union, a.Children[0].DataType);
+            Assert.Equal(50, a.Children[0].TotalRows);
+        }
+
+        [Fact]
+        public void MergePromotesToUnionPreservesNestedChildren()
+        {
+            var header = StructHeader.Create("x", "y");
+            var a = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Struct,
+                StructHeader = header,
+                TotalRows = 10,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 10, BitWidth = 8 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 10, TotalVariableBytes = 200 },
+                }
+            };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Double, TotalRows = 5 };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(15, a.TotalRows);
+            Assert.Equal(2, a.Children!.Count);
+
+            var structChild = a.Children.First(c => c.DataType == ArrowTypeId.Struct);
+            Assert.Equal(header, structChild.StructHeader);
+            Assert.Equal(2, structChild.Children!.Count);
+            Assert.Equal(ArrowTypeId.Int64, structChild.Children[0].DataType);
+            Assert.Equal(ArrowTypeId.String, structChild.Children[1].DataType);
+        }
+
+        [Fact]
+        public void MergeChainOfThreeBatches()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 10, TotalVariableBytes = 100 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 20, TotalVariableBytes = 200 };
+            var c = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 30, TotalVariableBytes = 300 };
+
+            a.Merge(b);
+            a.Merge(c);
+
+            Assert.Equal(ArrowTypeId.String, a.DataType);
+            Assert.Equal(60, a.TotalRows);
+            Assert.Equal(600, a.TotalVariableBytes);
+        }
+
+        [Fact]
+        public void MergeChainWithTypeChange()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 10, BitWidth = 8 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 20, BitWidth = 32 };
+            var c = new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 5, TotalVariableBytes = 100 };
+            var d = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 15, BitWidth = 16 };
+
+            a.Merge(b);
+            a.Merge(c);
+            a.Merge(d);
+
+            Assert.Equal(ArrowTypeId.Union, a.DataType);
+            Assert.Equal(50, a.TotalRows);
+            Assert.Equal(2, a.Children!.Count);
+
+            var intChild = a.Children.First(x => x.DataType == ArrowTypeId.Int64);
+            Assert.Equal(45, intChild.TotalRows);
+            Assert.Equal(32, intChild.BitWidth);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromListOfStructs()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            var header = StructHeader.Create("name", "value");
+            column.Add(new ListValue(new IDataValue[]
+            {
+                new StructValue(header, new IDataValue[] { new StringValue("a"), new Int64Value(1) }),
+                new StructValue(header, new IDataValue[] { new StringValue("b"), new Int64Value(2) }),
+            }));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.List, info.DataType);
+            Assert.Equal(1, info.TotalRows);
+            Assert.Single(info.Children!);
+            Assert.Equal(ArrowTypeId.Struct, info.Children[0].DataType);
+            Assert.Equal(header, info.Children[0].StructHeader);
+            Assert.Equal(2, info.Children[0].Children!.Count);
+        }
+
+        [Fact]
+        public void GetSizeInfoFromMapWithListValues()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new MapValue(
+                new List<KeyValuePair<IDataValue, IDataValue>>
+                {
+                    new KeyValuePair<IDataValue, IDataValue>(
+                        new StringValue("k1"),
+                        new ListValue(new IDataValue[] { new Int64Value(1), new Int64Value(2) }))
+                }
+            ));
+
+            var info = column.GetColumnSizeInfo();
+
+            Assert.Equal(ArrowTypeId.Map, info.DataType);
+            Assert.Equal(2, info.Children!.Count);
+            Assert.Equal(ArrowTypeId.String, info.Children[0].DataType);
+            Assert.Equal(ArrowTypeId.List, info.Children[1].DataType);
+            Assert.Single(info.Children[1].Children!);
+        }
+
+        [Fact]
+        public void RoundTripUnionColumn()
+        {
+            using var original = new Column(GlobalMemoryManager.Instance);
+            original.Add(new Int64Value(1));
+            original.Add(new StringValue("hello"));
+            original.Add(NullValue.Instance);
+            original.Add(new Int64Value(2));
+
+            var sizeInfo = original.GetColumnSizeInfo();
+
+            using var preallocated = new Column(GlobalMemoryManager.Instance, sizeInfo);
+            preallocated.Add(new Int64Value(10));
+            preallocated.Add(new StringValue("world"));
+
+            Assert.Equal(2, preallocated.Count);
+            Assert.Equal(10, preallocated.GetValueAt(0, default).AsLong);
+            Assert.Equal("world", preallocated.GetValueAt(1, default).AsString.ToString());
+        }
+
+        [Fact]
+        public void MergeMapWithSameChildTypes()
+        {
+            var a = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Map,
+                TotalRows = 10,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 30, TotalVariableBytes = 500 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 30, BitWidth = 8 },
+                }
+            };
+            var b = new ColumnSizeInfo
+            {
+                DataType = ArrowTypeId.Map,
+                TotalRows = 5,
+                Children = new List<ColumnSizeInfo>
+                {
+                    new ColumnSizeInfo { DataType = ArrowTypeId.String, TotalRows = 15, TotalVariableBytes = 200 },
+                    new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 15, BitWidth = 32 },
+                }
+            };
+
+            a.Merge(b);
+
+            Assert.Equal(ArrowTypeId.Map, a.DataType);
+            Assert.Equal(15, a.TotalRows);
+            Assert.Equal(2, a.Children!.Count);
+            Assert.Equal(45, a.Children[0].TotalRows);
+            Assert.Equal(700, a.Children[0].TotalVariableBytes);
+            Assert.Equal(45, a.Children[1].TotalRows);
+            Assert.Equal(32, a.Children[1].BitWidth);
+        }
+
+        [Fact]
+        public void MergeBitWidthNotAppliedWhenOneSideIsZero()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 10, BitWidth = 32 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5, BitWidth = 0 };
+
+            a.Merge(b);
+
+            Assert.Equal(32, a.BitWidth);
+        }
+
+        [Fact]
+        public void MergeBitWidthNotAppliedWhenBothZero()
+        {
+            var a = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 10, BitWidth = 0 };
+            var b = new ColumnSizeInfo { DataType = ArrowTypeId.Int64, TotalRows = 5, BitWidth = 0 };
+
+            a.Merge(b);
+
+            Assert.Equal(0, a.BitWidth);
+        }
+    }
+}


### PR DESCRIPTION
This helps when merging batches together to reduce the amount realloc that happens.