### PR TITLE
Add bulk insert and bulk search with a new implementation of merge join with new methods

### DIFF
--- a/samples/SqlSampleWithUI/DummyReadOperator.cs
+++ b/samples/SqlSampleWithUI/DummyReadOperator.cs
@@ -77,7 +77,7 @@ namespace SqlSampleWithUI
         protected override async Task SendInitial(IngressOutput<StreamEventBatch> output)
         {
             
-            for (int i = 0; i < 10_000; i++)
+            for (int i = 0; i < 1_000_000; i++)
             {
                 await output.EnterCheckpointLock();
                 var memoryManager = MemoryAllocator;

--- a/samples/SqlSampleWithUI/Program.cs
+++ b/samples/SqlSampleWithUI/Program.cs
@@ -33,7 +33,7 @@ CREATE TABLE other (
 );
 
 INSERT INTO output
-SELECT map('a', t.val, 'b', o.val) as data FROM testtable t
+SELECT t.val, o.val FROM testtable t
 LEFT JOIN other o
 ON t.val = o.val;
 ";

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueContainer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueContainer.cs
@@ -44,6 +44,11 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             }
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _list.Dispose();

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueContainer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/DoubleValueContainer.cs
@@ -74,6 +74,11 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             _list.InsertAt(index, value);
         }
 
+        public void InsertFrom(double[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveAt(int index)
         {
             _list.RemoveAt(index);

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampComparer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampComparer.cs
@@ -29,6 +29,11 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             throw new NotImplementedException();
         }
 
+        public FindBoundriesResult FindBoundries(in long key, in TimestampKeyContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
+
         public int FindIndex(in long key, in TimestampKeyContainer keyContainer)
         {
             return keyContainer.BinarySearch(key, new LongComparer());

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeyContainer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeyContainer.cs
@@ -102,6 +102,11 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             _list.InsertAt(index, key);
         }
 
+        public void InsertFrom(long[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Insert_Internal(int index, long key)
         {
             _list.InsertAt(index, key);

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeyContainer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeyContainer.cs
@@ -77,6 +77,11 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             return ~lo;
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _list.Dispose();

--- a/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeyContainer.cs
+++ b/src/FlowtideDotNet.AspNetCore/Internal/TimeSeries/Storage/TimestampKeyContainer.cs
@@ -107,7 +107,7 @@ namespace FlowtideDotNet.AspNetCore.TimeSeries
             _list.InsertAt(index, key);
         }
 
-        public void InsertFrom(long[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(long[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/AlwaysNullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/AlwaysNullColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -173,7 +173,7 @@ namespace FlowtideDotNet.Core.ColumnStore
             throw new NotSupportedException();
         }
 
-        public void InsertFrom(IColumn column, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(IColumn column, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             throw new NotSupportedException();
         }
@@ -184,3 +184,4 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -1215,7 +1215,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                         if (_nullCounter > 0 && other._nullCounter > 0)
                         {
                             Debug.Assert(other._validityList != null);
-                            _validityList.InsertFrom(other._validityList, sortedLookup, insertPositions);
+                            _validityList.InsertFrom(in other._validityList!, in sortedLookup, in insertPositions, -1);
                             // Count new nulls from the inserted elements
                             for (int i = 0; i < count; i++)
                             {
@@ -1234,7 +1234,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                         {
                             Debug.Assert(other._validityList != null);
                             CheckNullInitialization();
-                            _validityList.InsertFrom(other._validityList, sortedLookup, insertPositions);
+                            _validityList.InsertFrom(in other._validityList!, in sortedLookup, in insertPositions, -1);
                             for (int i = 0; i < count; i++)
                             {
                                 if (!other._validityList.Get(sortedLookup[i]))
@@ -1290,7 +1290,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                             if (other._nullCounter > 0)
                             {
                                 Debug.Assert(other._validityList != null);
-                                _validityList.InsertFrom(other._validityList, sortedLookup, insertPositions);
+                                _validityList.InsertFrom(in other._validityList!, in sortedLookup, in insertPositions, -1);
                                 for (int i = 0; i < count; i++)
                                 {
                                     if (!other._validityList.Get(sortedLookup[i]))
@@ -1395,3 +1395,6 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -1183,7 +1183,7 @@ namespace FlowtideDotNet.Core.ColumnStore
             _dataColumn!.WriteDataToBuffer(ref dataWriter);
         }
 
-        public void InsertFrom(IColumn column, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(IColumn column, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             Debug.Assert(_validityList != null);
 
@@ -1204,50 +1204,63 @@ namespace FlowtideDotNet.Core.ColumnStore
                     {
                         Debug.Assert(_dataColumn != null);
                         Debug.Assert(other._dataColumn != null);
-                        _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, -1);
+                        _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, lookupNullIndex);
                         return;
                     }
 
                     // Same non-null, non-union type
                     // Handle validity list
-                    if (_nullCounter > 0 || other._nullCounter > 0)
+                    int incomingNullCount = 0;
+                    for (int i = 0; i < count; i++)
                     {
-                        if (_nullCounter > 0 && other._nullCounter > 0)
+                        var idx = sortedLookup[i];
+                        if (idx == lookupNullIndex)
                         {
-                            Debug.Assert(other._validityList != null);
-                            _validityList.InsertFrom(in other._validityList!, in sortedLookup, in insertPositions, -1);
-                            // Count new nulls from the inserted elements
-                            for (int i = 0; i < count; i++)
+                            incomingNullCount++;
+                        }
+                        else if (other._nullCounter > 0 && !other._validityList!.Get(idx))
+                        {
+                            incomingNullCount++;
+                        }
+                    }
+
+                    if (_nullCounter > 0 || incomingNullCount > 0)
+                    {
+                        if (_nullCounter == 0)
+                        {
+                            CheckNullInitialization();
+                        }
+
+                        if (incomingNullCount > 0)
+                        {
+                            if (other._nullCounter > 0)
                             {
-                                if (!other._validityList.Get(sortedLookup[i]))
+                                Debug.Assert(other._validityList != null);
+                                _validityList.InsertFrom(in other._validityList!, in sortedLookup, in insertPositions, lookupNullIndex);
+                            }
+                            else
+                            {
+                                _validityList.InsertConstantFrom(true, insertPositions);
+                                for (int i = 0; i < count; i++)
                                 {
-                                    _nullCounter++;
+                                    if (sortedLookup[i] == lookupNullIndex)
+                                    {
+                                        _validityList.Unset(insertPositions[i] + i);
+                                    }
                                 }
                             }
+                            _nullCounter += incomingNullCount;
                         }
-                        else if (_nullCounter > 0)
+                        else
                         {
                             // This has nulls, other doesn't — insert all as valid
                             _validityList.InsertConstantFrom(true, insertPositions);
-                        }
-                        else // other has nulls, this doesn't
-                        {
-                            Debug.Assert(other._validityList != null);
-                            CheckNullInitialization();
-                            _validityList.InsertFrom(in other._validityList!, in sortedLookup, in insertPositions, -1);
-                            for (int i = 0; i < count; i++)
-                            {
-                                if (!other._validityList.Get(sortedLookup[i]))
-                                {
-                                    _nullCounter++;
-                                }
-                            }
                         }
                     }
 
                     Debug.Assert(_dataColumn != null);
                     Debug.Assert(other._dataColumn != null);
-                    _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, -1);
+                    _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, lookupNullIndex);
                 }
                 else
                 {
@@ -1285,19 +1298,41 @@ namespace FlowtideDotNet.Core.ColumnStore
                         }
 
                         // Handle validity bitmap for the inserted elements
-                        if (other._nullCounter > 0 || _nullCounter > 0)
+                        int incomingNullCount = 0;
+                        for (int i = 0; i < count; i++)
                         {
-                            if (other._nullCounter > 0)
+                            var idx = sortedLookup[i];
+                            if (idx == lookupNullIndex)
                             {
-                                Debug.Assert(other._validityList != null);
-                                _validityList.InsertFrom(in other._validityList!, in sortedLookup, in insertPositions, -1);
-                                for (int i = 0; i < count; i++)
+                                incomingNullCount++;
+                            }
+                            else if (other._nullCounter > 0 && !other._validityList!.Get(idx))
+                            {
+                                incomingNullCount++;
+                            }
+                        }
+
+                        if (incomingNullCount > 0 || _nullCounter > 0)
+                        {
+                            if (incomingNullCount > 0)
+                            {
+                                if (other._nullCounter > 0)
                                 {
-                                    if (!other._validityList.Get(sortedLookup[i]))
+                                    Debug.Assert(other._validityList != null);
+                                    _validityList.InsertFrom(in other._validityList!, in sortedLookup, in insertPositions, lookupNullIndex);
+                                }
+                                else
+                                {
+                                    _validityList.InsertConstantFrom(true, insertPositions);
+                                    for (int i = 0; i < count; i++)
                                     {
-                                        _nullCounter++;
+                                        if (sortedLookup[i] == lookupNullIndex)
+                                        {
+                                            _validityList.Unset(insertPositions[i] + i);
+                                        }
                                     }
                                 }
+                                _nullCounter += incomingNullCount;
                             }
                             else
                             {
@@ -1352,7 +1387,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                     }
                     else
                     {
-                        _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, -1);
+                        _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, lookupNullIndex);
                     }
                 }
             }
@@ -1395,6 +1430,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
 
 
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -1204,7 +1204,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                     {
                         Debug.Assert(_dataColumn != null);
                         Debug.Assert(other._dataColumn != null);
-                        _dataColumn.InsertFrom(other._dataColumn, sortedLookup, insertPositions);
+                        _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, -1);
                         return;
                     }
 
@@ -1247,7 +1247,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
                     Debug.Assert(_dataColumn != null);
                     Debug.Assert(other._dataColumn != null);
-                    _dataColumn.InsertFrom(other._dataColumn, sortedLookup, insertPositions);
+                    _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, -1);
                 }
                 else
                 {
@@ -1352,7 +1352,7 @@ namespace FlowtideDotNet.Core.ColumnStore
                     }
                     else
                     {
-                        _dataColumn.InsertFrom(other._dataColumn, sortedLookup, insertPositions);
+                        _dataColumn.InsertFrom(in other._dataColumn, in sortedLookup, in insertPositions, -1);
                     }
                 }
             }
@@ -1395,6 +1395,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
 
 
 

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -52,6 +52,10 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         StructHeader? IColumn.StructHeader => innerColumn.StructHeader;
 
+        public PrimitiveList<int> Offsets => offsets;
+
+        public IColumn InnerColumn => innerColumn;
+
         public void Add<T>(in T value) where T : IDataValue
         {
             throw new NotSupportedException("Column with offset does not support add.");

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -272,7 +272,7 @@ namespace FlowtideDotNet.Core.ColumnStore
             return new ColumnWithOffset(column, offsets, includeNullValueAtEnd);
         }
 
-        public void InsertFrom(IColumn column, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(IColumn column, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             throw new NotSupportedException("Column with offset does not support InsertFrom.");
         }
@@ -283,3 +283,4 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -275,7 +275,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             if (other is BinaryColumn binaryColumn)
             {
-                _data.InsertFrom(binaryColumn._data, sortedLookup, insertPositions, -1);
+                _data.InsertFrom(in binaryColumn._data, in sortedLookup, in insertPositions, -1);
             }
             else
             {
@@ -289,3 +289,5 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -271,11 +271,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataWriter.WriteArrowBuffer(_data.DataMemory.Span);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is BinaryColumn binaryColumn)
             {
-                _data.InsertFrom(in binaryColumn._data, in sortedLookup, in insertPositions, -1);
+                _data.InsertFrom(in binaryColumn._data, in sortedLookup, in insertPositions, lookupNullIndex);
             }
             else
             {
@@ -289,5 +289,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+
 
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -275,7 +275,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             if (other is BinaryColumn binaryColumn)
             {
-                _data.InsertFrom(binaryColumn._data, sortedLookup, insertPositions);
+                _data.InsertFrom(binaryColumn._data, sortedLookup, insertPositions, -1);
             }
             else
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -304,7 +304,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             if (other is BoolColumn boolColumn)
             {
-                _data.InsertFrom(boolColumn._data, sortedLookup, insertPositions);
+                _data.InsertFrom(in boolColumn._data, in sortedLookup, in insertPositions, -1);
             }
             else
             {
@@ -318,3 +318,6 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -300,11 +300,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataWriter.WriteArrowBuffer(_data.MemorySlice.Span);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is BoolColumn boolColumn)
             {
-                _data.InsertFrom(in boolColumn._data, in sortedLookup, in insertPositions, -1);
+                _data.InsertFrom(in boolColumn._data, in sortedLookup, in insertPositions, lookupNullIndex);
             }
             else
             {
@@ -318,6 +318,8 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+
 
 
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -281,7 +281,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             if (other is DecimalColumn decimalColumn)
             {
-                _values.InsertFrom(decimalColumn._values, sortedLookup, insertPositions);
+                _values.InsertFrom(in decimalColumn._values, in sortedLookup, in insertPositions, -1);
             }
             else
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -277,11 +277,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataWriter.WriteArrowBuffer(_values.SlicedMemory.Span);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is DecimalColumn decimalColumn)
             {
-                _values.InsertFrom(in decimalColumn._values, in sortedLookup, in insertPositions, -1);
+                _values.InsertFrom(in decimalColumn._values, in sortedLookup, in insertPositions, lookupNullIndex);
             }
             else
             {
@@ -295,3 +295,5 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -271,11 +271,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataWriter.WriteArrowBuffer(_data.SlicedMemory.Span);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is DoubleColumn doubleColumn)
             {
-                _data.InsertFrom(in doubleColumn._data, in sortedLookup, in insertPositions, -1);
+                _data.InsertFrom(in doubleColumn._data, in sortedLookup, in insertPositions, lookupNullIndex);
             }
             else
             {
@@ -289,5 +289,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+
 
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -275,7 +275,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             if (other is DoubleColumn doubleColumn)
             {
-                _data.InsertFrom(doubleColumn._data, sortedLookup, insertPositions);
+                _data.InsertFrom(in doubleColumn._data, sortedLookup, insertPositions, -1);
             }
             else
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -275,7 +275,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             if (other is DoubleColumn doubleColumn)
             {
-                _data.InsertFrom(in doubleColumn._data, sortedLookup, insertPositions, -1);
+                _data.InsertFrom(in doubleColumn._data, in sortedLookup, in insertPositions, -1);
             }
             else
             {
@@ -289,3 +289,5 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
@@ -100,7 +100,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         /// </summary>
         StructHeader StructHeader { get; }
 
-        void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions);
+        void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex);
 
         void DeleteBatch(ReadOnlySpan<int> targets);
     }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -337,7 +337,7 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataWriter.WriteArrowBuffer(_data.SlicedMemory.Span);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             // Int64 column is not in use right now
             throw new NotImplementedException();
@@ -350,3 +350,4 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -74,7 +74,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
             (IArrowArray, IArrowType) ToArrowArray(ArrowBuffer nullBuffer, int nullCount);
 
-            void InsertFrom(IIntData other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions);
+            void InsertFrom(IIntData other, in ReadOnlySpan<int> sortedLookup, in ReadOnlySpan<int> targetPositions, in int lookupNullIndex);
 
             void DeleteBatch(ReadOnlySpan<int> targets);
         }
@@ -212,11 +212,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 return index;
             }
 
-            public void InsertFrom(IIntData other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+            public void InsertFrom(IIntData other, in ReadOnlySpan<int> sortedLookup, in ReadOnlySpan<int> targetPositions, in int lookupNullIndex)
             {
                 if (other is Int8Data int8data)
                 {
-                    _list.InsertFrom(in int8data._list, in sortedLookup, in targetPositions, -1);
+                    _list.InsertFrom(in int8data._list, in sortedLookup, in targetPositions, lookupNullIndex);
                     return;
                 }
                 throw new NotImplementedException();
@@ -361,11 +361,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 return (new Int16Array(valueBuffer, nullBuffer, _list.Count, nullCount, 0), Int16Type.Default);
             }
 
-            public void InsertFrom(IIntData other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+            public void InsertFrom(IIntData other, in ReadOnlySpan<int> sortedLookup, in ReadOnlySpan<int> targetPositions, in int lookupNullIndex)
             {
                 if (other is Int16Data int16Data)
                 {
-                    _list.InsertFrom(in int16Data._list, in sortedLookup, in targetPositions, -1);
+                    _list.InsertFrom(in int16Data._list, in sortedLookup, in targetPositions, lookupNullIndex);
                     return;
                 }
                 throw new NotImplementedException();
@@ -511,11 +511,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 return (new Int32Array(valueBuffer, nullBuffer, _list.Count, nullCount, 0), Int32Type.Default);
             }
 
-            public void InsertFrom(IIntData other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+            public void InsertFrom(IIntData other, in ReadOnlySpan<int> sortedLookup, in ReadOnlySpan<int> targetPositions, in int lookupNullIndex)
             {
                 if (other is Int32Data int32Data)
                 {
-                    _list.InsertFrom(in int32Data._list, in sortedLookup, in targetPositions, -1);
+                    _list.InsertFrom(in int32Data._list, in sortedLookup, in targetPositions, lookupNullIndex);
                     return;
                 }
                 throw new NotImplementedException();
@@ -660,11 +660,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 return (new Int64Array(valueBuffer, nullBuffer, _list.Count, nullCount, 0), Int64Type.Default);
             }
 
-            public void InsertFrom(IIntData other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+            public void InsertFrom(IIntData other, in ReadOnlySpan<int> sortedLookup, in ReadOnlySpan<int> targetPositions, in int lookupNullIndex)
             {
                 if (other is Int64Data int64Data)
                 {
-                    _list.InsertFrom(in int64Data._list, in sortedLookup, in targetPositions, -1);
+                    _list.InsertFrom(in int64Data._list, in sortedLookup, in targetPositions, lookupNullIndex);
                     return;
                 }
                 throw new NotImplementedException();
@@ -1064,7 +1064,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             hashAlgorithm.Append(buffer);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is IntegerColumn integerColumn)
             {
@@ -1088,7 +1088,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                         return;
                     }
                 }
-                _data.InsertFrom(integerColumn._data, sortedLookup, insertPositions);
+                _data.InsertFrom(integerColumn._data, in sortedLookup, in insertPositions, lookupNullIndex);
                 return;
             }
             throw new NotImplementedException();
@@ -1103,3 +1103,5 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -216,7 +216,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             {
                 if (other is Int8Data int8data)
                 {
-                    _list.InsertFrom(int8data._list, sortedLookup, targetPositions);
+                    _list.InsertFrom(in int8data._list, in sortedLookup, in targetPositions, -1);
                     return;
                 }
                 throw new NotImplementedException();
@@ -365,7 +365,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             {
                 if (other is Int16Data int16Data)
                 {
-                    _list.InsertFrom(int16Data._list, sortedLookup, targetPositions);
+                    _list.InsertFrom(in int16Data._list, in sortedLookup, in targetPositions, -1);
                     return;
                 }
                 throw new NotImplementedException();
@@ -515,7 +515,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             {
                 if (other is Int32Data int32Data)
                 {
-                    _list.InsertFrom(int32Data._list, sortedLookup, targetPositions);
+                    _list.InsertFrom(in int32Data._list, in sortedLookup, in targetPositions, -1);
                     return;
                 }
                 throw new NotImplementedException();
@@ -664,7 +664,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             {
                 if (other is Int64Data int64Data)
                 {
-                    _list.InsertFrom(int64Data._list, sortedLookup, targetPositions);
+                    _list.InsertFrom(in int64Data._list, in sortedLookup, in targetPositions, -1);
                     return;
                 }
                 throw new NotImplementedException();
@@ -894,16 +894,8 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
         public IDataValue GetValueAt(in int index, in ReferenceSegment? child)
         {
-            try
-            {
-                Debug.Assert(_data != null);
-                return new Int64Value(_data.Get(index));
-            }
-            catch(Exception e)
-            {
-                throw;
-            }
-            
+            Debug.Assert(_data != null);
+            return new Int64Value(_data.Get(index));
         }
 
         public void GetValueAt(in int index, in DataValueContainer dataValueContainer, in ReferenceSegment? child)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -450,7 +450,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 _list.InsertStaticRange(index, 0, count);
             }
 
-            public (int, int) SearchBoundries(in long dataValue, in int start, in int end, in ReferenceSegment? child, bool desc)
+            public unsafe (int, int) SearchBoundries(in long dataValue, in int start, in int end, in ReferenceSegment? child, bool desc)
             {
                 if (desc)
                 {
@@ -476,7 +476,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                         var index = ~(end + 1);
                         return (index, index);
                     }
-                    return BoundarySearch.SearchBoundries(_list, (int)dataValue, start, end, Int32Comparer.Instance);
+                    return BoundarySearch.SearchBoundriesAsc(_list.GetPointer_Unsafe(), (int)dataValue, start, in end);
                 }
             }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -894,8 +894,16 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 
         public IDataValue GetValueAt(in int index, in ReferenceSegment? child)
         {
-            Debug.Assert(_data != null);
-            return new Int64Value(_data.Get(index));
+            try
+            {
+                Debug.Assert(_data != null);
+                return new Int64Value(_data.Get(index));
+            }
+            catch(Exception e)
+            {
+                throw;
+            }
+            
         }
 
         public void GetValueAt(in int index, in DataValueContainer dataValueContainer, in ReferenceSegment? child)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
@@ -555,15 +555,22 @@ namespace FlowtideDotNet.Core.ColumnStore
             _internalColumn.WriteDataToBuffer(ref dataWriter);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is ListColumn otherList)
             {
                 for (int i = sortedLookup.Length - 1; i >= 0; i--)
                 {
                     int oIdx = sortedLookup[i];
-                    var value = otherList.GetValueAt(oIdx, default);
-                    InsertAt(insertPositions[i], value);
+                    if (oIdx == lookupNullIndex)
+                    {
+                        InsertAt(insertPositions[i], NullValue.Instance);
+                    }
+                    else
+                    {
+                        var value = otherList.GetValueAt(oIdx, default);
+                        InsertAt(insertPositions[i], value);
+                    }
                 }
                 return;
             }
@@ -579,3 +586,5 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -698,15 +698,22 @@ namespace FlowtideDotNet.Core.ColumnStore
             _valueColumn.WriteDataToBuffer(ref dataWriter);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is MapColumn otherMap)
             {
                 for (int i = sortedLookup.Length - 1; i >= 0; i--)
                 {
                     int oIdx = sortedLookup[i];
-                    var value = otherMap.GetValueAt(oIdx, default);
-                    InsertAt(insertPositions[i], value);
+                    if (oIdx == lookupNullIndex)
+                    {
+                        InsertAt(insertPositions[i], NullValue.Instance);
+                    }
+                    else
+                    {
+                        var value = otherMap.GetValueAt(oIdx, default);
+                        InsertAt(insertPositions[i], value);
+                    }
                 }
                 return;
             }
@@ -722,3 +729,5 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -181,7 +181,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             _count += sortedLookup.Length;
         }
@@ -192,3 +192,4 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         }
     }
 }
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -288,7 +288,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             if (other is StringColumn stringColumn)
             {
-                _binaryList.InsertFrom(stringColumn._binaryList, sortedLookup, insertPositions, -1);
+                _binaryList.InsertFrom(in stringColumn._binaryList, in sortedLookup, in insertPositions, -1);
             }
             else
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -288,7 +288,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             if (other is StringColumn stringColumn)
             {
-                _binaryList.InsertFrom(stringColumn._binaryList, sortedLookup, insertPositions);
+                _binaryList.InsertFrom(stringColumn._binaryList, sortedLookup, insertPositions, -1);
             }
             else
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -284,11 +284,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             dataWriter.WriteArrowBuffer(_binaryList.DataMemory.Span);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is StringColumn stringColumn)
             {
-                _binaryList.InsertFrom(in stringColumn._binaryList, in sortedLookup, in insertPositions, -1);
+                _binaryList.InsertFrom(in stringColumn._binaryList, in sortedLookup, in insertPositions, lookupNullIndex);
             }
             else
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
@@ -592,15 +592,22 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             }
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is StructColumn otherStruct)
             {
                 for (int i = sortedLookup.Length - 1; i >= 0; i--)
                 {
                     int oIdx = sortedLookup[i];
-                    var value = otherStruct.GetValueAt(oIdx, default);
-                    InsertAt(insertPositions[i], value);
+                    if (oIdx == lookupNullIndex)
+                    {
+                        InsertAt(insertPositions[i], NullValue.Instance);
+                    }
+                    else
+                    {
+                        var value = otherStruct.GetValueAt(oIdx, default);
+                        InsertAt(insertPositions[i], value);
+                    }
                 }
                 return;
             }
@@ -616,3 +623,5 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
@@ -293,7 +293,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
             if (other is TimestampTzColumn timestampColumn)
             {
-                _values.InsertFrom(in timestampColumn._values, sortedLookup, insertPositions, -1);
+                _values.InsertFrom(in timestampColumn._values, in sortedLookup, in insertPositions, -1);
             }
             else
             {
@@ -307,3 +307,5 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -293,7 +293,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
             if (other is TimestampTzColumn timestampColumn)
             {
-                _values.InsertFrom(timestampColumn._values, sortedLookup, insertPositions);
+                _values.InsertFrom(in timestampColumn._values, sortedLookup, insertPositions, -1);
             }
             else
             {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
@@ -289,11 +289,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             dataWriter.WriteArrowBuffer(_values.SlicedMemory.Span);
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             if (other is TimestampTzColumn timestampColumn)
             {
-                _values.InsertFrom(in timestampColumn._values, in sortedLookup, in insertPositions, -1);
+                _values.InsertFrom(in timestampColumn._values, in sortedLookup, in insertPositions, lookupNullIndex);
             }
             else
             {
@@ -307,5 +307,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         }
     }
 }
+
+
 
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -926,13 +926,20 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             }
         }
 
-        public void InsertFrom(IDataColumn other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(in IDataColumn other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             for (int i = sortedLookup.Length - 1; i >= 0; i--)
             {
                 int oIdx = sortedLookup[i];
-                var value = other.GetValueAt(oIdx, default);
-                InsertAt(insertPositions[i], value);
+                if (oIdx == lookupNullIndex)
+                {
+                    InsertAt(insertPositions[i], NullValue.Instance);
+                }
+                else
+                {
+                    var value = other.GetValueAt(oIdx, default);
+                    InsertAt(insertPositions[i], value);
+                }
             }
         }
 
@@ -945,3 +952,5 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         }
     }
 }
+
+

--- a/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -87,8 +87,9 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         void AddToHash(in int index, ReferenceSegment? child, NonCryptographicHashAlgorithm hashAlgorithm);
 
-        void InsertFrom(IColumn column, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions);
+        void InsertFrom(IColumn column, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex);
 
         void DeleteBatch(ReadOnlySpan<int> targets);
     }
 }
+

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/BoundarySearch.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/BoundarySearch.cs
@@ -669,5 +669,50 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
 
             return (lowerbound, upperbound);
         }
+
+        public unsafe static (int, int) SearchBoundriesAsc(in int* list, in int value, int start, in int end)
+        {
+            if (end < start)
+            {
+                return (~start, ~start);
+            }
+            var arr = list + start;
+            var size = end - start + 1;
+            while (size > 2)
+            {
+                var middle = size >> 1;
+                size = (size + 1) >> 1;
+                // Hack since cmov is not available so far from what has been benchmarked.
+                // Clt returns 0 or 1, so we can multiply by the result to get the correct index.
+                arr += (middle * UnsafeEx.Clt(arr[middle], value));
+            }
+
+            arr += UnsafeEx.Cgt(size, 1) & UnsafeEx.Clt(*arr, value);
+            arr += UnsafeEx.Cgt(size, 0) & UnsafeEx.Clt(*arr, value);
+
+            start = (int)(arr - list);
+            int lowIndex = start;
+            if (start > end || *arr != value)
+            {
+                return (~start, ~start);
+            }
+
+            if (start == end || arr[1] != value)
+            {
+                return (start, start);
+            }
+
+            size = end - start + 1;
+            while (size > 2)
+            {
+                var middle = size >> 1;
+                size = (size + 1) >> 1;
+                arr += middle * UnsafeEx.Cle(arr[middle], value);
+            }
+            arr += UnsafeEx.Cgt(size, 1) & UnsafeEx.Cle(*arr, value);
+            arr += UnsafeEx.Cgt(size, 0) & UnsafeEx.Cle(*arr, value);
+
+            return (lowIndex, (int)(arr - list) - 1);
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnComparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnComparer.cs
@@ -69,5 +69,10 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             }
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -166,19 +166,9 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             {
                 var column = _data.Columns[i];
                 var sourceColumn = batchReference.Columns[i];
-
-                //column.InsertFrom(sourceColumn, sortedLookup, targetPositions);
-
-                //for (int j = 0; j < sortedLookup.Length; j++)
-                //{
-                //    int sourceIndex = sortedLookup[j];
-                //    int targetIndex = targetPositions[j];
-                //    sourceColumn.GetValueAt(sourceIndex, _dataValueContainer, default);
-                //    column.InsertAt(targetIndex, _dataValueContainer);
-                //}
+                column.InsertFrom(sourceColumn, sortedLookup, targetPositions);
             }
-
-            throw new NotImplementedException();
+            _count += sortedLookup.Length;
         }
 
         public void DeleteBatch(ReadOnlySpan<int> positions)

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -192,6 +192,7 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
                 var column = _data.Columns[i];
                 column.DeleteBatch(positions);
             }
+            _count -= positions.Length;
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -175,11 +175,12 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
                         var key = keys[sortedLookup[j]];
                         lookupBuffer[j] = offsets[key.RowIndex];
                     }
-                    column.InsertFrom(columnWithOffset.InnerColumn, lookupBuffer, targetPositions);
+                    ReadOnlySpan<int> lb = lookupBuffer; 
+                    column.InsertFrom(columnWithOffset.InnerColumn, in lb, in targetPositions, -1);
                 }
                 else
                 {
-                    column.InsertFrom(sourceColumn, sortedLookup, targetPositions);
+                    column.InsertFrom(sourceColumn, in sortedLookup, in targetPositions, -1);
                 }
             }
             _count += sortedLookup.Length;
@@ -196,3 +197,4 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
         }
     }
 }
+

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -155,5 +155,10 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
         {
             return _data.GetByteSize(start, end);
         }
+
+        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -156,7 +156,7 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             return _data.GetByteSize(start, end);
         }
 
-        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             // All columnrowref should come from the same batch, so we can optimize by only looking at the first one to get the batch reference.
 
@@ -166,7 +166,21 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             {
                 var column = _data.Columns[i];
                 var sourceColumn = batchReference.Columns[i];
-                column.InsertFrom(sourceColumn, sortedLookup, targetPositions);
+
+                if ( sourceColumn is ColumnWithOffset columnWithOffset)
+                {
+                    var offsets = columnWithOffset.Offsets;
+                    for (int j = 0; j < sortedLookup.Length; j++)
+                    {
+                        var key = keys[sortedLookup[j]];
+                        lookupBuffer[j] = offsets[key.RowIndex];
+                    }
+                    column.InsertFrom(columnWithOffset.InnerColumn, lookupBuffer, targetPositions);
+                }
+                else
+                {
+                    column.InsertFrom(sourceColumn, sortedLookup, targetPositions);
+                }
             }
             _count += sortedLookup.Length;
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -160,5 +160,10 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -158,6 +158,26 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
 
         public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
         {
+            // All columnrowref should come from the same batch, so we can optimize by only looking at the first one to get the batch reference.
+
+            var batchReference = keys[0].referenceBatch;
+
+            for (int i = 0; i < _data.Columns.Count; i++)
+            {
+                var column = _data.Columns[i];
+                var sourceColumn = batchReference.Columns[i];
+
+                //column.InsertFrom(sourceColumn, sortedLookup, targetPositions);
+
+                //for (int j = 0; j < sortedLookup.Length; j++)
+                //{
+                //    int sourceIndex = sortedLookup[j];
+                //    int targetIndex = targetPositions[j];
+                //    sourceColumn.GetValueAt(sourceIndex, _dataValueContainer, default);
+                //    column.InsertAt(targetIndex, _dataValueContainer);
+                //}
+            }
+
             throw new NotImplementedException();
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -173,7 +173,11 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
 
         public void DeleteBatch(ReadOnlySpan<int> positions)
         {
-            throw new NotImplementedException();
+            for (int i = 0; i < _data.Columns.Count; i++)
+            {
+                var column = _data.Columns[i];
+                column.DeleteBatch(positions);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnKeyStorageContainer.cs
@@ -176,7 +176,7 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
                         lookupBuffer[j] = offsets[key.RowIndex];
                     }
                     ReadOnlySpan<int> lb = lookupBuffer; 
-                    column.InsertFrom(columnWithOffset.InnerColumn, in lb, in targetPositions, -1);
+                    column.InsertFrom(columnWithOffset.InnerColumn, in lb, in targetPositions, columnWithOffset.InnerColumn.Count);
                 }
                 else
                 {

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnValueStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnValueStorageContainer.cs
@@ -63,6 +63,11 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             }
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _data.Dispose();

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnValueStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnValueStorageContainer.cs
@@ -100,6 +100,11 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             }
         }
 
+        public void InsertFrom(ColumnRowReference[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveAt(int index)
         {
             for (int i = 0; i < columnCount; i++)

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/DataValueValueContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/DataValueValueContainer.cs
@@ -78,6 +78,11 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             _column.InsertAt(index, value);
         }
 
+        public void InsertFrom(IDataValue[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveAt(int index)
         {
             _column.RemoveAt(index);

--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/DataValueValueContainer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/DataValueValueContainer.cs
@@ -48,6 +48,11 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             }
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _column.Dispose();

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
@@ -374,7 +374,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
         /// <param name="other">The other binary list to insert data from.</param>
         /// <param name="sortedLookup">A span containing the sorted indices of the elements to insert from the other list.</param>
         /// <param name="insertPositions">A span containing the positions at which to insert the elements in the current list.</param>
-        public void InsertFrom(BinaryList other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(ref readonly BinaryList other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             Debug.Assert(sortedLookup.Length == insertPositions.Length);
             int otherCount = sortedLookup.Length;
@@ -385,7 +385,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             for (int i = 0; i < otherCount; i++)
             {
                 int oIdx = sortedLookup[i];
-                totalNewBytes += other._offsets.Get(oIdx + 1) - other._offsets.Get(oIdx);
+                if (oIdx != lookupNullIndex)
+                {
+                    totalNewBytes += other._offsets.Get(oIdx + 1) - other._offsets.Get(oIdx);
+                }
             }
 
 
@@ -429,13 +432,18 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
                 }
 
                 int oIdx = sortedLookup[i];
-                int oStart = other._offsets.Get(oIdx);
-                int oEnd = other._offsets.Get(oIdx + 1);
-                int oSize = oEnd - oStart;
+                int oSize = 0;
+                
+                if (oIdx != lookupNullIndex)
+                {
+                    int oStart = other._offsets.Get(oIdx);
+                    int oEnd = other._offsets.Get(oIdx + 1);
+                    oSize = oEnd - oStart;
 
-                // Copy the data
-                currentWriteDataPtr -= oSize;
-                otherData.Slice(oStart, oSize).CopyTo(selfData.Slice(currentWriteDataPtr));
+                    // Copy the data
+                    currentWriteDataPtr -= oSize;
+                    otherData.Slice(oStart, oSize).CopyTo(selfData.Slice(currentWriteDataPtr));
+                }
 
                 // Update the running delta
                 runningByteDelta -= oSize;

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/UnsafeEx.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/UnsafeEx.cs
@@ -34,7 +34,31 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Cle(int first, int second)
+        {
+            Ldarg_0();
+            Ldarg_1();
+            IL.Emit.Cgt();
+            IL.Emit.Ldc_I4_0();
+            IL.Emit.Ceq();
+            Ret();
+            throw IL.Unreachable();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Clt(long first, long second)
+        {
+            Ldarg_0();
+            Ldarg_1();
+            IL.Emit.Clt();
+            Ret();
+            throw IL.Unreachable();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Clt(int first, int second)
         {
             Ldarg_0();
             Ldarg_1();
@@ -68,6 +92,19 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
         [EditorBrowsable(EditorBrowsableState.Never)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Cge(long first, long second)
+        {
+            Ldarg_0();
+            Ldarg_1();
+            IL.Emit.Clt();
+            IL.Emit.Ldc_I4_0();
+            IL.Emit.Ceq();
+            Ret();
+            throw IL.Unreachable();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Cge(int first, int second)
         {
             Ldarg_0();
             Ldarg_1();

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggInsertComparer.cs
@@ -64,5 +64,10 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.Li
 
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
@@ -74,6 +74,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             throw new NotImplementedException();
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _data.Dispose();

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
@@ -110,6 +110,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             _data.Columns[_groupingKeyLength].InsertAt(index, key.insertValue);
         }
 
+        public void InsertFrom(ListAggColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Insert_Internal(int index, ListAggColumnRowReference key)
         {
             for (int i = 0; i < (_groupingKeyLength + 1); i++)

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggKeyStorageContainer.cs
@@ -115,7 +115,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             _data.Columns[_groupingKeyLength].InsertAt(index, key.insertValue);
         }
 
-        public void InsertFrom(ListAggColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(ListAggColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/ListAgg/ListAggSearchComparer.cs
@@ -41,6 +41,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations
             throw new NotImplementedException();
         }
 
+        public FindBoundriesResult FindBoundries(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
+
         public int FindIndex(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer)
         {
             int index = -1;

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MaxInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MaxInsertComparer.cs
@@ -64,5 +64,10 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.Mi
 
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MaxSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MaxSearchComparer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.Tree;
 
 namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax
 {
@@ -37,6 +38,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.Mi
         }
 
         public int CompareTo(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, in int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FindBoundriesResult FindBoundries(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, int startIndex, int length)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinInsertComparer.cs
@@ -64,5 +64,10 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.Mi
 
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinMaxByValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinMaxByValueContainer.cs
@@ -96,6 +96,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.Mi
             _weights.InsertAt(index, value.Weight);
         }
 
+        public void InsertFrom(MinMaxByValue[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveAt(int index)
         {
             _data.RemoveAt(index);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinMaxByValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinMaxByValueContainer.cs
@@ -60,6 +60,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.Mi
             }
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _data.Dispose();

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/StatefulAggregations/MinMax/MinSearchComparer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.Tree;
 
 namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.MinMax
 {
@@ -37,6 +38,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.StatefulAggregations.Mi
         }
 
         public int CompareTo(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, in int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FindBoundriesResult FindBoundries(in ListAggColumnRowReference key, in ListAggKeyStorageContainer keyContainer, int startIndex, int length)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByIndexValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByIndexValueContainer.cs
@@ -132,5 +132,10 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.MinMax
             _compareData.UpdateAt(index, value.CompareValue);
             _indices.Update(index, value.Index);
         }
+
+        public void InsertFrom(MinMaxByIndexValue[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByIndexValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/MinMax/MinMaxByIndexValueContainer.cs
@@ -137,5 +137,10 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.MinMax
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyValueContainer.cs
@@ -54,6 +54,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.Surroga
             }
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _column.Dispose();

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/WindowFunctions/SurrogateKey/SurrogateKeyValueContainer.cs
@@ -90,6 +90,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.WindowFunctions.Surroga
             _weights.InsertAt(index, value.Weight);
         }
 
+        public void InsertFrom(SurrogateKeyValue[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveAt(int index)
         {
             _column.RemoveAt(index);

--- a/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
+++ b/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
@@ -295,7 +295,7 @@ namespace FlowtideDotNet.Core.Engine
                     MultipleInputVertex<StreamEventBatch> op;
                     if (_useColumnStore)
                     {
-                        op = new ColumnStoreMergeJoin(mergeJoinRelation, functionsRegister, DefaultBlockOptions);
+                        op = new ColumnBulkMergeJoin(mergeJoinRelation, functionsRegister, DefaultBlockOptions);
                     }
                     else
                     {
@@ -323,7 +323,7 @@ namespace FlowtideDotNet.Core.Engine
                 MultipleInputVertex<StreamEventBatch> op;
                 if (_useColumnStore)
                 {
-                    op = new ColumnStoreMergeJoin(mergeJoinRelation, functionsRegister, DefaultBlockOptions);
+                    op = new ColumnBulkMergeJoin(mergeJoinRelation, functionsRegister, DefaultBlockOptions);
                 }
                 else
                 {

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateInsertComparer.cs
@@ -70,5 +70,10 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             }
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in AggregateKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
@@ -119,7 +119,7 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             _length++;
         }
 
-        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
@@ -114,6 +114,11 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             _length++;
         }
 
+        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Insert_Internal(int index, ColumnRowReference key)
         {
             for (int i = 0; i < columnCount; i++)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateKeyStorageContainer.cs
@@ -79,6 +79,11 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             throw new NotImplementedException();
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _data.Dispose();

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/AggregateSearchComparer.cs
@@ -81,5 +81,10 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             }
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in AggregateKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
@@ -118,6 +118,11 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             _previousValueSent.InsertAt(index, value.valueSent);
         }
 
+        public void InsertFrom(ColumnAggregateStateReference[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveAt(int index)
         {
             for (int i = 0; i < columnCount; i++)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Column/ColumnAggregateValueContainer.cs
@@ -75,6 +75,11 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Column
             }
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _eventBatch.Dispose();

--- a/src/FlowtideDotNet.Core/Operators/Exchange/StreamEventValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Exchange/StreamEventValueContainer.cs
@@ -123,5 +123,10 @@ namespace FlowtideDotNet.Core.Operators.Exchange
         {
             _streamEvents[index] = value;
         }
+
+        public void InsertFrom(IStreamEvent[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Exchange/StreamEventValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Exchange/StreamEventValueContainer.cs
@@ -128,5 +128,10 @@ namespace FlowtideDotNet.Core.Operators.Exchange
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -1,0 +1,658 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Base.Metrics;
+using FlowtideDotNet.Base.Vertices;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Compute;
+using FlowtideDotNet.Core.Compute.Columnar;
+using FlowtideDotNet.Core.Utils;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Relations;
+using System.Diagnostics;
+using System.Threading.Tasks.Dataflow;
+
+namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
+{
+    internal struct JoinWeightsMutator : IRowMutator<ColumnRowReference, JoinWeights>
+    {
+        public GenericWriteOperation Process(ColumnRowReference key, bool exists, in JoinWeights existingData, ref JoinWeights incomingData)
+        {
+            if (exists)
+            {
+                incomingData.weight += existingData.weight;
+                incomingData.joinWeight += existingData.joinWeight;
+                if (incomingData.weight == 0)
+                {
+                    return GenericWriteOperation.Delete;
+                }
+                return GenericWriteOperation.Upsert;
+            }
+            return GenericWriteOperation.Upsert;
+        }
+    }
+
+    internal class ColumnBulkMergeJoin : MultipleInputVertex<StreamEventBatch>
+    {
+        protected IBPlusTree<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>? _leftTree;
+        protected IBPlusTree<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>? _rightTree;
+        private IBPlusTreeBulkInserter<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>? _leftInserter;
+        private IBPlusTreeBulkInserter<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>? _rightInserter;
+        private IBplusTreeBulkSearch<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer, MergeJoinSearchComparer>? _rightSearcher;
+        private IBplusTreeBulkSearch<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer, MergeJoinSearchComparer>? _leftSearcher;
+
+
+        private readonly MergeJoinRelation _mergeJoinRelation;
+        private readonly MergeJoinInsertComparer _leftInsertComparer;
+        private readonly MergeJoinInsertComparer _rightInsertComparer;
+        private readonly MergeJoinSearchComparer _searchLeftComparer;
+        private readonly MergeJoinSearchComparer _searchRightComparer;
+
+        private readonly List<int> _leftOutputColumns;
+        private readonly List<int> _rightOutputColumns;
+
+        private readonly List<int> _leftOutputIndices;
+        private readonly List<int> _rightOutputIndices;
+
+        // Metrics
+        private ICounter<long>? _eventsCounter;
+        private ICounter<long>? _eventsProcessed;
+
+        protected readonly Func<EventBatchData, int, EventBatchData, int, bool>? _postCondition;
+        private readonly DataValueContainer _dataValueContainer;
+
+        private const int MaxRowSize = 100;
+
+        public ColumnBulkMergeJoin(MergeJoinRelation mergeJoinRelation, FunctionsRegister functionsRegister, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(2, executionDataflowBlockOptions)
+        {
+            this._mergeJoinRelation = mergeJoinRelation;
+            _dataValueContainer = new DataValueContainer();
+            var leftColumns = GetCompareColumns(mergeJoinRelation.LeftKeys, 0);
+            var rightColumns = GetCompareColumns(mergeJoinRelation.RightKeys, mergeJoinRelation.Left.OutputLength);
+            _leftInsertComparer = new MergeJoinInsertComparer(leftColumns, mergeJoinRelation.Left.OutputLength);
+            _rightInsertComparer = new MergeJoinInsertComparer(rightColumns, mergeJoinRelation.Right.OutputLength);
+
+            _searchLeftComparer = new MergeJoinSearchComparer(leftColumns, rightColumns);
+            _searchRightComparer = new MergeJoinSearchComparer(rightColumns, leftColumns);
+
+            (_leftOutputColumns, _leftOutputIndices) = GetOutputColumns(mergeJoinRelation, 0, mergeJoinRelation.Left.OutputLength);
+            (_rightOutputColumns, _rightOutputIndices) = GetOutputColumns(mergeJoinRelation, mergeJoinRelation.Left.OutputLength, mergeJoinRelation.Right.OutputLength);
+
+            if (mergeJoinRelation.PostJoinFilter != null)
+            {
+                _postCondition = ColumnBooleanCompiler.CompileTwoInputs(mergeJoinRelation.PostJoinFilter, functionsRegister, mergeJoinRelation.Left.OutputLength);
+            }
+        }
+
+        private static (List<int> incomingIndices, List<int> outgoingIndex) GetOutputColumns(MergeJoinRelation mergeJoinRelation, int relative, int maxSize)
+        {
+            List<int> columns = new List<int>();
+            List<int> outgoingIndices = new List<int>();
+            if (mergeJoinRelation.EmitSet)
+            {
+                for (int i = 0; i < mergeJoinRelation.Emit.Count; i++)
+                {
+                    var index = mergeJoinRelation.Emit[i];
+                    if (index >= relative)
+                    {
+                        index = index - relative;
+                        if (index < maxSize)
+                        {
+                            columns.Add(index);
+                            outgoingIndices.Add(i);
+                        }
+                    }
+
+                }
+            }
+            else
+            {
+                for (int i = 0; i < mergeJoinRelation.OutputLength - relative; i++)
+                {
+                    if (i < maxSize)
+                    {
+                        columns.Add(i);
+                        outgoingIndices.Add(i + relative);
+                    }
+                }
+            }
+            return (columns, outgoingIndices);
+        }
+
+        private static List<KeyValuePair<int, ReferenceSegment?>> GetCompareColumns(List<FieldReference> fieldReferences, int relativeIndex)
+        {
+            List<KeyValuePair<int, ReferenceSegment?>> leftKeys = new List<KeyValuePair<int, ReferenceSegment?>>();
+            for (int i = 0; i < fieldReferences.Count; i++)
+            {
+                if (fieldReferences[i] is DirectFieldReference directFieldReference &&
+                    directFieldReference.ReferenceSegment is StructReferenceSegment structReferenceSegment)
+                {
+                    leftKeys.Add(new KeyValuePair<int, ReferenceSegment?>(structReferenceSegment.Field - relativeIndex, structReferenceSegment.Child));
+                }
+                else
+                {
+                    throw new NotImplementedException("Merge join can only have keys that use struct reference segments at this time");
+                }
+            }
+            return leftKeys;
+        }
+
+        public override string DisplayName => "Merge Join Bulk";
+
+        public override Task Compact()
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task DeleteAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public override async Task OnCheckpoint()
+        {
+            await _leftTree!.Commit();
+            await _rightTree!.Commit();
+        }
+
+        public override IAsyncEnumerable<StreamEventBatch> OnRecieve(int targetId, StreamEventBatch msg, long time)
+        {
+            Debug.Assert(_eventsProcessed != null, nameof(_eventsProcessed));
+            _eventsProcessed.Add(msg.Data.Weights.Count);
+            if (targetId == 0)
+            {
+                return OnRecieveLeft(msg, time);
+            }
+            else
+            {
+                return OnRecieveRight(msg, time);
+            }
+        }
+
+        private async IAsyncEnumerable<StreamEventBatch> OnRecieveLeft(StreamEventBatch msg, long time)
+        {
+            Debug.Assert(_eventsCounter != null);
+            Debug.Assert(_leftInserter != null);
+            Debug.Assert(_rightSearcher != null);
+
+            var memoryManager = MemoryAllocator;
+
+            List<Column> rightColumns = new List<Column>();
+            PrimitiveList<int> foundOffsets = new PrimitiveList<int>(memoryManager);
+            PrimitiveList<int> weights = new PrimitiveList<int>(memoryManager);
+            PrimitiveList<uint> iterations = new PrimitiveList<uint>(memoryManager);
+
+            for (int i = 0; i < _rightOutputColumns.Count; i++)
+            {
+                rightColumns.Add(Column.Create(memoryManager));
+            }
+
+            int keyLength = msg.Data.Weights.Count;
+            ColumnRowReference[] keys = new ColumnRowReference[keyLength];
+            JoinWeights[] insertValues = new JoinWeights[keyLength];
+
+            for (int i = 0; i < keyLength; i++)
+            {
+                keys[i] = new ColumnRowReference()
+                {
+                    referenceBatch = msg.Data.EventBatchData,
+                    RowIndex = i
+                };
+                insertValues[i] = new JoinWeights()
+                {
+                    weight = msg.Data.Weights[i],
+                    joinWeight = 0 
+                };
+            }
+
+            //var leftInserter = _leftTree!.CreateBulkInserter();
+            var sortedIndices = _leftInserter.SortAndGetIndices(keys, keyLength);
+
+            //var rightSearcher = _rightTree!.CreateBulkSearcher(_searchRightComparer);
+            await _rightSearcher.Start(keys, keyLength, sortedIndices);
+
+            bool emitLeftAlways = _mergeJoinRelation.Type == JoinType.Left || _mergeJoinRelation.Type == JoinType.Outer;
+
+            while (await _rightSearcher.MoveNextLeaf())
+            {
+                var leafNode = _rightSearcher.CurrentLeaf;
+                var pageKeyStorage = leafNode.keys;
+                var pageValues = leafNode.values;
+                bool pageUpdated = false;
+
+                var results = _rightSearcher.CurrentResults;
+                for (int r = 0; r < results.Count; r++)
+                {
+                    var result = results[r];
+                    var keyIndex = result.KeyIndex;
+                    int weight = msg.Data.Weights[keyIndex];
+
+                    int lowerBound = result.LowerBound < 0 ? ~result.LowerBound : result.LowerBound;
+                    int upperBound = result.UpperBound;
+
+                    for (int k = lowerBound; k <= upperBound; k++)
+                    {
+                        if (_postCondition != null)
+                        {
+                            if (!_postCondition(keys[keyIndex].referenceBatch, keys[keyIndex].RowIndex, pageKeyStorage._data, k))
+                            {
+                                continue;
+                            }
+                        }
+
+                        var joinStorageValue = pageValues.Get(k);
+                        int outWeight = joinStorageValue.weight * weight;
+                        insertValues[keyIndex].joinWeight += outWeight;
+
+                        for (int z = 0; z < rightColumns.Count; z++)
+                        {
+                            pageKeyStorage._data.Columns[_rightOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
+                            rightColumns[z].Add(_dataValueContainer);
+                        }
+                        foundOffsets.Add(keyIndex);
+                        iterations.Add(msg.Data.Iterations[keyIndex]);
+                        weights.Add(outWeight);
+
+                        if (emitLeftAlways || _mergeJoinRelation.Type == JoinType.Right || _mergeJoinRelation.Type == JoinType.Outer)
+                        {
+                            pageUpdated = true;
+                            if (joinStorageValue.joinWeight == 0)
+                            {
+                                for (int z = 0; z < rightColumns.Count; z++)
+                                {
+                                    pageKeyStorage._data.Columns[_rightOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
+                                    rightColumns[z].Add(_dataValueContainer);
+                                }
+                                foundOffsets.Add(keyLength);
+                                weights.Add(-joinStorageValue.weight);
+                                iterations.Add(msg.Data.Iterations[keyIndex]);
+                            }
+
+                            joinStorageValue.joinWeight += outWeight;
+
+                            if (joinStorageValue.joinWeight == 0)
+                            {
+                                for (int z = 0; z < rightColumns.Count; z++)
+                                {
+                                    pageKeyStorage._data.Columns[_rightOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
+                                    rightColumns[z].Add(_dataValueContainer);
+                                }
+                                foundOffsets.Add(keyLength);
+                                weights.Add(joinStorageValue.weight);
+                                iterations.Add(msg.Data.Iterations[keyIndex]);
+                            }
+                            
+                            pageValues.Update(k, joinStorageValue);
+                        }
+                        else
+                        {
+                            joinStorageValue.joinWeight += outWeight;
+                            pageValues.Update(k, joinStorageValue);
+                            pageUpdated = true;
+                        }
+
+                        if (foundOffsets.Count >= MaxRowSize)
+                        {
+                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, null, rightColumns, true);
+                            _eventsCounter.Add(outputBatch.Data.Weights.Count);
+                            yield return outputBatch;
+                            ResetOutputLists(ref foundOffsets, ref weights, ref iterations, null, rightColumns);
+                        }
+                    }
+                }
+
+                if (pageUpdated)
+                {
+                    var bTree = (BPlusTree<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>)_rightTree!;
+                    var isFull = bTree.m_stateClient.AddOrUpdate(leafNode.Id, leafNode);
+                    if (isFull)
+                    {
+                        await bTree.m_stateClient.WaitForNotFullAsync();
+                    }
+                }
+            }
+
+            if (emitLeftAlways)
+            {
+                for (int i = 0; i < keyLength; i++)
+                {
+                    if (insertValues[i].joinWeight == 0)
+                    {
+                        foundOffsets.Add(i);
+                        iterations.Add(msg.Data.Iterations[i]);
+                        weights.Add(msg.Data.Weights[i]);
+                        for (int z = 0; z < rightColumns.Count; z++)
+                        {
+                            rightColumns[z].Add(NullValue.Instance);
+                        }
+
+                        if (foundOffsets.Count >= MaxRowSize)
+                        {
+                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, null, rightColumns, true);
+                            _eventsCounter.Add(outputBatch.Data.Weights.Count);
+                            yield return outputBatch;
+                            ResetOutputLists(ref foundOffsets, ref weights, ref iterations, null, rightColumns);
+                        }
+                    }
+                }
+            }
+
+            if (foundOffsets.Count > 0)
+            {
+                var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, null, rightColumns, true);
+                _eventsCounter.Add(outputBatch.Data.Weights.Count);
+                yield return outputBatch;
+            }
+            else
+            {
+                for (int z = 0; z < rightColumns.Count; z++)
+                {
+                    rightColumns[z].Dispose();
+                }
+                foundOffsets.Dispose();
+                weights.Dispose();
+                iterations.Dispose();
+            }
+
+
+            await _leftInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator());
+        }
+
+        private async IAsyncEnumerable<StreamEventBatch> OnRecieveRight(StreamEventBatch msg, long time)
+        {
+            Debug.Assert(_eventsCounter != null);
+            Debug.Assert(_rightInserter != null);
+            Debug.Assert(_leftSearcher != null);
+
+            var memoryManager = MemoryAllocator;
+
+            List<Column> leftColumns = new List<Column>();
+            PrimitiveList<int> foundOffsets = new PrimitiveList<int>(memoryManager);
+            PrimitiveList<int> weights = new PrimitiveList<int>(memoryManager);
+            PrimitiveList<uint> iterations = new PrimitiveList<uint>(memoryManager);
+
+            for (int i = 0; i < _leftOutputColumns.Count; i++)
+            {
+                leftColumns.Add(Column.Create(memoryManager));
+            }
+
+            int keyLength = msg.Data.Weights.Count;
+            ColumnRowReference[] keys = new ColumnRowReference[keyLength];
+            JoinWeights[] insertValues = new JoinWeights[keyLength];
+
+            for (int i = 0; i < keyLength; i++)
+            {
+                keys[i] = new ColumnRowReference()
+                {
+                    referenceBatch = msg.Data.EventBatchData,
+                    RowIndex = i
+                };
+                insertValues[i] = new JoinWeights()
+                {
+                    weight = msg.Data.Weights[i],
+                    joinWeight = 0 
+                };
+            }
+
+            var sortedIndices = _rightInserter.SortAndGetIndices(keys, keyLength);
+
+            var leftSearcher = _leftTree!.CreateBulkSearcher(_searchLeftComparer);
+            await leftSearcher.Start(keys, keyLength, sortedIndices);
+
+            bool emitRightAlways = _mergeJoinRelation.Type == JoinType.Right || _mergeJoinRelation.Type == JoinType.Outer;
+
+            while (await leftSearcher.MoveNextLeaf())
+            {
+                var leafNode = leftSearcher.CurrentLeaf;
+                var pageKeyStorage = leafNode.keys;
+                var pageValues = leafNode.values;
+                bool pageUpdated = false;
+
+                var results = leftSearcher.CurrentResults;
+                for (int r = 0; r < results.Count; r++)
+                {
+                    var result = results[r];
+                    var keyIndex = result.KeyIndex;
+                    int weight = msg.Data.Weights[keyIndex];
+
+                    int lowerBound = result.LowerBound < 0 ? ~result.LowerBound : result.LowerBound;
+                    int upperBound = result.UpperBound;
+
+                    for (int k = lowerBound; k <= upperBound; k++)
+                    {
+                        if (_postCondition != null)
+                        {
+                            if (!_postCondition(pageKeyStorage._data, k, keys[keyIndex].referenceBatch, keys[keyIndex].RowIndex))
+                            {
+                                continue;
+                            }
+                        }
+
+                        var joinStorageValue = pageValues.Get(k);
+                        int outWeight = joinStorageValue.weight * weight;
+                        insertValues[keyIndex].joinWeight += outWeight;
+
+                        for (int z = 0; z < leftColumns.Count; z++)
+                        {
+                            pageKeyStorage._data.Columns[_leftOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
+                            leftColumns[z].Add(_dataValueContainer);
+                        }
+                        foundOffsets.Add(keyIndex);
+                        iterations.Add(msg.Data.Iterations[keyIndex]);
+                        weights.Add(outWeight);
+
+                        if (emitRightAlways || _mergeJoinRelation.Type == JoinType.Left || _mergeJoinRelation.Type == JoinType.Outer)
+                        {
+                            pageUpdated = true;
+                            if (joinStorageValue.joinWeight == 0)
+                            {
+                                for (int z = 0; z < leftColumns.Count; z++)
+                                {
+                                    pageKeyStorage._data.Columns[_leftOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
+                                    leftColumns[z].Add(_dataValueContainer);
+                                }
+                                foundOffsets.Add(keyLength);
+                                weights.Add(-joinStorageValue.weight);
+                                iterations.Add(msg.Data.Iterations[keyIndex]);
+                            }
+
+                            joinStorageValue.joinWeight += outWeight;
+
+                            if (joinStorageValue.joinWeight == 0)
+                            {
+                                for (int z = 0; z < leftColumns.Count; z++)
+                                {
+                                    pageKeyStorage._data.Columns[_leftOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
+                                    leftColumns[z].Add(_dataValueContainer);
+                                }
+                                foundOffsets.Add(keyLength);
+                                weights.Add(joinStorageValue.weight);
+                                iterations.Add(msg.Data.Iterations[keyIndex]);
+                            }
+                            
+                            pageValues.Update(k, joinStorageValue);
+                        }
+                        else
+                        {
+                            joinStorageValue.joinWeight += outWeight;
+                            pageValues.Update(k, joinStorageValue);
+                            pageUpdated = true;
+                        }
+
+                        if (foundOffsets.Count >= MaxRowSize)
+                        {
+                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, leftColumns, null, false);
+                            _eventsCounter.Add(outputBatch.Data.Weights.Count);
+                            yield return outputBatch;
+                            ResetOutputLists(ref foundOffsets, ref weights, ref iterations, leftColumns, null);
+                        }
+                    }
+                }
+
+                if (pageUpdated)
+                {
+                    var bTree = (BPlusTree<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>)_leftTree!;
+                    var isFull = bTree.m_stateClient.AddOrUpdate(leafNode.Id, leafNode);
+                    if (isFull)
+                    {
+                        await bTree.m_stateClient.WaitForNotFullAsync();
+                    }
+                }
+            }
+
+            if (emitRightAlways)
+            {
+                for (int i = 0; i < keyLength; i++)
+                {
+                    if (insertValues[i].joinWeight == 0)
+                    {
+                        foundOffsets.Add(i);
+                        iterations.Add(msg.Data.Iterations[i]);
+                        weights.Add(msg.Data.Weights[i]);
+                        for (int z = 0; z < leftColumns.Count; z++)
+                        {
+                            leftColumns[z].Add(NullValue.Instance);
+                        }
+
+                        if (foundOffsets.Count >= MaxRowSize)
+                        {
+                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, leftColumns, null, false);
+                            _eventsCounter.Add(outputBatch.Data.Weights.Count);
+                            yield return outputBatch;
+                            ResetOutputLists(ref foundOffsets, ref weights, ref iterations, leftColumns, null);
+                        }
+                    }
+                }
+            }
+
+            if (foundOffsets.Count > 0)
+            {
+                var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, leftColumns, null, false);
+                _eventsCounter.Add(outputBatch.Data.Weights.Count);
+                yield return outputBatch;
+            }
+            else
+            {
+                for (int z = 0; z < leftColumns.Count; z++)
+                {
+                    leftColumns[z].Dispose();
+                }
+                foundOffsets.Dispose();
+                weights.Dispose();
+                iterations.Dispose();
+            }
+
+
+
+            await _rightInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator());
+        }
+
+        private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)
+        {
+            IColumn[] outputColumns = new IColumn[_leftOutputColumns.Count + _rightOutputColumns.Count];
+            if (isLeft)
+            {
+                if (_leftOutputColumns.Count > 0)
+                {
+                    for (int i = 0; i < _leftOutputColumns.Count; i++)
+                    {
+                        outputColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, true, MemoryAllocator, out _);
+                    }
+                }
+                for (int i = 0; i < rightColumns!.Count; i++)
+                {
+                    outputColumns[_rightOutputIndices[i]] = rightColumns[i];
+                }
+            }
+            else
+            {
+                for (int i = 0; i < leftColumns!.Count; i++)
+                {
+                    outputColumns[_leftOutputIndices[i]] = leftColumns[i];
+                }
+                if (_rightOutputColumns.Count > 0)
+                {
+                    for (int i = 0; i < _rightOutputColumns.Count; i++)
+                    {
+                        outputColumns[_rightOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_rightOutputColumns[i]], foundOffsets, true, MemoryAllocator, out _);
+                    }
+                }
+            }
+            return new StreamEventBatch(new EventBatchWeighted(weights, iterations, new EventBatchData(outputColumns)));
+        }
+
+        private void ResetOutputLists(ref PrimitiveList<int> foundOffsets, ref PrimitiveList<int> weights, ref PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns)
+        {
+            var memoryManager = MemoryAllocator;
+            foundOffsets = new PrimitiveList<int>(memoryManager);
+            weights = new PrimitiveList<int>(memoryManager);
+            iterations = new PrimitiveList<uint>(memoryManager);
+
+            if (leftColumns != null)
+            {
+                for (int l = 0; l < leftColumns.Count; l++)
+                {
+                    leftColumns[l] = Column.Create(memoryManager);
+                }
+            }
+            if (rightColumns != null)
+            {
+                for (int l = 0; l < rightColumns.Count; l++)
+                {
+                    rightColumns[l] = Column.Create(memoryManager);
+                }
+            }
+        }
+
+        protected override async Task InitializeOrRestore(IStateManagerClient stateManagerClient)
+        {
+            Logger.InitializingMergeJoinOperator(StreamName, Name);
+            if (_eventsCounter == null)
+            {
+                _eventsCounter = Metrics.CreateCounter<long>("events");
+            }
+            if (_eventsProcessed == null)
+            {
+                _eventsProcessed = Metrics.CreateCounter<long>("events_processed");
+            }
+
+            _leftTree = await stateManagerClient.GetOrCreateTree("left",
+                new BPlusTreeOptions<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>()
+                {
+                    Comparer = _leftInsertComparer,
+                    KeySerializer = new ColumnStoreSerializer(_mergeJoinRelation.Left.OutputLength, MemoryAllocator),
+                    ValueSerializer = new JoinWeightsSerializer(MemoryAllocator),
+                    UseByteBasedPageSizes = true,
+                    MemoryAllocator = MemoryAllocator
+                });
+            _leftInserter = _leftTree.CreateBulkInserter();
+            _leftSearcher = _leftTree.CreateBulkSearcher(_searchLeftComparer); 
+            _rightTree = await stateManagerClient.GetOrCreateTree("right",
+                new BPlusTreeOptions<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>()
+                {
+                    Comparer = _rightInsertComparer,
+                    KeySerializer = new ColumnStoreSerializer(_mergeJoinRelation.Right.OutputLength, MemoryAllocator),
+                    ValueSerializer = new JoinWeightsSerializer(MemoryAllocator),
+                    UseByteBasedPageSizes = true,
+                    MemoryAllocator = MemoryAllocator
+                });
+            _rightInserter = _rightTree.CreateBulkInserter();
+            _rightSearcher = _rightTree.CreateBulkSearcher(_searchRightComparer);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -210,14 +210,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 #endif
 
             _eventsProcessed.Add(msg.Data.Weights.Count);
-            if (targetId == 0)
-            {
-                return OnRecieveLeft(msg, time);
-            }
-            else
-            {
-                return OnRecieveRight(msg, time);
-            }
+            return targetId == 0 ? OnRecieveLeft(msg, time) : OnRecieveRight(msg, time);
         }
 
         private async IAsyncEnumerable<StreamEventBatch> OnRecieveLeft(StreamEventBatch msg, long time)

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -76,7 +76,12 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         protected readonly Func<EventBatchData, int, EventBatchData, int, bool>? _postCondition;
         private readonly DataValueContainer _dataValueContainer;
 
+        private int _leftTargetBatchSize = 100;
+        private int _rightTargetBatchSize = 100;
+
         private const int MaxRowSize = 100;
+        private const int MaxAmountOfRows = 10_000;
+        private const int MinRowSize = 1;
 
 #if DEBUG_WRITE
         // Debug data
@@ -261,9 +266,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             await _rightSearcher.Start(keys, keyLength, sortedIndices);
 
             bool emitLeftAlways = _mergeJoinRelation.Type == JoinType.Left || _mergeJoinRelation.Type == JoinType.Outer;
-
+            int leafTransitionsCount = 0;
             while (await _rightSearcher.MoveNextLeaf())
             {
+                leafTransitionsCount++;
                 var leafNode = _rightSearcher.CurrentLeaf;
                 var pageKeyStorage = leafNode.keys;
                 var pageValues = leafNode.values;
@@ -399,6 +405,15 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
 
             await _leftInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator());
+            float leafHitRatio = (float)_leftInserter.LeafHitCount / keyLength;
+            if (leafHitRatio > 0.05f)
+            {
+                _leftTargetBatchSize = Math.Min(_leftTargetBatchSize * 2, MaxAmountOfRows);
+            }
+            else
+            {
+                _leftTargetBatchSize = Math.Max(_leftTargetBatchSize / 2, MinRowSize);
+            }
         }
 
         private async IAsyncEnumerable<StreamEventBatch> OnRecieveRight(StreamEventBatch msg, long time)
@@ -582,6 +597,15 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
 
             await _rightInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator());
+            float leafHitRatio = (float)_rightInserter.LeafHitCount / keyLength;
+            if (leafHitRatio > 0.05f)
+            {
+                _rightTargetBatchSize = Math.Min(_rightTargetBatchSize * 2, MaxAmountOfRows);
+            }
+            else
+            {
+                _rightTargetBatchSize = Math.Max(_rightTargetBatchSize / 2, MinRowSize);
+            }
         }
 
         private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -268,7 +268,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                         iterations.Add(msg.Data.Iterations[keyIndex]);
                         weights.Add(outWeight);
 
-                        if (emitLeftAlways || _mergeJoinRelation.Type == JoinType.Right || _mergeJoinRelation.Type == JoinType.Outer)
+                        if (_mergeJoinRelation.Type == JoinType.Right || _mergeJoinRelation.Type == JoinType.Outer)
                         {
                             pageUpdated = true;
                             if (joinStorageValue.joinWeight == 0)
@@ -298,12 +298,6 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                             }
                             
                             pageValues.Update(k, joinStorageValue);
-                        }
-                        else
-                        {
-                            joinStorageValue.joinWeight += outWeight;
-                            pageValues.Update(k, joinStorageValue);
-                            pageUpdated = true;
                         }
 
                         if (foundOffsets.Count >= MaxRowSize)
@@ -456,7 +450,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                         iterations.Add(msg.Data.Iterations[keyIndex]);
                         weights.Add(outWeight);
 
-                        if (emitRightAlways || _mergeJoinRelation.Type == JoinType.Left || _mergeJoinRelation.Type == JoinType.Outer)
+                        if (_mergeJoinRelation.Type == JoinType.Left || _mergeJoinRelation.Type == JoinType.Outer)
                         {
                             pageUpdated = true;
                             if (joinStorageValue.joinWeight == 0)
@@ -486,12 +480,6 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                             }
                             
                             pageValues.Update(k, joinStorageValue);
-                        }
-                        else
-                        {
-                            joinStorageValue.joinWeight += outWeight;
-                            pageValues.Update(k, joinStorageValue);
-                            pageUpdated = true;
                         }
 
                         if (foundOffsets.Count >= MaxRowSize)

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -78,6 +78,13 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         private const int MaxRowSize = 100;
 
+#if DEBUG_WRITE
+        // Debug data
+        private StreamWriter? allInput;
+        private StreamWriter? leftInput;
+        private StreamWriter? rightInput;
+#endif
+
         public ColumnBulkMergeJoin(MergeJoinRelation mergeJoinRelation, FunctionsRegister functionsRegister, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(2, executionDataflowBlockOptions)
         {
             this._mergeJoinRelation = mergeJoinRelation;
@@ -173,6 +180,33 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         public override IAsyncEnumerable<StreamEventBatch> OnRecieve(int targetId, StreamEventBatch msg, long time)
         {
             Debug.Assert(_eventsProcessed != null, nameof(_eventsProcessed));
+
+#if DEBUG_WRITE
+            allInput!.WriteLine("New batch");
+            foreach (var e in msg.Events)
+            {
+                allInput!.WriteLine($"{targetId}, {e.Weight} {e.ToJson()}");
+            }
+            if (targetId == 0)
+            {
+                foreach (var e in msg.Events)
+                {
+                    leftInput!.WriteLine($"{e.Weight} {e.ToJson()}");
+                }
+                leftInput!.Flush();
+            }
+            else
+            {
+                foreach (var e in msg.Events)
+                {
+                    rightInput!.WriteLine($"{e.Weight} {e.ToJson()}");
+                }
+                rightInput!.Flush();
+            }
+            
+            allInput!.Flush();
+#endif
+
             _eventsProcessed.Add(msg.Data.Weights.Count);
             if (targetId == 0)
             {
@@ -610,6 +644,24 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         protected override async Task InitializeOrRestore(IStateManagerClient stateManagerClient)
         {
             Logger.InitializingMergeJoinOperator(StreamName, Name);
+
+#if DEBUG_WRITE
+            if (!Directory.Exists("debugwrite"))
+            {
+                var dir = Directory.CreateDirectory("debugwrite");
+            }
+            if (allInput != null)
+            {
+                allInput.WriteLine("Restart");
+            }
+            else
+            {
+                allInput = File.CreateText($"debugwrite/{StreamName}-{Name}.all.txt");
+                leftInput = File.CreateText($"debugwrite/{StreamName}-{Name}.left.txt");
+                rightInput = File.CreateText($"debugwrite/{StreamName}-{Name}.right.txt");
+            }
+#endif
+
             if (_eventsCounter == null)
             {
                 _eventsCounter = Metrics.CreateCounter<long>("events");

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -75,13 +75,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         protected readonly Func<EventBatchData, int, EventBatchData, int, bool>? _postCondition;
         private readonly DataValueContainer _dataValueContainer;
-
-        private int _leftTargetBatchSize = 100;
-        private int _rightTargetBatchSize = 100;
-
         private const int MaxRowSize = 100;
-        private const int MaxAmountOfRows = 10_000;
-        private const int MinRowSize = 1;
 
 #if DEBUG_WRITE
         // Debug data
@@ -405,15 +399,6 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
 
             await _leftInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator());
-            float leafHitRatio = (float)_leftInserter.LeafHitCount / keyLength;
-            if (leafHitRatio > 0.05f)
-            {
-                _leftTargetBatchSize = Math.Min(_leftTargetBatchSize * 2, MaxAmountOfRows);
-            }
-            else
-            {
-                _leftTargetBatchSize = Math.Max(_leftTargetBatchSize / 2, MinRowSize);
-            }
         }
 
         private async IAsyncEnumerable<StreamEventBatch> OnRecieveRight(StreamEventBatch msg, long time)
@@ -597,15 +582,6 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
 
             await _rightInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator());
-            float leafHitRatio = (float)_rightInserter.LeafHitCount / keyLength;
-            if (leafHitRatio > 0.05f)
-            {
-                _rightTargetBatchSize = Math.Min(_rightTargetBatchSize * 2, MaxAmountOfRows);
-            }
-            else
-            {
-                _rightTargetBatchSize = Math.Max(_rightTargetBatchSize / 2, MinRowSize);
-            }
         }
 
         private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -172,8 +172,11 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         public override async Task OnCheckpoint()
         {
-            await _leftTree!.Commit();
-            await _rightTree!.Commit();
+            Debug.Assert(_leftTree != null);
+            Debug.Assert(_rightTree != null);
+
+            await _leftTree.Commit();
+            await _rightTree.Commit();
         }
 
         public override IAsyncEnumerable<StreamEventBatch> OnRecieve(int targetId, StreamEventBatch msg, long time)
@@ -219,6 +222,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         private async IAsyncEnumerable<StreamEventBatch> OnRecieveLeft(StreamEventBatch msg, long time)
         {
+            Debug.Assert(_rightTree != null);
             Debug.Assert(_eventsCounter != null);
             Debug.Assert(_leftInserter != null);
             Debug.Assert(_rightSearcher != null);
@@ -253,10 +257,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 };
             }
 
-            //var leftInserter = _leftTree!.CreateBulkInserter();
             var sortedIndices = _leftInserter.SortAndGetIndices(keys, keyLength);
 
-            //var rightSearcher = _rightTree!.CreateBulkSearcher(_searchRightComparer);
             await _rightSearcher.Start(keys, keyLength, sortedIndices);
 
             bool emitLeftAlways = _mergeJoinRelation.Type == JoinType.Left || _mergeJoinRelation.Type == JoinType.Outer;
@@ -346,7 +348,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                 if (pageUpdated)
                 {
-                    var bTree = (BPlusTree<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>)_rightTree!;
+                    var bTree = (BPlusTree<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>)_rightTree;
                     var isFull = bTree.m_stateClient.AddOrUpdate(leafNode.Id, leafNode);
                     if (isFull)
                     {
@@ -403,6 +405,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         private async IAsyncEnumerable<StreamEventBatch> OnRecieveRight(StreamEventBatch msg, long time)
         {
+            Debug.Assert(_leftTree != null);
             Debug.Assert(_eventsCounter != null);
             Debug.Assert(_rightInserter != null);
             Debug.Assert(_leftSearcher != null);
@@ -439,7 +442,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
             var sortedIndices = _rightInserter.SortAndGetIndices(keys, keyLength);
 
-            var leftSearcher = _leftTree!.CreateBulkSearcher(_searchLeftComparer);
+            var leftSearcher = _leftTree.CreateBulkSearcher(_searchLeftComparer);
             await leftSearcher.Start(keys, keyLength, sortedIndices);
 
             bool emitRightAlways = _mergeJoinRelation.Type == JoinType.Right || _mergeJoinRelation.Type == JoinType.Outer;
@@ -528,7 +531,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                 if (pageUpdated)
                 {
-                    var bTree = (BPlusTree<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>)_leftTree!;
+                    var bTree = (BPlusTree<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>)_leftTree;
                     var isFull = bTree.m_stateClient.AddOrUpdate(leafNode.Id, leafNode);
                     if (isFull)
                     {
@@ -586,24 +589,31 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)
         {
+            Debug.Assert(rightColumns != null);
+            Debug.Assert(leftColumns != null);
             IColumn[] outputColumns = new IColumn[_leftOutputColumns.Count + _rightOutputColumns.Count];
+            bool shouldDisposeOffsets = true;
             if (isLeft)
             {
                 if (_leftOutputColumns.Count > 0)
                 {
                     for (int i = 0; i < _leftOutputColumns.Count; i++)
                     {
-                        outputColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, true, MemoryAllocator, out _);
+                        outputColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, true, MemoryAllocator, out var usedOffset);
+                        if (usedOffset)
+                        {
+                            shouldDisposeOffsets = false;
+                        }
                     }
                 }
-                for (int i = 0; i < rightColumns!.Count; i++)
+                for (int i = 0; i < rightColumns.Count; i++)
                 {
                     outputColumns[_rightOutputIndices[i]] = rightColumns[i];
                 }
             }
             else
             {
-                for (int i = 0; i < leftColumns!.Count; i++)
+                for (int i = 0; i < leftColumns.Count; i++)
                 {
                     outputColumns[_leftOutputIndices[i]] = leftColumns[i];
                 }
@@ -611,9 +621,17 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 {
                     for (int i = 0; i < _rightOutputColumns.Count; i++)
                     {
-                        outputColumns[_rightOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_rightOutputColumns[i]], foundOffsets, true, MemoryAllocator, out _);
+                        outputColumns[_rightOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_rightOutputColumns[i]], foundOffsets, true, MemoryAllocator, out var usedOffset);
+                        if (usedOffset)
+                        {
+                            shouldDisposeOffsets = false;
+                        }
                     }
                 }
+            }
+            if (shouldDisposeOffsets)
+            {
+                foundOffsets.Dispose();
             }
             return new StreamEventBatch(new EventBatchWeighted(weights, iterations, new EventBatchData(outputColumns)));
         }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -283,12 +283,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                     for (int k = lowerBound; k <= upperBound; k++)
                     {
-                        if (_postCondition != null)
+                        if (_postCondition != null && !_postCondition(keys[keyIndex].referenceBatch, keys[keyIndex].RowIndex, pageKeyStorage._data, k))
                         {
-                            if (!_postCondition(keys[keyIndex].referenceBatch, keys[keyIndex].RowIndex, pageKeyStorage._data, k))
-                            {
-                                continue;
-                            }
+                            continue;
                         }
 
                         var joinStorageValue = pageValues.Get(k);

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -589,8 +589,6 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)
         {
-            Debug.Assert(rightColumns != null);
-            Debug.Assert(leftColumns != null);
             IColumn[] outputColumns = new IColumn[_leftOutputColumns.Count + _rightOutputColumns.Count];
             bool shouldDisposeOffsets = true;
             if (isLeft)
@@ -606,6 +604,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                         }
                     }
                 }
+                Debug.Assert(rightColumns != null);
                 for (int i = 0; i < rightColumns.Count; i++)
                 {
                     outputColumns[_rightOutputIndices[i]] = rightColumns[i];
@@ -613,6 +612,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             }
             else
             {
+                Debug.Assert(leftColumns != null);
                 for (int i = 0; i < leftColumns.Count; i++)
                 {
                     outputColumns[_leftOutputIndices[i]] = leftColumns[i];

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -456,12 +456,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                     for (int k = lowerBound; k <= upperBound; k++)
                     {
-                        if (_postCondition != null)
+                        if (_postCondition != null && !_postCondition(pageKeyStorage._data, k, keys[keyIndex].referenceBatch, keys[keyIndex].RowIndex))
                         {
-                            if (!_postCondition(pageKeyStorage._data, k, keys[keyIndex].referenceBatch, keys[keyIndex].RowIndex))
-                            {
-                                continue;
-                            }
+                            continue;
                         }
 
                         var joinStorageValue = pageValues.Get(k);

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsValueContainer.cs
@@ -91,5 +91,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         {
             return (end - start + 1) * 8;
         }
+
+        public void InsertFrom(JoinWeights[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsValueContainer.cs
@@ -96,5 +96,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/JoinWeightsValueContainer.cs
@@ -94,12 +94,12 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         public void InsertFrom(JoinWeights[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
         {
-            throw new NotImplementedException();
+            _values.InsertFrom(values, sortedLookup, targetPositions);
         }
 
         public void DeleteBatch(ReadOnlySpan<int> positions)
         {
-            throw new NotImplementedException();
+            _values.DeleteBatch(positions);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
@@ -83,7 +83,6 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         {
             int start = startIndex;
             int end = endIndex;
-            bool noMatch = false;
             for (int i = 0; i < columnOrder.Count; i++)
             {
                 var column = columnOrder[i];

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
@@ -45,7 +45,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         public bool SeekNextPageForValue => false;
 
-        private DataValueContainer _yDataValueContainer = new DataValueContainer();
+        private readonly DataValueContainer _yDataValueContainer = new DataValueContainer();
 
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
         {

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -45,19 +45,62 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         public bool SeekNextPageForValue => false;
 
+        private DataValueContainer _yDataValueContainer = new DataValueContainer();
+
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
         {
-            throw new NotImplementedException();
+            for (int i = 0; i < columnOrder.Count; i++)
+            {
+                var col = columnOrder[i];
+                x.referenceBatch.Columns[col.Key].GetValueAt(x.RowIndex, dataValueContainer, col.Value);
+                y.referenceBatch.Columns[col.Key].GetValueAt(y.RowIndex, _yDataValueContainer, col.Value);
+                int cmp = FlowtideDotNet.Core.ColumnStore.Comparers.DataValueComparer.CompareTo(dataValueContainer, _yDataValueContainer);
+                if (cmp != 0)
+                {
+                    return cmp;
+                }
+            }
+            return 0;
         }
 
         public int CompareTo(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, in int index)
         {
-            throw new NotImplementedException();
+            for (int i = 0; i < columnOrder.Count; i++)
+            {
+                var col = columnOrder[i];
+                key.referenceBatch.Columns[col.Key].GetValueAt(key.RowIndex, dataValueContainer, col.Value);
+                keyContainer._data.Columns[col.Key].GetValueAt(index, _yDataValueContainer, col.Value);
+                int cmp = FlowtideDotNet.Core.ColumnStore.Comparers.DataValueComparer.CompareTo(dataValueContainer, _yDataValueContainer);
+                if (cmp != 0)
+                {
+                    return cmp;
+                }
+            }
+            return 0;
         }
 
-        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int endIndex)
         {
-            throw new NotImplementedException();
+            int start = startIndex;
+            int end = endIndex;
+            bool noMatch = false;
+            for (int i = 0; i < columnOrder.Count; i++)
+            {
+                var column = columnOrder[i];
+                key.referenceBatch.Columns[column.Key].GetValueAt(key.RowIndex, dataValueContainer, column.Value);
+                var (low, high) = keyContainer._data.Columns[column.Key].SearchBoundries(dataValueContainer, start, end, column.Value);
+
+                if (low < 0)
+                {
+                    return new FindBoundriesResult(low, low);
+                }
+                else
+                {
+                    start = low;
+                    end = high;
+                }
+            }
+            return new FindBoundriesResult(start, end);
         }
 
         public int FindIndex(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer)

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
@@ -55,6 +55,11 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             throw new NotImplementedException();
         }
 
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
+
         public int FindIndex(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer)
         {
             int index = -1;

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
@@ -35,7 +35,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             this.selfColumns = selfColumns;
             this.referenceColumns = referenceColumns;
         }
-        private DataValueContainer _yDataValueContainer = new DataValueContainer();
+        private readonly DataValueContainer _yDataValueContainer = new DataValueContainer();
 
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
         {

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -35,14 +35,39 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             this.selfColumns = selfColumns;
             this.referenceColumns = referenceColumns;
         }
+        private DataValueContainer _yDataValueContainer = new DataValueContainer();
+
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
         {
-            throw new NotImplementedException();
+            // Usually not called for SearchComparer, but implementing similarly if needed
+            for (int i = 0; i < selfColumns.Count; i++)
+            {
+                var col = selfColumns[i];
+                x.referenceBatch.Columns[col.Key].GetValueAt(x.RowIndex, dataValueContainer, col.Value);
+                y.referenceBatch.Columns[col.Key].GetValueAt(y.RowIndex, _yDataValueContainer, col.Value);
+                int cmp = FlowtideDotNet.Core.ColumnStore.Comparers.DataValueComparer.CompareTo(dataValueContainer, _yDataValueContainer);
+                if (cmp != 0)
+                {
+                    return cmp;
+                }
+            }
+            return 0;
         }
 
         public int CompareTo(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, in int index)
         {
-            throw new NotImplementedException();
+            for (int i = 0; i < selfColumns.Count; i++)
+            {
+                var col = selfColumns[i];
+                key.referenceBatch.Columns[referenceColumns[i].Key].GetValueAt(key.RowIndex, dataValueContainer, referenceColumns[i].Value);
+                keyContainer._data.Columns[col.Key].GetValueAt(index, _yDataValueContainer, col.Value);
+                int cmp = FlowtideDotNet.Core.ColumnStore.Comparers.DataValueComparer.CompareTo(dataValueContainer, _yDataValueContainer);
+                if (cmp != 0)
+                {
+                    return cmp;
+                }
+            }
+            return 0;
         }
 
         public int FindIndex(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer)
@@ -79,9 +104,40 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             return index;
         }
 
-        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int endIndex)
         {
-            throw new NotImplementedException();
+            try
+            {
+                int start = startIndex;
+                int end = endIndex;
+                for (int i = 0; i < selfColumns.Count; i++)
+                {
+                    // Get value by container to skip boxing for each value
+                    key.referenceBatch.Columns[referenceColumns[i].Key].GetValueAt(key.RowIndex, dataValueContainer, referenceColumns[i].Value);
+
+                    if (dataValueContainer._type == ArrowTypeId.Null)
+                    {
+                        return new FindBoundriesResult(~start, ~start);
+                    }
+                    var (low, high) = keyContainer._data.Columns[selfColumns[i].Key].SearchBoundries(dataValueContainer, start, end, selfColumns[i].Value);
+
+                    if (low < 0)
+                    {
+                        return new FindBoundriesResult(low, low);
+                    }
+                    else
+                    {
+                        start = low;
+                        end = high;
+                    }
+                }
+                return new FindBoundriesResult(start, end);
+            }
+            catch
+            {
+                throw;
+            }
+            
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
@@ -108,8 +108,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         {
             try
             {
-                int start = startIndex;
-                int end = endIndex;
+                int currentStart = startIndex;
+                int currentEnd = endIndex;
                 for (int i = 0; i < selfColumns.Count; i++)
                 {
                     // Get value by container to skip boxing for each value
@@ -117,9 +117,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                     if (dataValueContainer._type == ArrowTypeId.Null)
                     {
-                        return new FindBoundriesResult(~start, ~start);
+                        return new FindBoundriesResult(~currentStart, ~currentStart);
                     }
-                    var (low, high) = keyContainer._data.Columns[selfColumns[i].Key].SearchBoundries(dataValueContainer, start, end, selfColumns[i].Value);
+                    var (low, high) = keyContainer._data.Columns[selfColumns[i].Key].SearchBoundries(dataValueContainer, currentStart, currentEnd, selfColumns[i].Value);
 
                     if (low < 0)
                     {
@@ -127,11 +127,11 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     }
                     else
                     {
-                        start = low;
-                        end = high;
+                        currentStart = low;
+                        currentEnd = high;
                     }
                 }
-                return new FindBoundriesResult(start, end);
+                return new FindBoundriesResult(currentStart, currentEnd);
             }
             catch
             {

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
@@ -78,5 +78,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             }
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorage.cs
@@ -141,5 +141,10 @@ namespace FlowtideDotNet.Core.Operators.Normalization
         {
             return _data.GetByteSize(start, end);
         }
+
+        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorage.cs
@@ -142,7 +142,7 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             return _data.GetByteSize(start, end);
         }
 
-        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeKeyStorage.cs
@@ -146,5 +146,10 @@ namespace FlowtideDotNet.Core.Operators.Normalization
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeTreeComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeTreeComparer.cs
@@ -63,5 +63,10 @@ namespace FlowtideDotNet.Core.Operators.Normalization
             }
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in NormalizeKeyStorage keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueStorage.cs
@@ -142,5 +142,10 @@ namespace FlowtideDotNet.Core.Operators.Normalization
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Normalization/NormalizeValueStorage.cs
@@ -137,5 +137,10 @@ namespace FlowtideDotNet.Core.Operators.Normalization
         {
             return _data.GetByteSize(start, end);
         }
+
+        public void InsertFrom(ColumnRowReference[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/TopN/TopNComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/TopN/TopNComparer.cs
@@ -40,6 +40,11 @@ namespace FlowtideDotNet.Core.Operators.TopN
             throw new NotImplementedException();
         }
 
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
+
         public int FindIndex(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer)
         {
             int index = -1;

--- a/src/FlowtideDotNet.Core/Operators/Window/WindowInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Window/WindowInsertComparer.cs
@@ -50,6 +50,11 @@ namespace FlowtideDotNet.Core.Operators.Window
             throw new NotImplementedException();
         }
 
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
+
         public int FindIndex(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer)
         {
             int index = -1;

--- a/src/FlowtideDotNet.Core/Operators/Window/WindowPartitionStartSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Window/WindowPartitionStartSearchComparer.cs
@@ -89,5 +89,10 @@ namespace FlowtideDotNet.Core.Operators.Window
             }
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Window/WindowValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Window/WindowValueContainer.cs
@@ -122,6 +122,11 @@ namespace FlowtideDotNet.Core.Operators.Window
             _previousValueSent.InsertAt(index, false);
         }
 
+        public void InsertFrom(WindowValue[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveAt(int index)
         {
             _weights.RemoveAt(index);

--- a/src/FlowtideDotNet.Core/Operators/Window/WindowValueContainer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Window/WindowValueContainer.cs
@@ -76,6 +76,11 @@ namespace FlowtideDotNet.Core.Operators.Window
             }
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _weights.Dispose();

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedKeyStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedKeyStorage.cs
@@ -136,7 +136,7 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
             return _data.GetByteSize(start, end);
         }
 
-        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedKeyStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedKeyStorage.cs
@@ -140,5 +140,10 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
         {
             throw new NotImplementedException();
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedKeyStorage.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedKeyStorage.cs
@@ -135,5 +135,10 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
         {
             return _data.GetByteSize(start, end);
         }
+
+        public void InsertFrom(ColumnRowReference[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedTreeComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/ModifiedTreeComparer.cs
@@ -63,5 +63,10 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
             }
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ModifiedKeyStorage keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/WriteTreeInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/WriteTreeInsertComparer.cs
@@ -56,6 +56,11 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
             throw new NotImplementedException();
         }
 
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
+
         public int FindIndex(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer)
         {
             int index = -1;

--- a/src/FlowtideDotNet.Core/Operators/Write/Column/WriteTreeSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Write/Column/WriteTreeSearchComparer.cs
@@ -82,5 +82,10 @@ namespace FlowtideDotNet.Core.Operators.Write.Column
             }
             return index;
         }
+
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Storage/Comparers/PrimitiveListComparer.cs
+++ b/src/FlowtideDotNet.Storage/Comparers/PrimitiveListComparer.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 using FlowtideDotNet.Storage.Tree;
+using System.Collections;
 
 namespace FlowtideDotNet.Storage.Comparers
 {
@@ -46,6 +47,84 @@ namespace FlowtideDotNet.Storage.Comparers
         public int FindIndex(in T key, in PrimitiveListKeyContainer<T> keyContainer)
         {
             return keyContainer.BinarySearch(key, m_comparer);
+        }
+
+        public FindBoundriesResult FindBoundries(in T key, in PrimitiveListKeyContainer<T> keyContainer, int startIndex, int endIndex)
+        {
+            int lo = startIndex;
+            int hi = endIndex;
+            int maxNotFound = hi;
+
+            var span = keyContainer._values.Span;
+
+            bool found = false;
+            while (lo <= hi)
+            {
+                int i = lo + ((hi - lo) >> 1);
+
+                int c = span[i].CompareTo(key);
+                if (c == 0)
+                {
+                    found = true;
+                    hi = i - 1;
+                }
+                else if (c < 0)
+                {
+                    lo = i + 1;
+                }
+                else
+                {
+                    hi = i - 1;
+                    maxNotFound = hi;
+                }
+            }
+            int lowerbound = lo;
+            if (!found)
+            {
+                lowerbound = ~lo;
+                // We did not find the value so this is the the bounds.
+                return new FindBoundriesResult(lowerbound, lowerbound);
+            }
+
+            if (lo < endIndex)
+            {
+                // Check that the next value is the same, if not we are at the of the bounds.
+                int c = span[lo + 1].CompareTo(key);
+                if (c != 0)
+                {
+                    return new FindBoundriesResult(lowerbound, lowerbound);
+                }
+            }
+            else
+            {
+                // At the top of the array
+                return new FindBoundriesResult(lowerbound, lowerbound);
+            }
+
+            // There are duplicate values, binary search for the end.
+            hi = maxNotFound;
+
+            while (lo <= hi)
+            {
+                int i = lo + ((hi - lo) >> 1);
+
+                int c = span[i].CompareTo(key);
+                if (c <= 0)
+                {
+                    lo = i + 1;
+                }
+                else
+                {
+                    hi = i - 1;
+                }
+            }
+            int upperbound = lo - 1;
+            if (!found)
+            {
+                upperbound = ~upperbound;
+            }
+
+            return new FindBoundriesResult(lowerbound, upperbound);
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Comparers/PrimitiveListComparer.cs
+++ b/src/FlowtideDotNet.Storage/Comparers/PrimitiveListComparer.cs
@@ -11,11 +11,6 @@
 // limitations under the License.
 
 using FlowtideDotNet.Storage.Tree;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Storage.Comparers
 {

--- a/src/FlowtideDotNet.Storage/Comparers/PrimitiveListComparer.cs
+++ b/src/FlowtideDotNet.Storage/Comparers/PrimitiveListComparer.cs
@@ -119,11 +119,6 @@ namespace FlowtideDotNet.Storage.Comparers
                 }
             }
             int upperbound = lo - 1;
-            if (!found)
-            {
-                upperbound = ~upperbound;
-            }
-
             return new FindBoundriesResult(lowerbound, upperbound);
         }
     }

--- a/src/FlowtideDotNet.Storage/DataStructures/BitmapList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/BitmapList.cs
@@ -899,7 +899,7 @@ namespace FlowtideDotNet.Storage.DataStructures
             }
         }
 
-        public void InsertFrom(BitmapList other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(ref readonly BitmapList other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             int otherCount = sortedLookup.Length;
             if (otherCount == 0) return;
@@ -925,10 +925,17 @@ namespace FlowtideDotNet.Storage.DataStructures
                 }
 
                 int oIdx = sortedLookup[i];
-                int oIntIdx = oIdx >> 5;
-                int oBitOffset = oIdx & 31;
-
-                bool isSet = (otherSpan[oIntIdx] & (1 << oBitOffset)) != 0;
+                bool isSet;
+                if (oIdx == lookupNullIndex)
+                {
+                    isSet = false;
+                }
+                else
+                {
+                    int oIntIdx = oIdx >> 5;
+                    int oBitOffset = oIdx & 31;
+                    isSet = (otherSpan[oIntIdx] & (1 << oBitOffset)) != 0;
+                }
 
                 int writeBitIdx = targetInsertIdx + i;
                 int wIntIdx = writeBitIdx >> 5;

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -159,7 +159,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="other">The other primitive list to insert data from.</param>
         /// <param name="sortedLookup">A span containing the indices of the elements to insert from the other list.</param>
         /// <param name="insertPositions">A span containing the positions at which to insert the elements in the current list. Must be in non-decreasing order.</param>
-        public void InsertFrom(PrimitiveList<T> other, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        public void InsertFrom(ref readonly PrimitiveList<T> other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
             Debug.Assert(sortedLookup.Length == insertPositions.Length);
             int otherCount = sortedLookup.Length;
@@ -193,7 +193,14 @@ namespace FlowtideDotNet.Storage.DataStructures
                 // Place the new element from the other list
                 int oIdx = sortedLookup[i];
                 currentWriteIdx--;
-                selfData[currentWriteIdx] = otherData[oIdx];
+                if (oIdx == lookupNullIndex)
+                {
+                    selfData[currentWriteIdx] = default;
+                }
+                else
+                {
+                    selfData[currentWriteIdx] = otherData[oIdx];
+                }
 
                 // Move the read tracker to the left of the block we just processed
                 currentReadIdx = targetInsertIdx;

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -208,14 +208,7 @@ namespace FlowtideDotNet.Storage.DataStructures
                 // Place the new element from the other list
                 int oIdx = sortedLookup[i];
                 currentWriteIdx--;
-                if (oIdx == lookupNullIndex)
-                {
-                    selfData[currentWriteIdx] = default;
-                }
-                else
-                {
-                    selfData[currentWriteIdx] = otherData[oIdx];
-                }
+                selfData[currentWriteIdx] = oIdx == lookupNullIndex ? default : otherData[oIdx];
 
                 // Move the read tracker to the left of the block we just processed
                 currentReadIdx = targetInsertIdx;

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -202,6 +202,56 @@ namespace FlowtideDotNet.Storage.DataStructures
             _length += otherCount;
         }
 
+        /// <summary>
+        /// Special case insert that allows inserting a subset of elements from an array at specific positions.
+        /// This is used when merging two lists together more memory efficiently than inserting each element one by one.
+        /// The sortedLookup and insertPositions spans must have the same length, but do not need to cover every element in the array.
+        /// The positions in <paramref name="insertPositions"/> are interpreted relative to the original contents of the current list before any elements are inserted.
+        /// Conceptually, this behaves like inserting the selected elements in order using <c>InsertAt(insertPositions[i] + i, ...)</c>.
+        /// </summary>
+        /// <param name="keys">The array to insert data from.</param>
+        /// <param name="sortedLookup">A span containing the indices of the elements to insert from the array.</param>
+        /// <param name="insertPositions">A span containing the positions at which to insert the elements in the current list. Must be in non-decreasing order.</param>
+        public void InsertFrom(T[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
+        {
+            Debug.Assert(sortedLookup.Length == insertPositions.Length);
+            int otherCount = sortedLookup.Length;
+            if (otherCount == 0) return;
+
+            int oldCount = _length;
+
+            EnsureCapacity(oldCount + otherCount);
+
+            var selfData = AccessSpan;
+            var otherData = keys.AsSpan();
+
+            int currentReadIdx = oldCount;
+            int currentWriteIdx = oldCount + otherCount;
+
+            for (int i = otherCount - 1; i >= 0; i--)
+            {
+                int targetInsertIdx = insertPositions[i];
+                int elementsToMove = currentReadIdx - targetInsertIdx;
+
+                if (elementsToMove > 0)
+                {
+                    currentWriteIdx -= elementsToMove;
+                    currentReadIdx -= elementsToMove;
+
+                    selfData.Slice(currentReadIdx, elementsToMove)
+                            .CopyTo(selfData.Slice(currentWriteIdx, elementsToMove));
+                }
+
+                int oIdx = sortedLookup[i];
+                currentWriteIdx--;
+                selfData[currentWriteIdx] = otherData[oIdx];
+
+                currentReadIdx = targetInsertIdx;
+            }
+
+            _length += otherCount;
+        }
+
         public void MoveAtIndex(int index, int count)
         {
             EnsureCapacity(_length + count);

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -57,6 +57,15 @@ namespace FlowtideDotNet.Storage.DataStructures
             _memoryAllocator = memoryAllocator;
         }
 
+        /// <summary>
+        /// UNSAFE: Gets the raw pointer to do operations without boundary checks
+        /// </summary>
+        /// <returns></returns>
+        internal T* GetPointer_Unsafe()
+        {
+            return (T*)_data;
+        }
+
         internal void EnsureCapacity(int length)
         {
             if (_dataLength < length)

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveListKeyContainer.cs
@@ -106,6 +106,11 @@ namespace FlowtideDotNet.Storage.DataStructures
             _list.InsertAt(index, key);
         }
 
+        public void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Insert_Internal(int index, K key)
         {
             _list.InsertAt(index, key);

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveListKeyContainer.cs
@@ -81,6 +81,11 @@ namespace FlowtideDotNet.Storage.DataStructures
             return ~lo;
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
             _list.Dispose();

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveListKeyContainer.cs
@@ -111,7 +111,7 @@ namespace FlowtideDotNet.Storage.DataStructures
             _list.InsertAt(index, key);
         }
 
-        public void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Storage/Properties/AssemblyInfo.cs
+++ b/src/FlowtideDotNet.Storage/Properties/AssemblyInfo.cs
@@ -18,3 +18,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("FlowtideDotNet.Core.Tests")]
 [assembly: InternalsVisibleTo("FlowtideDotNet.AspNetCore")]
 [assembly: InternalsVisibleTo("FlowtideDotNet.AcceptanceTests")]
+[assembly: InternalsVisibleTo("FlowtideDotNet.Benchmarks")]

--- a/src/FlowtideDotNet.Storage/Tree/BPlusTreeListComparer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/BPlusTreeListComparer.cs
@@ -33,6 +33,11 @@ namespace FlowtideDotNet.Storage.Tree
             return comparer.Compare(key, keyContainer.Get(index));
         }
 
+        public FindBoundriesResult FindBoundries(in K key, in ListKeyContainer<K> keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
+
         public int FindIndex(in K key, in ListKeyContainer<K> keyContainer)
         {
             return keyContainer._list.BinarySearch(key, comparer);

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTree.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTree.cs
@@ -64,5 +64,10 @@ namespace FlowtideDotNet.Storage.Tree
         ValueTask Clear();
 
         long CacheMisses { get; }
+
+        IBplusTreeBulkSearch<K, V, TKeyContainer, TValueContainer, TComparer> CreateBulkSearcher<TComparer>(TComparer comparer)
+            where TComparer : IBplusTreeComparer<K, TKeyContainer>;
+
+        IBPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer> CreateBulkInserter();
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTreeBulkInserter.cs
@@ -22,6 +22,12 @@ namespace FlowtideDotNet.Storage.Tree
         where TKeyContainer : IKeyContainer<K>
         where TValueContainer : IValueContainer<V>
     {
-        ValueTask StartBatch(K[] keys, V[] values, int keyLength);
+        int[] SortAndGetIndices(K[] keys, int keyLength);
+
+        ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, TMutator mutator)
+            where TMutator : IRowMutator<K, V>;
+
+        ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, int[] sortedIndices, TMutator mutator)
+            where TMutator : IRowMutator<K, V>;
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTreeBulkInserter.cs
@@ -1,0 +1,27 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage.Tree
+{
+    public interface IBPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer>
+        where TKeyContainer : IKeyContainer<K>
+        where TValueContainer : IValueContainer<V>
+    {
+        ValueTask StartBatch(K[] keys, V[] values);
+    }
+}

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTreeBulkInserter.cs
@@ -29,5 +29,7 @@ namespace FlowtideDotNet.Storage.Tree
 
         ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, int[] sortedIndices, TMutator mutator)
             where TMutator : IRowMutator<K, V>;
+
+        int LeafHitCount { get; }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IBplusTreeBulkSearch.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBplusTreeBulkSearch.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -44,7 +44,7 @@ namespace FlowtideDotNet.Storage.Tree
         public bool Found => LowerBound >= 0;
     }
 
-    public interface IBplusTreeBulkSearch<K, V, TKeyContainer, TValueContainer, TComparer>
+    public interface IBplusTreeBulkSearch<K, V, TKeyContainer, TValueContainer, TComparer> : IDisposable
         where TKeyContainer : IKeyContainer<K>
         where TValueContainer : IValueContainer<V>
         where TComparer : IBplusTreeComparer<K, TKeyContainer>

--- a/src/FlowtideDotNet.Storage/Tree/IBplusTreeBulkSearch.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBplusTreeBulkSearch.cs
@@ -1,0 +1,62 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Tree.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage.Tree
+{
+    public struct BulkSearchKeyResult
+    {
+        /// <summary>
+        /// The original index of the search key in the input array.
+        /// </summary>
+        public int KeyIndex;
+
+        /// <summary>
+        /// The lower bound index in the leaf. Negative (bitwise complement) if the key was not found.
+        /// </summary>
+        public int LowerBound;
+
+        /// <summary>
+        /// The upper bound index in the leaf. Negative (bitwise complement) if the key was not found.
+        /// </summary>
+        public int UpperBound;
+
+        /// <summary>
+        /// True if this key may continue into the next leaf (upper bound is the last index of the leaf).
+        /// </summary>
+        public bool ContinuesToNextLeaf;
+
+        public bool Found => LowerBound >= 0;
+    }
+
+    public interface IBplusTreeBulkSearch<K, V, TKeyContainer, TValueContainer, TComparer>
+        where TKeyContainer : IKeyContainer<K>
+        where TValueContainer : IValueContainer<V>
+        where TComparer : IBplusTreeComparer<K, TKeyContainer>
+    {
+        ValueTask Start(K[] keys, int keyLength);
+
+        ValueTask Start(K[] keys, int keyLength, int[] sortedIndices);
+
+        ValueTask<bool> MoveNextLeaf();
+
+        LeafNode<K, V, TKeyContainer, TValueContainer> CurrentLeaf { get; }
+
+        IReadOnlyList<BulkSearchKeyResult> CurrentResults { get; }
+    }
+}

--- a/src/FlowtideDotNet.Storage/Tree/IBplusTreeComparer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBplusTreeComparer.cs
@@ -12,6 +12,18 @@
 
 namespace FlowtideDotNet.Storage.Tree
 {
+    public struct FindBoundriesResult
+    {
+        public readonly int lowerBounds; 
+        public readonly int upperBounds;
+
+        public FindBoundriesResult(int lowerBounds, int upperBounds)
+        {
+            this.lowerBounds = lowerBounds;
+            this.upperBounds = upperBounds;
+        }
+    }
+
     public interface IBplusTreeComparer<K, TKeyContainer>
         where TKeyContainer : IKeyContainer<K>
     {
@@ -23,6 +35,8 @@ namespace FlowtideDotNet.Storage.Tree
         /// <param name="keyContainer"></param>
         /// <returns></returns>
         int FindIndex(in K key, in TKeyContainer keyContainer);
+
+        FindBoundriesResult FindBoundries(in K key, in TKeyContainer keyContainer, int startIndex, int endIndex);
 
         /// <summary>
         /// Compare two kwys with eachother

--- a/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
@@ -20,6 +20,8 @@ namespace FlowtideDotNet.Storage.Tree
 
         void Insert(int index, K key);
 
+        void InsertBulk(K[] items, Span<int> sortedLookup, Span<int> targetPositions);
+
         void Insert_Internal(int index, K key);
 
         void Update(int index, K key);

--- a/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
@@ -20,7 +20,7 @@ namespace FlowtideDotNet.Storage.Tree
 
         void Insert(int index, K key);
 
-        void InsertBulk(K[] items, Span<int> sortedLookup, Span<int> targetPositions);
+        //void InsertBulk(K[] items, Span<int> sortedLookup, Span<int> targetPositions);
 
         void Insert_Internal(int index, K key);
 

--- a/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
@@ -39,5 +39,7 @@ namespace FlowtideDotNet.Storage.Tree
         int GetByteSize();
 
         int GetByteSize(int start, int end);
+
+        void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions);
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
@@ -41,5 +41,7 @@ namespace FlowtideDotNet.Storage.Tree
         int GetByteSize(int start, int end);
 
         void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions);
+
+        void DeleteBatch(ReadOnlySpan<int> positions);
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IKeyContainer.cs
@@ -40,7 +40,11 @@ namespace FlowtideDotNet.Storage.Tree
 
         int GetByteSize(int start, int end);
 
-        void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions);
+        void InsertFrom(
+            K[] keys, 
+            ReadOnlySpan<int> sortedLookup, 
+            ReadOnlySpan<int> targetPositions,
+            Span<int> lookupBuffer);
 
         void DeleteBatch(ReadOnlySpan<int> positions);
     }

--- a/src/FlowtideDotNet.Storage/Tree/IRowMutator.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IRowMutator.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Storage.Tree
 {
-    internal interface IRowMutator<K, V>
+    public interface IRowMutator<K, V>
     {
         GenericWriteOperation Process(K key, bool exists, in V existingData, ref V incomingData);
     }

--- a/src/FlowtideDotNet.Storage/Tree/IRowMutator.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IRowMutator.cs
@@ -18,10 +18,8 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Storage.Tree
 {
-    public interface IBPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer>
-        where TKeyContainer : IKeyContainer<K>
-        where TValueContainer : IValueContainer<V>
+    internal interface IRowMutator<K, V>
     {
-        ValueTask StartBatch(K[] keys, V[] values, int keyLength);
+        GenericWriteOperation Process(K key, bool exists, in V existingData, ref V incomingData);
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IValueContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IValueContainer.cs
@@ -33,5 +33,7 @@ namespace FlowtideDotNet.Storage.Tree
         int GetByteSize();
 
         int GetByteSize(int start, int end);
+
+        void InsertFrom(V[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions);
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/IValueContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IValueContainer.cs
@@ -35,5 +35,7 @@ namespace FlowtideDotNet.Storage.Tree
         int GetByteSize(int start, int end);
 
         void InsertFrom(V[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions);
+
+        void DeleteBatch(ReadOnlySpan<int> positions);
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.GenericWriteByteBased.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.GenericWriteByteBased.cs
@@ -94,7 +94,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                     // No lock required
                     newParentNode.children.InsertAt(0, leafNode.Id);
-                    m_stateClient.Metadata = m_stateClient.Metadata.UpdateRoot(nextId);
+                    m_stateClient.Metadata = m_stateClient.Metadata.UpdateRootAndDepth(nextId, m_stateClient.Metadata.Depth + 1);
                     LeafNode<K, V, TKeyContainer, TValueContainer> newNode;
 
                     (newNode, _) = SplitLeafNodeBasedOnBytes(in newParentNode, 0, in leafNode, in byteSize);
@@ -301,7 +301,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 var newParentNode = new InternalNode<K, V, TKeyContainer>(nextId, emptyKeys, m_options.MemoryAllocator);
                 // No lock requireds
                 newParentNode.children.InsertAt(0, internalNode.Id);
-                m_stateClient.Metadata = m_stateClient.Metadata.UpdateRoot(nextId);
+                m_stateClient.Metadata = m_stateClient.Metadata.UpdateRootAndDepth(nextId, m_stateClient.Metadata.Depth + 1);
 
                 var (newNode, _) = SplitInternalNodeBasedOnBytes(in newParentNode, 0, in internalNode, in byteSize);
 
@@ -318,7 +318,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             }
             if (internalNode.children.Count == 1)
             {
-                m_stateClient.Metadata = m_stateClient.Metadata.UpdateRoot(internalNode.children[0]);
+                m_stateClient.Metadata = m_stateClient.Metadata.UpdateRootAndDepth(internalNode.children[0], m_stateClient.Metadata.Depth - 1);
                 m_stateClient.Delete(internalNode.Id);
             }
             else

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.GenericWriteByteBased.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.GenericWriteByteBased.cs
@@ -28,9 +28,9 @@ namespace FlowtideDotNet.Storage.Tree.Internal
     {
         // These constants exist only to have a minimum size so there will be a sufficent fanout.
         // This must be atleast 2x larger than minpagesize
-        private const int minPageSizeBeforeSplit = 16;
-        private const int minPageSize = 4;
-        private const int minPageSizeAfterSplit = 8;
+        internal const int minPageSizeBeforeSplit = 16;
+        internal const int minPageSize = 4;
+        internal const int minPageSizeAfterSplit = 8;
 
         public ValueTask<GenericWriteOperation> GenericWriteByteBased(ref readonly K key, ref readonly V? value, ref readonly GenericWriteFunction<V> function)
         {

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.Search.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.Search.cs
@@ -111,13 +111,13 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
         internal async ValueTask RouteBatchRootAsync(
             K[] keys, 
+            int batchLength,
             int[] sortedIndices, 
             IBplusTreeComparer<K, TKeyContainer> searchComparer,
             List<LeafBatchMapping> mappings)
         {
             Debug.Assert(m_stateClient.Metadata != null);
 
-            int batchLength = keys.Length;
             int depth = m_stateClient.Metadata.Depth;
 
             int safeArenaSize = depth == 0 ? 0 : depth * batchLength;
@@ -172,16 +172,25 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 int targetChildIndex = searchComparer.FindIndex(keys[firstKeyIndex], node.keys);
                 if (targetChildIndex < 0) targetChildIndex = ~targetChildIndex;
 
-                int itemsForThisChild = 1;
+                int itemsForThisChild;
 
-                while (currentOffset + itemsForThisChild < end)
+                if (targetChildIndex == node.keys.Count)
                 {
-                    int nextKeyIndex = sortedIndices[currentOffset + itemsForThisChild];
-                    int nextChildIndex = searchComparer.FindIndex(keys[nextKeyIndex], node.keys);
-                    if (nextChildIndex < 0) nextChildIndex = ~nextChildIndex;
+                    itemsForThisChild = end - currentOffset;
+                }
+                else
+                {
+                    // Normal look-ahead for non-last children
+                    itemsForThisChild = 1;
+                    while (currentOffset + itemsForThisChild < end)
+                    {
+                        int nextKeyIndex = sortedIndices[currentOffset + itemsForThisChild];
+                        int nextChildIndex = searchComparer.FindIndex(keys[nextKeyIndex], node.keys);
+                        if (nextChildIndex < 0) nextChildIndex = ~nextChildIndex;
 
-                    if (nextChildIndex == targetChildIndex) itemsForThisChild++;
-                    else break;
+                        if (nextChildIndex == targetChildIndex) itemsForThisChild++;
+                        else break;
+                    }
                 }
 
                 workspace[workspaceStartIndex + sliceCount] =

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.Search.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.Search.cs
@@ -97,7 +97,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
         public readonly struct LeafBatchMapping
         {
-            public readonly long LeafId; // Assuming your pointers are longs/ints
+            public readonly long LeafId;
             public readonly int Offset;
             public readonly int Length;
 

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.Search.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.Search.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Buffers;
 using System.Diagnostics;
 
 namespace FlowtideDotNet.Storage.Tree.Internal
@@ -92,6 +93,130 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         {
             var childNode = await task;
             return await SearchLeafNodeForRead_AfterTask(key, childNode!, searchComparer);
+        }
+
+        public readonly struct LeafBatchMapping
+        {
+            public readonly long LeafId; // Assuming your pointers are longs/ints
+            public readonly int Offset;
+            public readonly int Length;
+
+            public LeafBatchMapping(long leafId, int offset, int length)
+            {
+                LeafId = leafId;
+                Offset = offset;
+                Length = length;
+            }
+        }
+
+        internal async ValueTask RouteBatchRootAsync(
+            K[] keys, 
+            int[] sortedIndices, 
+            IBplusTreeComparer<K, TKeyContainer> searchComparer,
+            List<LeafBatchMapping> mappings)
+        {
+            Debug.Assert(m_stateClient.Metadata != null);
+
+            int batchLength = keys.Length;
+            int depth = m_stateClient.Metadata.Depth;
+
+            int safeArenaSize = depth == 0 ? 0 : depth * batchLength;
+            var workspace = depth > 0 ? ArrayPool<(long, int, int)>.Shared.Rent(safeArenaSize) : null;
+
+            try
+            {
+                if (depth == 0)
+                {
+                    // If depth 0 it is just a leaf as root
+                    mappings.Add(new LeafBatchMapping(m_stateClient.Metadata.Root, 0, batchLength));
+                }
+                else
+                {
+                    var rootTask = m_stateClient.GetValue(m_stateClient.Metadata.Root);
+                    var root = (rootTask.IsCompletedSuccessfully ? rootTask.Result : await rootTask)
+                                as InternalNode<K, V, TKeyContainer>;
+
+                    await RouteBatchInternalAsync(
+                        keys, sortedIndices, 0, batchLength,
+                        root!, depth, searchComparer, mappings, workspace!, 0);
+                }
+            }
+            finally
+            {
+                if (workspace != null)
+                {
+                    ArrayPool<(long, int, int)>.Shared.Return(workspace);
+                }
+            }
+        }
+
+        private async ValueTask RouteBatchInternalAsync(
+            K[] keys,
+            int[] sortedIndices,
+            int offset,
+            int length,
+            InternalNode<K, V, TKeyContainer> node,
+            int currentDepth,
+            IBplusTreeComparer<K, TKeyContainer> searchComparer,
+            List<LeafBatchMapping> mappings,
+            (long pointer, int offset, int length)[] workspace,
+            int workspaceStartIndex)
+        {
+            int sliceCount = 0;
+            int currentOffset = offset;
+            int end = offset + length;
+
+            while (currentOffset < end)
+            {
+                int firstKeyIndex = sortedIndices[currentOffset];
+                int targetChildIndex = searchComparer.FindIndex(keys[firstKeyIndex], node.keys);
+                if (targetChildIndex < 0) targetChildIndex = ~targetChildIndex;
+
+                int itemsForThisChild = 1;
+
+                while (currentOffset + itemsForThisChild < end)
+                {
+                    int nextKeyIndex = sortedIndices[currentOffset + itemsForThisChild];
+                    int nextChildIndex = searchComparer.FindIndex(keys[nextKeyIndex], node.keys);
+                    if (nextChildIndex < 0) nextChildIndex = ~nextChildIndex;
+
+                    if (nextChildIndex == targetChildIndex) itemsForThisChild++;
+                    else break;
+                }
+
+                workspace[workspaceStartIndex + sliceCount] =
+                    (node.children[targetChildIndex], currentOffset, itemsForThisChild);
+
+                sliceCount++;
+                currentOffset += itemsForThisChild;
+            }
+
+            node.Return();
+
+            for (int i = 0; i < sliceCount; i++)
+            {
+                var slice = workspace[workspaceStartIndex + i];
+
+                if (currentDepth == 1)
+                {
+                    // At leaf id
+                    mappings.Add(new LeafBatchMapping(slice.pointer, slice.offset, slice.length));
+                }
+                else
+                {
+                    var childNodeTask = m_stateClient.GetValue(slice.pointer);
+                    var rawChildNode = childNodeTask.IsCompletedSuccessfully
+                        ? childNodeTask.Result!
+                        : (await childNodeTask)!;
+
+                    var internalChild = (InternalNode<K, V, TKeyContainer>)rawChildNode;
+
+                    await RouteBatchInternalAsync(
+                        keys, sortedIndices, slice.offset, slice.length,
+                        internalChild, currentDepth - 1, searchComparer,
+                        mappings, workspace, workspaceStartIndex + sliceCount);
+                }
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
@@ -25,7 +25,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         internal IBplusTreeComparer<K, TKeyContainer> m_keyComparer;
         private int minSize;
         private bool m_isByteBased;
-        private int byteMinSize;
+        internal int byteMinSize;
         private bool m_usePreviousPointer;
 
         public BPlusTree(IStateClient<IBPlusTreeNode, BPlusTreeMetadata> stateClient, BPlusTreeOptions<K, V, TKeyContainer, TValueContainer> options)

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
@@ -54,7 +54,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 var emptyKeyContainer = m_options.KeySerializer.CreateEmpty();
                 var emptyValueContainer = m_options.ValueSerializer.CreateEmpty();
                 var root = new LeafNode<K, V, TKeyContainer, TValueContainer>(rootId, emptyKeyContainer, emptyValueContainer);
-                m_stateClient.Metadata = BPlusTreeMetadata.Create(m_options.BucketSize.Value, rootId, rootId, m_options.PageSizeBytes.Value, new List<long>(), new List<long>());
+                m_stateClient.Metadata = BPlusTreeMetadata.Create(m_options.BucketSize.Value, rootId, rootId, m_options.PageSizeBytes.Value, new List<long>(), new List<long>(), 0);
                 m_stateClient.AddOrUpdate(rootId, root);
             }
             return Task.CompletedTask;
@@ -204,7 +204,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             var emptyKeys = m_options.KeySerializer.CreateEmpty();
             var emptyValues = m_options.ValueSerializer.CreateEmpty();
             var root = new LeafNode<K, V, TKeyContainer, TValueContainer>(rootId, emptyKeys, emptyValues);
-            m_stateClient.Metadata = BPlusTreeMetadata.Create(m_options.BucketSize.Value, rootId, rootId, m_options.PageSizeBytes.Value, new List<long>(), new List<long>());
+            m_stateClient.Metadata = BPlusTreeMetadata.Create(m_options.BucketSize.Value, rootId, rootId, m_options.PageSizeBytes.Value, new List<long>(), new List<long>(), 0);
             m_stateClient.AddOrUpdate(rootId, root);
         }
     }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
@@ -25,7 +25,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         internal IBplusTreeComparer<K, TKeyContainer> m_keyComparer;
         private int minSize;
         private bool m_isByteBased;
-        internal int byteMinSize;
+        internal readonly int byteMinSize;
         private bool m_usePreviousPointer;
 
         public BPlusTree(IStateClient<IBPlusTreeNode, BPlusTreeMetadata> stateClient, BPlusTreeOptions<K, V, TKeyContainer, TValueContainer> options)

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTree.cs
@@ -207,5 +207,16 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             m_stateClient.Metadata = BPlusTreeMetadata.Create(m_options.BucketSize.Value, rootId, rootId, m_options.PageSizeBytes.Value, new List<long>(), new List<long>(), 0);
             m_stateClient.AddOrUpdate(rootId, root);
         }
+
+        public IBplusTreeBulkSearch<K, V, TKeyContainer, TValueContainer, TComparer> CreateBulkSearcher<TComparer>(TComparer comparer)
+            where TComparer : IBplusTreeComparer<K, TKeyContainer>
+        {
+            return new BPlusTreeBulkSearch<K, V, TKeyContainer, TValueContainer, TComparer>(this, comparer);
+        }
+
+        public IBPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer> CreateBulkInserter()
+        {
+            return new BPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer>(this);
+        }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -52,7 +52,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         private int[] _insertTargetPositions = Array.Empty<int>();
         private int[] _deletePositions = Array.Empty<int>();
         private int[] _lookupBuffer = Array.Empty<int>();
-        List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
+        private readonly List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
         private K[]? _keys;
         private V[]? _values;
         private readonly List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireSplitMappings;

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -97,13 +97,14 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         public async ValueTask MutateBatch<TMutator>(TMutator mutator)
             where TMutator : IRowMutator<K, V>
         {
-            foreach (var map in _mappings)
+            for (int i = 0; i < _mappings.Count; i++)
             {
-                var leafTask = _tree.m_stateClient.GetValue(map.LeafId);
+                var mapping = _mappings[i];
+                var leafTask = _tree.m_stateClient.GetValue(mapping.LeafId);
                 var leaf = (leafTask.IsCompletedSuccessfully ? leafTask.Result : await leafTask)
                             as LeafNode<K, V, TKeyContainer, TValueContainer>;
 
-                LeafMutateFromBatch(leaf!, mutator, in map, _tree.m_keyComparer);
+                LeafMutateFromBatch(leaf!, mutator, in mapping, _tree.m_keyComparer);
                 leaf.Return();
             }
         }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -1,0 +1,81 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage.Tree.Internal
+{
+    internal readonly struct ExternalKeyComparer<T, TKeyContainer> : IComparer<int>
+        where TKeyContainer : IKeyContainer<T>
+    {
+        private readonly T[] _keys;
+        private readonly IBplusTreeComparer<T, TKeyContainer> _comparer;
+
+        public ExternalKeyComparer(T[] keys, IBplusTreeComparer<T, TKeyContainer> comparer)
+        {
+            _keys = keys;
+            _comparer = comparer;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Compare(int x, int y)
+        {
+            return _comparer.CompareTo(_keys[x], _keys[y]);
+        }
+    }
+
+    internal class BPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer> 
+        : IBPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer>
+        where TKeyContainer : IKeyContainer<K>
+        where TValueContainer : IValueContainer<V>
+    {
+        
+
+        private readonly BPlusTree<K, V, TKeyContainer, TValueContainer> _tree;
+        private int[] _sortedIndices = Array.Empty<int>();
+        private int _keyLength;
+
+        public BPlusTreeBulkInserter(BPlusTree<K, V, TKeyContainer, TValueContainer> tree)
+        {
+            _tree = tree;
+        }
+
+        public ValueTask StartBatch(K[] keys, V[] values)
+        {
+            if (keys.Length > _sortedIndices.Length)
+            {
+                _sortedIndices = new int[keys.Length];
+            }
+            _keyLength = keys.Length;
+
+            // Sort the keys and values by keys
+            var keyComparer = _tree.m_keyComparer;
+
+            for (int i = 0; i < keys.Length; i++)
+            {
+                _sortedIndices[i] = i;
+            }
+
+            var indicesSpan = _sortedIndices.AsSpan().Slice(0, _keyLength);
+            indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer>(keys,keyComparer));
+
+            // Find leafIds where the keys should be inserted
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -76,16 +76,16 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             _keys = keys;
             _values = values;
             _mappings.Clear();
-            if (keys.Length > _sortedIndices.Length)
+            if (keyLength > _sortedIndices.Length)
             {
-                _sortedIndices = new int[keys.Length];
+                _sortedIndices = new int[keyLength];
             }
-            _keyLength = keys.Length;
+            _keyLength = keyLength;
 
             // Sort the keys and values by keys
             var keyComparer = _tree.m_keyComparer;
 
-            for (int i = 0; i < keys.Length; i++)
+            for (int i = 0; i < keyLength; i++)
             {
                 _sortedIndices[i] = i;
             }
@@ -106,6 +106,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                             as LeafNode<K, V, TKeyContainer, TValueContainer>;
 
                 LeafMutateFromBatch(leaf!, mutator, in map, _tree.m_keyComparer);
+                leaf.Return();
             }
         }
 

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -163,15 +163,17 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 MultiElementLeaf++;
             }
 
+            var leafCount = leaf.keys.Count;
             int insertCounter = 0;
             for (int i = 0; i < mapping.Length; i++)
             {
                 var keyIndex = _sortedIndices[mapping.Offset + i];
                 var key = _keys[keyIndex];
 
+                
                 // check if we are at the end of the leaf
                 // // if so we can just append the remaining keys to the end of the leaf without searching
-                if ((previousIndex + 1) == leaf.keys.Count)
+                if ((previousIndex) == leafCount)
                 {
                     // This means all the remaining keys in the batch are greater than the keys in the leaf, so we can just append them to the end of the leaf without searching
                     var operation = mutator.Process(key, false, default!, ref _values[keyIndex]);
@@ -179,10 +181,10 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     {
                         // Insert the key and value into the leaf at the correct position
                         _insertSortedIndices[insertCounter] = keyIndex;
-                        _insertTargetPositions[insertCounter] = leaf.keys.Count;
+                        _insertTargetPositions[insertCounter] = leafCount;
                         insertCounter++;
                         //leaf.InsertAt(key, _values[keyIndex], leaf.keys.Count);
-                        previousIndex = leaf.keys.Count - 1;
+                        previousIndex = leafCount;
                     }
                     continue;
                 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -48,6 +48,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         private int[] _sortedIndices = Array.Empty<int>();
         private int[] _insertSortedIndices = Array.Empty<int>();
         private int[] _insertTargetPositions = Array.Empty<int>();
+        private int[] _deletePositions = Array.Empty<int>();
         private int _keyLength;
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
         private K[]? _keys;
@@ -83,6 +84,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 _sortedIndices = new int[keyLength];
                 _insertSortedIndices = new int[keyLength];
                 _insertTargetPositions = new int[keyLength];
+                _deletePositions = new int[keyLength];
             }
             _keyLength = keyLength;
 
@@ -165,6 +167,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
             var leafCount = leaf.keys.Count;
             int insertCounter = 0;
+            int deleteCounter = 0;
+            int insertOffset = 0;
             for (int i = 0; i < mapping.Length; i++)
             {
                 var keyIndex = _sortedIndices[mapping.Offset + i];
@@ -181,9 +185,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     {
                         // Insert the key and value into the leaf at the correct position
                         _insertSortedIndices[insertCounter] = keyIndex;
-                        _insertTargetPositions[insertCounter] = leafCount;
+                        _insertTargetPositions[insertCounter] = leafCount + insertOffset;
                         insertCounter++;
-                        //leaf.InsertAt(key, _values[keyIndex], leaf.keys.Count);
                         previousIndex = leafCount;
                     }
                     continue;
@@ -202,10 +205,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     if (operation == GenericWriteOperation.Upsert)
                     {
                         _insertSortedIndices[insertCounter] = keyIndex;
-                        _insertTargetPositions[insertCounter] = leafIndex;
+                        _insertTargetPositions[insertCounter] = leafIndex + insertOffset;
                         insertCounter++;
-                        // Insert the key and value into the leaf at the correct position
-                        //leaf.InsertAt(key, _values[keyIndex], leafIndex);
                     }
                 }
                 else
@@ -221,22 +222,29 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     }
                     else if (operation == GenericWriteOperation.Delete)
                     {
-                        // Remove the key and value from the leaf
-                        throw new NotImplementedException();
-                        //leaf.DeleteAt(leafIndex);
+                        // Add the leaf index for deletion
+                        _deletePositions[deleteCounter++] = leafIndex + insertOffset;
+
+                        // Since we are deleting an element, the insert offset needs to be decreased by one, because the leaf will have one less element after the deletion
+                        insertOffset--;
                     }
                 }
             }
 
+            if (deleteCounter > 0)
+            {
+                var deleteSpan = _deletePositions.AsSpan(0, deleteCounter);
+                leaf.keys.DeleteBatch(deleteSpan);
+                leaf.values.DeleteBatch(deleteSpan);
+            }
+
             if (insertCounter > 0)
             {
-                leaf.keys.InsertFrom(_keys, _insertSortedIndices.AsSpan(0, insertCounter), _insertTargetPositions.AsSpan(0, insertCounter));
-                leaf.values.InsertFrom(_values, _insertSortedIndices.AsSpan(0, insertCounter), _insertTargetPositions.AsSpan(0, insertCounter));
+                var insertSortedIndicesSpan = _insertSortedIndices.AsSpan(0, insertCounter);
+                var insertTargetPositionsSpan = _insertTargetPositions.AsSpan(0, insertCounter);
+                leaf.keys.InsertFrom(_keys, insertSortedIndicesSpan, insertTargetPositionsSpan);
+                leaf.values.InsertFrom(_values, insertSortedIndicesSpan, insertTargetPositionsSpan);
             }
-            //if (leaf.keys is PrimitiveListKeyContainer<K> list)
-            //{
-
-            //}
 
             var byteSize = leaf.ByteSize;
             if (byteSize > _tree.m_stateClient.Metadata!.PageSizeBytes &&

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -56,7 +56,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         private K[]? _keys;
         private V[]? _values;
         private readonly List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireSplitMappings;
-        List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireMergeMappings;
+        private readonly List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireMergeMappings;
 
         public int LeafHitCount => _mappings.Count;
 

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -10,13 +10,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Storage.Tree.Internal
 {
@@ -49,14 +45,11 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         private int[] _insertSortedIndices = Array.Empty<int>();
         private int[] _insertTargetPositions = Array.Empty<int>();
         private int[] _deletePositions = Array.Empty<int>();
-        private int _keyLength;
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
         private K[]? _keys;
         private V[]? _values;
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireSplitMappings;
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireMergeMappings;
-        private int singleElementLeaf = 0;
-        private int MultiElementLeaf = 0;
 
         public BPlusTreeBulkInserter(BPlusTree<K, V, TKeyContainer, TValueContainer> tree)
         {
@@ -86,7 +79,6 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 _insertTargetPositions = new int[keyLength];
                 _deletePositions = new int[keyLength];
             }
-            _keyLength = keyLength;
 
             // Sort the keys and values by keys
             var keyComparer = _tree.m_keyComparer;
@@ -96,7 +88,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 _sortedIndices[i] = i;
             }
 
-            var indicesSpan = _sortedIndices.AsSpan().Slice(0, _keyLength);
+            var indicesSpan = _sortedIndices.AsSpan().Slice(0, keyLength);
             indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer>(keys,keyComparer));
 
             return _tree.RouteBatchRootAsync(keys, keyLength, _sortedIndices, _tree.m_keyComparer, _mappings);
@@ -156,14 +148,6 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         {
             Debug.Assert(_values != null && _keys != null);
             int previousIndex = -1;
-            if (mapping.Length == 1)
-            {
-                singleElementLeaf++;
-            }
-            else
-            {
-                MultiElementLeaf++;
-            }
 
             var leafCount = leaf.keys.Count;
             int insertCounter = 0;
@@ -174,36 +158,74 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             // Since keys are sorted, duplicates are always adjacent.
             int prevSortedKeyIndex = -1;
             bool prevWasPendingInsert = false;
+            bool prevWasPendingDelete = false;
 
             for (int i = 0; i < mapping.Length; i++)
             {
                 var keyIndex = _sortedIndices[mapping.Offset + i];
                 var key = _keys[keyIndex];
 
-                // Duplicate detection
-                if (prevWasPendingInsert && prevSortedKeyIndex >= 0
+                // Detect duplicate: current key equals previous key in sorted order.
+                if (prevSortedKeyIndex >= 0
                     && searchComparer.CompareTo(key, _keys[prevSortedKeyIndex]) == 0)
                 {
-                    // The previous duplicate queued a pending insert.
-                    // Process this as an update to that pending insert.
-                    Debug.Assert(insertCounter > 0);
-                    var prevInsertKeyIndex = _insertSortedIndices[insertCounter - 1];
-                    var pendingValue = _values[prevInsertKeyIndex];
-                    var operation = mutator.Process(key, true, in pendingValue, ref _values[keyIndex]);
+                    if (prevWasPendingInsert)
+                    {
+                        // The previous duplicate queued a pending insert.
+                        // Process this as an update to that pending insert.
+                        Debug.Assert(insertCounter > 0);
+                        var prevInsertKeyIndex = _insertSortedIndices[insertCounter - 1];
+                        var pendingValue = _values[prevInsertKeyIndex];
+                        var operation = mutator.Process(key, true, in pendingValue, ref _values[keyIndex]);
 
-                    if (operation == GenericWriteOperation.Upsert)
-                    {
-                        // Replace the pending insert's key index so InsertFrom uses the new value
-                        _insertSortedIndices[insertCounter - 1] = keyIndex;
+                        if (operation == GenericWriteOperation.Upsert)
+                        {
+                            // Replace the pending insert's key index so InsertFrom uses the new value
+                            _insertSortedIndices[insertCounter - 1] = keyIndex;
+                        }
+                        else if (operation == GenericWriteOperation.Delete)
+                        {
+                            // Cancel the pending insert
+                            insertCounter--;
+                            insertOffset--;
+                            prevWasPendingInsert = false;
+                            prevWasPendingDelete = true;
+                        }
+                        // None: keep the previous pending insert unchanged
                     }
-                    else if (operation == GenericWriteOperation.Delete)
+                    else if (prevWasPendingDelete)
                     {
-                        // Cancel the pending insert
-                        insertCounter--;
-                        insertOffset--;
-                        prevWasPendingInsert = false;
+                        Debug.Assert(deleteCounter > 0);
+                        var operation = mutator.Process(key, false, default!, ref _values[keyIndex]);
+
+                        if (operation == GenericWriteOperation.Upsert)
+                        {
+                            deleteCounter--;
+                            insertOffset++;
+
+                            leaf.UpdateValueAt(previousIndex, _values[keyIndex]);
+                            prevWasPendingInsert = false;
+                            prevWasPendingDelete = false;
+                        }
                     }
-                    // None: keep the previous pending insert unchanged
+                    else
+                    {
+                        // Key exists in the original leaf and was updated/no-oped.
+                        // Process as exists=true with the current leaf value.
+                        var existingValue = leaf.values.Get(previousIndex);
+                        var operation = mutator.Process(key, true, in existingValue, ref _values[keyIndex]);
+
+                        if (operation == GenericWriteOperation.Upsert)
+                        {
+                            leaf.UpdateValueAt(previousIndex, _values[keyIndex]);
+                        }
+                        else if (operation == GenericWriteOperation.Delete)
+                        {
+                            _deletePositions[deleteCounter++] = previousIndex;
+                            insertOffset--;
+                            prevWasPendingDelete = true;
+                        }
+                    }
 
                     prevSortedKeyIndex = keyIndex;
                     continue;
@@ -211,7 +233,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                 // check if we are at the end of the leaf
                 // if so we can just append the remaining keys to the end of the leaf without searching
-                if ((previousIndex) == leafCount)
+                if (previousIndex == leafCount)
                 {
                     // This means all the remaining keys in the batch are greater than the keys in the leaf, so we can just append them to the end of the leaf without searching
                     var operation = mutator.Process(key, false, default!, ref _values[keyIndex]);
@@ -228,6 +250,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     {
                         prevWasPendingInsert = false;
                     }
+                    prevWasPendingDelete = false;
                     prevSortedKeyIndex = keyIndex;
                     continue;
                 }
@@ -251,6 +274,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     {
                         prevWasPendingInsert = false;
                     }
+                    prevWasPendingDelete = false;
                 }
                 else
                 {
@@ -262,6 +286,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     {
                         // Update the value in the leaf
                         leaf.UpdateValueAt(leafIndex, _values[keyIndex]);
+                        prevWasPendingInsert = false;
+                        prevWasPendingDelete = false;
                     }
                     else if (operation == GenericWriteOperation.Delete)
                     {
@@ -270,8 +296,14 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                         // Since we are deleting an element, the insert offset needs to be decreased by one, because the leaf will have one less element after the deletion
                         insertOffset--;
+                        prevWasPendingInsert = false;
+                        prevWasPendingDelete = true;
                     }
-                    prevWasPendingInsert = false;
+                    else
+                    {
+                        prevWasPendingInsert = false;
+                        prevWasPendingDelete = false;
+                    }
                 }
                 prevSortedKeyIndex = keyIndex;
             }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -53,6 +53,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireSplitMappings;
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireMergeMappings;
 
+        public int LeafHitCount => _mappings.Count;
+
         public BPlusTreeBulkInserter(BPlusTree<K, V, TKeyContainer, TValueContainer> tree)
         {
             _tree = tree;

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -48,10 +48,11 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         private readonly BPlusTree<K, V, TKeyContainer, TValueContainer> _tree;
         private int[] _sortedIndices = Array.Empty<int>();
         private int _keyLength;
-
+        List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
         public BPlusTreeBulkInserter(BPlusTree<K, V, TKeyContainer, TValueContainer> tree)
         {
             _tree = tree;
+            _mappings = new List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping>();
         }
 
         public ValueTask StartBatch(K[] keys, V[] values)
@@ -73,9 +74,9 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             var indicesSpan = _sortedIndices.AsSpan().Slice(0, _keyLength);
             indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer>(keys,keyComparer));
 
-            // Find leafIds where the keys should be inserted
-
-            return ValueTask.CompletedTask;
+            return _tree.RouteBatchRootAsync(keys, _sortedIndices, _tree.m_keyComparer, _mappings);
         }
+
+
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -46,6 +46,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         private int[] _insertSortedIndices = Array.Empty<int>();
         private int[] _insertTargetPositions = Array.Empty<int>();
         private int[] _deletePositions = Array.Empty<int>();
+        private int[] _lookupBuffer = Array.Empty<int>();
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
         private K[]? _keys;
         private V[]? _values;
@@ -97,7 +98,15 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         {
             _keys = keys;
             _values = values;
+            _sortedIndices = sortedIndices;
             _mappings.Clear();
+            if (keyLength > _insertSortedIndices.Length)
+            {
+                _insertSortedIndices = new int[keyLength];
+                _insertTargetPositions = new int[keyLength];
+                _deletePositions = new int[keyLength];
+                _lookupBuffer = new int[keyLength];
+            }
             return _tree.RouteBatchRootAsync(keys, keyLength, sortedIndices, _tree.m_keyComparer, _mappings);
         }
 
@@ -112,6 +121,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 _insertSortedIndices = new int[keyLength];
                 _insertTargetPositions = new int[keyLength];
                 _deletePositions = new int[keyLength];
+                _lookupBuffer = new int[keyLength];
             }
 
             // Sort the keys and values by keys
@@ -382,7 +392,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             {
                 var insertSortedIndicesSpan = _insertSortedIndices.AsSpan(0, insertCounter);
                 var insertTargetPositionsSpan = _insertTargetPositions.AsSpan(0, insertCounter);
-                leaf.keys.InsertFrom(_keys, insertSortedIndicesSpan, insertTargetPositionsSpan);
+                var lookupBufferSpan = _lookupBuffer.AsSpan(0, insertCounter);
+                leaf.keys.InsertFrom(_keys, insertSortedIndicesSpan, insertTargetPositionsSpan, lookupBufferSpan);
                 leaf.values.InsertFrom(_values, insertSortedIndicesSpan, insertTargetPositionsSpan);
             }
 

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -43,20 +44,38 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         where TKeyContainer : IKeyContainer<K>
         where TValueContainer : IValueContainer<V>
     {
-        
-
         private readonly BPlusTree<K, V, TKeyContainer, TValueContainer> _tree;
         private int[] _sortedIndices = Array.Empty<int>();
         private int _keyLength;
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
+        private K[]? _keys;
+        private V[]? _values;
+        List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireSplitMappings;
+        List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireMergeMappings;
+        private int singleElementLeaf = 0;
+        private int MultiElementLeaf = 0;
+
         public BPlusTreeBulkInserter(BPlusTree<K, V, TKeyContainer, TValueContainer> tree)
         {
             _tree = tree;
             _mappings = new List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping>();
+            _requireSplitMappings = new List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping>();
+            _requireMergeMappings = new List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping>();
         }
 
-        public ValueTask StartBatch(K[] keys, V[] values)
+        public async ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, TMutator mutator)
+            where TMutator : IRowMutator<K, V>
         {
+            await StartBatch(keys, values, keyLength);
+            await MutateBatch(mutator);
+            await ApplySplitsAndMerges();
+        }
+
+        public ValueTask StartBatch(K[] keys, V[] values, int keyLength)
+        {
+            _keys = keys;
+            _values = values;
+            _mappings.Clear();
             if (keys.Length > _sortedIndices.Length)
             {
                 _sortedIndices = new int[keys.Length];
@@ -74,9 +93,140 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             var indicesSpan = _sortedIndices.AsSpan().Slice(0, _keyLength);
             indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer>(keys,keyComparer));
 
-            return _tree.RouteBatchRootAsync(keys, _sortedIndices, _tree.m_keyComparer, _mappings);
+            return _tree.RouteBatchRootAsync(keys, keyLength, _sortedIndices, _tree.m_keyComparer, _mappings);
         }
 
+        public async ValueTask MutateBatch<TMutator>(TMutator mutator)
+            where TMutator : IRowMutator<K, V>
+        {
+            foreach (var map in _mappings)
+            {
+                var leafTask = _tree.m_stateClient.GetValue(map.LeafId);
+                var leaf = (leafTask.IsCompletedSuccessfully ? leafTask.Result : await leafTask)
+                            as LeafNode<K, V, TKeyContainer, TValueContainer>;
+
+                LeafMutateFromBatch(leaf!, mutator, in map, _tree.m_keyComparer);
+            }
+        }
+
+        public async ValueTask ApplySplitsAndMerges()
+        {
+            // at the start we just split once, not multi splits, this can also be improved later to do X splits directly.
+            for(int i = 0; i < _requireSplitMappings.Count; i++)
+            {
+                var map = _requireSplitMappings[i];
+                var keyIndex = _sortedIndices[map.Offset];
+                var firstKey = _keys[keyIndex];
+
+                await _tree.RMWNoResult(firstKey, default, static (input, current, found) =>
+                {
+                    return (default, GenericWriteOperation.None);
+                });
+            }
+
+            for (int i = 0; i < _requireMergeMappings.Count; i++)
+            {
+                var map = _requireSplitMappings[i];
+                var keyIndex = _sortedIndices[map.Offset];
+                var firstKey = _keys[keyIndex];
+
+                await _tree.RMWNoResult(firstKey, default, static (input, current, found) =>
+                {
+                    return (default, GenericWriteOperation.None);
+                });
+            }
+
+            _requireSplitMappings.Clear();
+            _requireMergeMappings.Clear();
+        }
+
+        private void LeafMutateFromBatch<TMutator>(
+            LeafNode<K, V, TKeyContainer, TValueContainer> leaf,
+            TMutator mutator,
+            in BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping mapping,
+            IBplusTreeComparer<K, TKeyContainer> searchComparer)
+            where TMutator : IRowMutator<K, V>
+        {
+            Debug.Assert(_values != null && _keys != null);
+            int previousIndex = -1;
+            if (mapping.Length == 1)
+            {
+                singleElementLeaf++;
+            }
+            else
+            {
+                MultiElementLeaf++;
+            }
+            for (int i = 0; i < mapping.Length; i++)
+            {
+                var keyIndex = _sortedIndices[mapping.Offset + i];
+                var key = _keys[keyIndex];
+
+                // check if we are at the end of the leaf
+                // // if so we can just append the remaining keys to the end of the leaf without searching
+                if ((previousIndex + 1) == leaf.keys.Count)
+                {
+                    // This means all the remaining keys in the batch are greater than the keys in the leaf, so we can just append them to the end of the leaf without searching
+                    var operation = mutator.Process(key, false, default!, ref _values[keyIndex]);
+                    if (operation == GenericWriteOperation.Upsert)
+                    {
+                        // Insert the key and value into the leaf at the correct position
+                        leaf.InsertAt(key, _values[keyIndex], leaf.keys.Count);
+                        previousIndex = leaf.keys.Count - 1;
+                    }
+                    continue;
+                }
+
+                var leafIndex = searchComparer.FindIndex(key, leaf.keys);
+                
+                // Later on all this code can be optimized to only modify the leaf data twice, once for insert and once for delete
+                // But for simplicity we will just do it in place for now, and optimize later
+                if (leafIndex < 0)
+                {
+                    leafIndex = ~leafIndex;
+                    previousIndex = leafIndex;
+                    var operation = mutator.Process(key, false, default!, ref _values[keyIndex]);
+
+                    if (operation == GenericWriteOperation.Upsert)
+                    {
+                        // Insert the key and value into the leaf at the correct position
+                        leaf.InsertAt(key, _values[keyIndex], leafIndex);
+                    }
+                }
+                else
+                {
+                    previousIndex = leafIndex;
+                    var existingValue = leaf.values.Get(leafIndex);
+                    var operation = mutator.Process(key, true, in existingValue, ref _values[keyIndex]);
+
+                    if (operation == GenericWriteOperation.Upsert)
+                    {
+                        // Update the value in the leaf
+                        leaf.UpdateValueAt(leafIndex, _values[keyIndex]);
+                    }
+                    else if (operation == GenericWriteOperation.Delete)
+                    {
+                        // Remove the key and value from the leaf
+                        leaf.DeleteAt(leafIndex);
+                    }
+                }
+
+            }
+
+            var byteSize = leaf.ByteSize;
+            if (byteSize > _tree.m_stateClient.Metadata!.PageSizeBytes &&
+                leaf.keys.Count > BPlusTree<K, V, TKeyContainer, TValueContainer>.minPageSizeBeforeSplit)
+            {
+                // Leaf is too big
+                _requireSplitMappings.Add(mapping);
+            }
+            else if (
+                leaf.Id != _tree.m_stateClient.Metadata!.Root &&
+                (byteSize <= _tree.byteMinSize || leaf.keys.Count < BPlusTree<K, V, TKeyContainer, TValueContainer>.minPageSize))
+            {
+                _requireMergeMappings.Add(mapping);
+            }
+        }
 
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -55,7 +55,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
         private K[]? _keys;
         private V[]? _values;
-        List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireSplitMappings;
+        private readonly List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireSplitMappings;
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _requireMergeMappings;
 
         public int LeafHitCount => _mappings.Count;

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -154,16 +154,18 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 var leafTask = _tree.m_stateClient.GetValue(mapping.LeafId);
                 var leaf = (leafTask.IsCompletedSuccessfully ? leafTask.Result : await leafTask)
                             as LeafNode<K, V, TKeyContainer, TValueContainer>;
-
-                LeafMutateFromBatch(leaf!, mutator, in mapping, _tree.m_keyComparer);
+                Debug.Assert(leaf != null, "Expected leaf node");
+                LeafMutateFromBatch(leaf, mutator, in mapping, _tree.m_keyComparer);
                 leaf.Return();
             }
         }
 
         public async ValueTask ApplySplitsAndMerges()
         {
+            Debug.Assert(_keys != null);
+
             // at the start we just split once, not multi splits, this can also be improved later to do X splits directly.
-            for(int i = 0; i < _requireSplitMappings.Count; i++)
+            for (int i = 0; i < _requireSplitMappings.Count; i++)
             {
                 var map = _requireSplitMappings[i];
                 var keyIndex = _sortedIndices[map.Offset];

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -159,6 +159,10 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             int prevSortedKeyIndex = -1;
             bool prevWasPendingInsert = false;
             bool prevWasPendingDelete = false;
+            // Whether the key physically exists in the original leaf (before
+            // deferred modifications). Needed to correctly cancel pending inserts:
+            // if the key was never in the leaf, canceling is a no-op on the leaf.
+            bool prevKeyExistsInLeaf = false;
 
             for (int i = 0; i < mapping.Length; i++)
             {
@@ -187,9 +191,18 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                         {
                             // Cancel the pending insert
                             insertCounter--;
-                            insertOffset--;
                             prevWasPendingInsert = false;
-                            prevWasPendingDelete = true;
+
+                            if (prevKeyExistsInLeaf)
+                            {
+                                insertOffset--;
+                                prevWasPendingDelete = true;
+                            }
+                            else
+                            {
+                                // Key was never in the leaf.
+                                prevWasPendingDelete = false;
+                            }
                         }
                         // None: keep the previous pending insert unchanged
                     }
@@ -208,7 +221,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                             prevWasPendingDelete = false;
                         }
                     }
-                    else
+                    else if (prevKeyExistsInLeaf)
                     {
                         // Key exists in the original leaf and was updated/no-oped.
                         // Process as exists=true with the current leaf value.
@@ -224,6 +237,18 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                             _deletePositions[deleteCounter++] = previousIndex;
                             insertOffset--;
                             prevWasPendingDelete = true;
+                        }
+                    }
+                    else
+                    {
+                        var operation = mutator.Process(key, false, default!, ref _values[keyIndex]);
+
+                        if (operation == GenericWriteOperation.Upsert)
+                        {
+                            _insertSortedIndices[insertCounter] = keyIndex;
+                            _insertTargetPositions[insertCounter] = previousIndex + insertOffset;
+                            insertCounter++;
+                            prevWasPendingInsert = true;
                         }
                     }
 
@@ -251,6 +276,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                         prevWasPendingInsert = false;
                     }
                     prevWasPendingDelete = false;
+                    prevKeyExistsInLeaf = false;
                     prevSortedKeyIndex = keyIndex;
                     continue;
                 }
@@ -275,6 +301,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                         prevWasPendingInsert = false;
                     }
                     prevWasPendingDelete = false;
+                    prevKeyExistsInLeaf = false;
                 }
                 else
                 {
@@ -304,6 +331,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                         prevWasPendingInsert = false;
                         prevWasPendingDelete = false;
                     }
+                    prevKeyExistsInLeaf = true;
                 }
                 prevSortedKeyIndex = keyIndex;
             }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -133,7 +133,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
             for (int i = 0; i < _requireMergeMappings.Count; i++)
             {
-                var map = _requireSplitMappings[i];
+                var map = _requireMergeMappings[i];
                 var keyIndex = _sortedIndices[map.Offset];
                 var firstKey = _keys[keyIndex];
 
@@ -169,14 +169,48 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             int insertCounter = 0;
             int deleteCounter = 0;
             int insertOffset = 0;
+
+            // Track the previous key's state for duplicate detection.
+            // Since keys are sorted, duplicates are always adjacent.
+            int prevSortedKeyIndex = -1;
+            bool prevWasPendingInsert = false;
+
             for (int i = 0; i < mapping.Length; i++)
             {
                 var keyIndex = _sortedIndices[mapping.Offset + i];
                 var key = _keys[keyIndex];
 
-                
+                // Duplicate detection
+                if (prevWasPendingInsert && prevSortedKeyIndex >= 0
+                    && searchComparer.CompareTo(key, _keys[prevSortedKeyIndex]) == 0)
+                {
+                    // The previous duplicate queued a pending insert.
+                    // Process this as an update to that pending insert.
+                    Debug.Assert(insertCounter > 0);
+                    var prevInsertKeyIndex = _insertSortedIndices[insertCounter - 1];
+                    var pendingValue = _values[prevInsertKeyIndex];
+                    var operation = mutator.Process(key, true, in pendingValue, ref _values[keyIndex]);
+
+                    if (operation == GenericWriteOperation.Upsert)
+                    {
+                        // Replace the pending insert's key index so InsertFrom uses the new value
+                        _insertSortedIndices[insertCounter - 1] = keyIndex;
+                    }
+                    else if (operation == GenericWriteOperation.Delete)
+                    {
+                        // Cancel the pending insert
+                        insertCounter--;
+                        insertOffset--;
+                        prevWasPendingInsert = false;
+                    }
+                    // None: keep the previous pending insert unchanged
+
+                    prevSortedKeyIndex = keyIndex;
+                    continue;
+                }
+
                 // check if we are at the end of the leaf
-                // // if so we can just append the remaining keys to the end of the leaf without searching
+                // if so we can just append the remaining keys to the end of the leaf without searching
                 if ((previousIndex) == leafCount)
                 {
                     // This means all the remaining keys in the batch are greater than the keys in the leaf, so we can just append them to the end of the leaf without searching
@@ -188,14 +222,18 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                         _insertTargetPositions[insertCounter] = leafCount + insertOffset;
                         insertCounter++;
                         previousIndex = leafCount;
+                        prevWasPendingInsert = true;
                     }
+                    else
+                    {
+                        prevWasPendingInsert = false;
+                    }
+                    prevSortedKeyIndex = keyIndex;
                     continue;
                 }
 
                 var leafIndex = searchComparer.FindIndex(key, leaf.keys);
-                
-                // Later on all this code can be optimized to only modify the leaf data twice, once for insert and once for delete
-                // But for simplicity we will just do it in place for now, and optimize later
+
                 if (leafIndex < 0)
                 {
                     leafIndex = ~leafIndex;
@@ -207,6 +245,11 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                         _insertSortedIndices[insertCounter] = keyIndex;
                         _insertTargetPositions[insertCounter] = leafIndex + insertOffset;
                         insertCounter++;
+                        prevWasPendingInsert = true;
+                    }
+                    else
+                    {
+                        prevWasPendingInsert = false;
                     }
                 }
                 else
@@ -223,12 +266,14 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     else if (operation == GenericWriteOperation.Delete)
                     {
                         // Add the leaf index for deletion
-                        _deletePositions[deleteCounter++] = leafIndex + insertOffset;
+                        _deletePositions[deleteCounter++] = leafIndex;
 
                         // Since we are deleting an element, the insert offset needs to be decreased by one, because the leaf will have one less element after the deletion
                         insertOffset--;
                     }
+                    prevWasPendingInsert = false;
                 }
+                prevSortedKeyIndex = keyIndex;
             }
 
             if (deleteCounter > 0)

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -46,6 +46,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
     {
         private readonly BPlusTree<K, V, TKeyContainer, TValueContainer> _tree;
         private int[] _sortedIndices = Array.Empty<int>();
+        private int[] _insertSortedIndices = Array.Empty<int>();
+        private int[] _insertTargetPositions = Array.Empty<int>();
         private int _keyLength;
         List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
         private K[]? _keys;
@@ -79,6 +81,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             if (keyLength > _sortedIndices.Length)
             {
                 _sortedIndices = new int[keyLength];
+                _insertSortedIndices = new int[keyLength];
+                _insertTargetPositions = new int[keyLength];
             }
             _keyLength = keyLength;
 
@@ -158,6 +162,8 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             {
                 MultiElementLeaf++;
             }
+
+            int insertCounter = 0;
             for (int i = 0; i < mapping.Length; i++)
             {
                 var keyIndex = _sortedIndices[mapping.Offset + i];
@@ -172,7 +178,10 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     if (operation == GenericWriteOperation.Upsert)
                     {
                         // Insert the key and value into the leaf at the correct position
-                        leaf.InsertAt(key, _values[keyIndex], leaf.keys.Count);
+                        _insertSortedIndices[insertCounter] = keyIndex;
+                        _insertTargetPositions[insertCounter] = leaf.keys.Count;
+                        insertCounter++;
+                        //leaf.InsertAt(key, _values[keyIndex], leaf.keys.Count);
                         previousIndex = leaf.keys.Count - 1;
                     }
                     continue;
@@ -190,8 +199,11 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
                     if (operation == GenericWriteOperation.Upsert)
                     {
+                        _insertSortedIndices[insertCounter] = keyIndex;
+                        _insertTargetPositions[insertCounter] = leafIndex;
+                        insertCounter++;
                         // Insert the key and value into the leaf at the correct position
-                        leaf.InsertAt(key, _values[keyIndex], leafIndex);
+                        //leaf.InsertAt(key, _values[keyIndex], leafIndex);
                     }
                 }
                 else
@@ -208,11 +220,21 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     else if (operation == GenericWriteOperation.Delete)
                     {
                         // Remove the key and value from the leaf
-                        leaf.DeleteAt(leafIndex);
+                        throw new NotImplementedException();
+                        //leaf.DeleteAt(leafIndex);
                     }
                 }
-
             }
+
+            if (insertCounter > 0)
+            {
+                leaf.keys.InsertFrom(_keys, _insertSortedIndices.AsSpan(0, insertCounter), _insertTargetPositions.AsSpan(0, insertCounter));
+                leaf.values.InsertFrom(_values, _insertSortedIndices.AsSpan(0, insertCounter), _insertTargetPositions.AsSpan(0, insertCounter));
+            }
+            //if (leaf.keys is PrimitiveListKeyContainer<K> list)
+            //{
+
+            //}
 
             var byteSize = leaf.ByteSize;
             if (byteSize > _tree.m_stateClient.Metadata!.PageSizeBytes &&

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -32,7 +32,12 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(int x, int y)
         {
-            return _comparer.CompareTo(_keys[x], _keys[y]);
+            var cmp = _comparer.CompareTo(_keys[x], _keys[y]);
+            if (cmp == 0)
+            {
+                return x.CompareTo(y);
+            }
+            return cmp;
         }
     }
 

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -16,13 +16,14 @@ using System.Runtime.CompilerServices;
 
 namespace FlowtideDotNet.Storage.Tree.Internal
 {
-    internal readonly struct ExternalKeyComparer<T, TKeyContainer> : IComparer<int>
+    internal readonly struct ExternalKeyComparer<T, TKeyContainer, TComparer> : IComparer<int>
         where TKeyContainer : IKeyContainer<T>
+        where TComparer : IBplusTreeComparer<T, TKeyContainer>
     {
         private readonly T[] _keys;
-        private readonly IBplusTreeComparer<T, TKeyContainer> _comparer;
+        private readonly TComparer _comparer;
 
-        public ExternalKeyComparer(T[] keys, IBplusTreeComparer<T, TKeyContainer> comparer)
+        public ExternalKeyComparer(T[] keys, TComparer comparer)
         {
             _keys = keys;
             _comparer = comparer;
@@ -35,7 +36,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         }
     }
 
-    internal class BPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer> 
+    internal class BPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer>
         : IBPlusTreeBulkInserter<K, V, TKeyContainer, TValueContainer>
         where TKeyContainer : IKeyContainer<K>
         where TValueContainer : IValueContainer<V>
@@ -67,6 +68,39 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             await ApplySplitsAndMerges();
         }
 
+
+        public async ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, int[] sortedIndices, TMutator mutator)
+            where TMutator : IRowMutator<K, V>
+        {
+            await StartBatch(keys, values, keyLength, sortedIndices);
+            await MutateBatch(mutator);
+            await ApplySplitsAndMerges();
+        }
+
+        public int[] SortAndGetIndices(K[] keys, int keyLength)
+        {
+            if (keyLength > _sortedIndices.Length)
+            {
+                _sortedIndices = new int[keyLength];
+            }
+            var keyComparer = _tree.m_keyComparer;
+            for (int i = 0; i < keyLength; i++)
+            {
+                _sortedIndices[i] = i;
+            }
+            var indicesSpan = _sortedIndices.AsSpan().Slice(0, keyLength);
+            indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer, IBplusTreeComparer<K, TKeyContainer>>(keys, keyComparer));
+            return _sortedIndices;
+        }
+
+        public ValueTask StartBatch(K[] keys, V[] values, int keyLength, int[] sortedIndices)
+        {
+            _keys = keys;
+            _values = values;
+            _mappings.Clear();
+            return _tree.RouteBatchRootAsync(keys, keyLength, sortedIndices, _tree.m_keyComparer, _mappings);
+        }
+
         public ValueTask StartBatch(K[] keys, V[] values, int keyLength)
         {
             _keys = keys;
@@ -89,7 +123,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             }
 
             var indicesSpan = _sortedIndices.AsSpan().Slice(0, keyLength);
-            indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer>(keys,keyComparer));
+            indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer, IBplusTreeComparer<K, TKeyContainer>>(keys,keyComparer));
 
             return _tree.RouteBatchRootAsync(keys, keyLength, _sortedIndices, _tree.m_keyComparer, _mappings);
         }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkSearch.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkSearch.cs
@@ -253,14 +253,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 var keyIndex = _sortedIndices[i];
                 var boundries = comparer.FindBoundries(_keys[keyIndex], leaf.keys, lowerBound, lastIndex);
 
-                if (boundries.lowerBounds < 0)
-                {
-                    lowerBound = ~boundries.lowerBounds;
-                }
-                else
-                {
-                    lowerBound = boundries.lowerBounds;
-                }
+                lowerBound = boundries.lowerBounds < 0 ? ~boundries.lowerBounds : boundries.lowerBounds;
 
                 var result = new BulkSearchKeyResult
                 {

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkSearch.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkSearch.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -121,29 +121,28 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
             if (_mappingIndex >= _mappings.Count)
             {
-                Debug.Assert(_currentLeaf != null);
-                if (_currentLeaf!.next == 0)
-                {
-                    // No next leaf, carry-over keys have no more matches.
-                    _currentLeaf.Return();
-                    _currentLeaf = null;
-                    _carryOverRead.Clear();
-                    return ValueTask.FromResult(false);
-                }
-
-                var getNextTask = _tree.m_stateClient.GetValue(_currentLeaf.next);
-                if (!getNextTask.IsCompletedSuccessfully)
-                {
-                    return MoveNextLeaf_CarryOverSlow(getNextTask);
-                }
-
-                _currentLeaf.Return();
-                _currentLeaf = (getNextTask.Result as LeafNode<K, V, TKeyContainer, TValueContainer>)!;
-                ProcessCarryOverOnly();
-                return ValueTask.FromResult(true);
+                return MoveNextLeaf_FollowLinkedList();
             }
 
             var mapping = _mappings[_mappingIndex];
+
+            // Carry-over keys exist: check if we need to visit intermediate leaves first.
+            if (_carryOverRead.Count > 0 && _currentLeaf != null)
+            {
+                if (_currentLeaf.next == 0)
+                {
+                    // No next leaf - drop carry-over, proceed to mapping below.
+                    _carryOverRead.Clear();
+                }
+                else if (_currentLeaf.next != mapping.LeafId)
+                {
+                    // Intermediate leaf exists between current position and the mapping's leaf.
+                    // Follow the linked list without consuming the mapping.
+                    return MoveNextLeaf_FollowLinkedList();
+                }
+                // else: next leaf IS the mapping's leaf - fall through to process both.
+            }
+
             _mappingIndex++;
 
             var getLeafTask = _tree.m_stateClient.GetValue(mapping.LeafId);
@@ -184,6 +183,36 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             return true;
         }
 
+        /// <summary>
+        /// Follows the leaf linked list to process carry-over keys in the next adjacent leaf.
+        /// Returns false if there is no next leaf (carry-over keys are dropped).
+        /// </summary>
+        private ValueTask<bool> MoveNextLeaf_FollowLinkedList()
+        {
+            Debug.Assert(_currentLeaf != null);
+            Debug.Assert(_carryOverRead.Count > 0);
+
+            if (_currentLeaf!.next == 0)
+            {
+                // No next leaf, carry-over keys have no more matches.
+                _currentLeaf.Return();
+                _currentLeaf = null;
+                _carryOverRead.Clear();
+                return ValueTask.FromResult(false);
+            }
+
+            var getNextTask = _tree.m_stateClient.GetValue(_currentLeaf.next);
+            if (!getNextTask.IsCompletedSuccessfully)
+            {
+                return MoveNextLeaf_CarryOverSlow(getNextTask);
+            }
+
+            _currentLeaf.Return();
+            _currentLeaf = (getNextTask.Result as LeafNode<K, V, TKeyContainer, TValueContainer>)!;
+            ProcessCarryOverOnly();
+            return ValueTask.FromResult(true);
+        }
+
         private void ProcessLeaf(BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping mapping)
         {
             _currentResults.Clear();
@@ -206,7 +235,9 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     ContinuesToNextLeaf = false
                 };
 
-                if (boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex && leaf.next != 0)
+                if (leaf.next != 0 &&
+                    ((boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex) ||
+                     (boundries.lowerBounds < 0 && (~boundries.lowerBounds) > lastIndex)))
                 {
                     result.ContinuesToNextLeaf = true;
                     _carryOverWrite.Add(keyIndex);
@@ -239,7 +270,9 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     ContinuesToNextLeaf = false
                 };
 
-                if (boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex && leaf.next != 0)
+                if (leaf.next != 0 &&
+                    ((boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex) ||
+                     (boundries.lowerBounds < 0 && (~boundries.lowerBounds) > lastIndex)))
                 {
                     result.ContinuesToNextLeaf = true;
                     _carryOverWrite.Add(keyIndex);
@@ -275,7 +308,9 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     ContinuesToNextLeaf = false
                 };
 
-                if (boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex && leaf.next != 0)
+                if (leaf.next != 0 &&
+                    ((boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex) ||
+                     (boundries.lowerBounds < 0 && (~boundries.lowerBounds) > lastIndex)))
                 {
                     result.ContinuesToNextLeaf = true;
                     _carryOverWrite.Add(keyIndex);
@@ -287,6 +322,18 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             var temp = _carryOverRead;
             _carryOverRead = _carryOverWrite;
             _carryOverWrite = temp;
+        }
+
+        public void Dispose()
+        {
+            if (_currentLeaf != null)
+            {
+                _currentLeaf.Return();
+                _currentLeaf = null;
+            }
+            _carryOverRead.Clear();
+            _carryOverWrite.Clear();
+            _currentResults.Clear();
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkSearch.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkSearch.cs
@@ -1,0 +1,292 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Storage.Tree.Internal
+{
+
+    internal class BPlusTreeBulkSearch<K, V, TKeyContainer, TValueContainer, TComparer> : IBplusTreeBulkSearch<K, V, TKeyContainer, TValueContainer, TComparer>
+        where TKeyContainer : IKeyContainer<K>
+        where TValueContainer : IValueContainer<V>
+        where TComparer : IBplusTreeComparer<K ,TKeyContainer>
+    {
+        private int[] _sortedIndices = Array.Empty<int>();
+        private readonly BPlusTree<K, V, TKeyContainer, TValueContainer> _tree;
+        private readonly TComparer _comparer;
+        private readonly List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping> _mappings;
+
+        private K[] _keys = Array.Empty<K>();
+        private int _mappingIndex;
+        private LeafNode<K, V, TKeyContainer, TValueContainer>? _currentLeaf;
+
+        // Keys that carry over from the previous leaf.
+        private List<int> _carryOverRead = new List<int>(64);
+        private List<int> _carryOverWrite = new List<int>(64);
+
+        // Results for the current leaf.
+        private readonly List<BulkSearchKeyResult> _currentResults = new List<BulkSearchKeyResult>();
+
+        public BPlusTreeBulkSearch(BPlusTree<K, V, TKeyContainer, TValueContainer> tree, TComparer comparer)
+        {
+            _tree = tree;
+            this._comparer = comparer;
+            _mappings = new List<BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping>();
+        }
+
+        /// <summary>
+        /// The current leaf node. Only valid after <see cref="MoveNextLeaf"/> returns true.
+        /// </summary>
+        public LeafNode<K, V, TKeyContainer, TValueContainer> CurrentLeaf
+        {
+            get
+            {
+                Debug.Assert(_currentLeaf != null);
+                return _currentLeaf;
+            }
+        }
+
+        /// <summary>
+        /// The search results for the current leaf. Each entry describes one search key
+        /// and its found boundaries within the leaf.
+        /// </summary>
+        public IReadOnlyList<BulkSearchKeyResult> CurrentResults => _currentResults;
+
+        public ValueTask Start(K[] keys, int keyLength)
+        {
+            if (keyLength > _sortedIndices.Length)
+            {
+                _sortedIndices = new int[keyLength];
+            }
+
+            for (int i = 0; i < keyLength; i++)
+            {
+                _sortedIndices[i] = i;
+            }
+
+            var indicesSpan = _sortedIndices.AsSpan().Slice(0, keyLength);
+            indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer, TComparer>(keys, _comparer));
+
+            return Start(keys, keyLength, _sortedIndices);
+        }
+
+        public ValueTask Start(K[] keys, int keyLength, int[] sortedIndices)
+        {
+            _keys = keys;
+            _sortedIndices = sortedIndices;
+            _mappingIndex = 0;
+            _carryOverRead.Clear();
+            _carryOverWrite.Clear();
+            _currentResults.Clear();
+            if (_currentLeaf != null)
+            {
+                _currentLeaf.Return();
+                _currentLeaf = null;
+            }
+            _mappings.Clear();
+            return _tree.RouteBatchRootAsync(keys, keyLength, sortedIndices, _comparer, _mappings);
+        }
+
+        /// <summary>
+        /// Advances to the next leaf that has search keys mapped to it.
+        /// Returns false when all leaves have been visited.
+        /// Await this only when moving between leaves; iteration within a leaf is synchronous via <see cref="CurrentResults"/>.
+        /// </summary>
+        public ValueTask<bool> MoveNextLeaf()
+        {
+            // If there are no more mappings and no carry-over keys, we are done.
+            if (_mappingIndex >= _mappings.Count && _carryOverRead.Count == 0)
+            {
+                if (_currentLeaf != null)
+                {
+                    _currentLeaf.Return();
+                    _currentLeaf = null;
+                }
+                return ValueTask.FromResult(false);
+            }
+
+            if (_mappingIndex >= _mappings.Count)
+            {
+                Debug.Assert(_currentLeaf != null);
+                if (_currentLeaf!.next == 0)
+                {
+                    // No next leaf, carry-over keys have no more matches.
+                    _currentLeaf.Return();
+                    _currentLeaf = null;
+                    _carryOverRead.Clear();
+                    return ValueTask.FromResult(false);
+                }
+
+                var getNextTask = _tree.m_stateClient.GetValue(_currentLeaf.next);
+                if (!getNextTask.IsCompletedSuccessfully)
+                {
+                    return MoveNextLeaf_CarryOverSlow(getNextTask);
+                }
+
+                _currentLeaf.Return();
+                _currentLeaf = (getNextTask.Result as LeafNode<K, V, TKeyContainer, TValueContainer>)!;
+                ProcessCarryOverOnly();
+                return ValueTask.FromResult(true);
+            }
+
+            var mapping = _mappings[_mappingIndex];
+            _mappingIndex++;
+
+            var getLeafTask = _tree.m_stateClient.GetValue(mapping.LeafId);
+            if (!getLeafTask.IsCompletedSuccessfully)
+            {
+                return MoveNextLeaf_Slow(getLeafTask, mapping);
+            }
+
+            if (_currentLeaf != null)
+            {
+                _currentLeaf.Return();
+            }
+            _currentLeaf = (getLeafTask.Result as LeafNode<K, V, TKeyContainer, TValueContainer>)!;
+            ProcessLeaf(mapping);
+            return ValueTask.FromResult(true);
+        }
+
+        private async ValueTask<bool> MoveNextLeaf_Slow(
+            ValueTask<IBPlusTreeNode?> getLeafTask,
+            BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping mapping)
+        {
+            var node = await getLeafTask;
+            if (_currentLeaf != null)
+            {
+                _currentLeaf.Return();
+            }
+            _currentLeaf = (node as LeafNode<K, V, TKeyContainer, TValueContainer>)!;
+            ProcessLeaf(mapping);
+            return true;
+        }
+
+        private async ValueTask<bool> MoveNextLeaf_CarryOverSlow(ValueTask<IBPlusTreeNode?> getNextTask)
+        {
+            var node = await getNextTask;
+            _currentLeaf!.Return();
+            _currentLeaf = (node as LeafNode<K, V, TKeyContainer, TValueContainer>)!;
+            ProcessCarryOverOnly();
+            return true;
+        }
+
+        private void ProcessLeaf(BPlusTree<K, V, TKeyContainer, TValueContainer>.LeafBatchMapping mapping)
+        {
+            _currentResults.Clear();
+            var leaf = _currentLeaf!;
+            var leafKeyCount = leaf.keys.Count;
+            var lastIndex = leafKeyCount - 1;
+            var comparer = _comparer;
+
+            _carryOverWrite.Clear();
+            for (int c = 0; c < _carryOverRead.Count; c++)
+            {
+                var keyIndex = _carryOverRead[c];
+                var boundries = comparer.FindBoundries(_keys[keyIndex], leaf.keys, 0, lastIndex);
+
+                var result = new BulkSearchKeyResult
+                {
+                    KeyIndex = keyIndex,
+                    LowerBound = boundries.lowerBounds,
+                    UpperBound = boundries.upperBounds,
+                    ContinuesToNextLeaf = false
+                };
+
+                if (boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex && leaf.next != 0)
+                {
+                    result.ContinuesToNextLeaf = true;
+                    _carryOverWrite.Add(keyIndex);
+                }
+
+                _currentResults.Add(result);
+            }
+
+            var end = mapping.Offset + mapping.Length;
+            int lowerBound = 0;
+            for (int i = mapping.Offset; i < end; i++)
+            {
+                var keyIndex = _sortedIndices[i];
+                var boundries = comparer.FindBoundries(_keys[keyIndex], leaf.keys, lowerBound, lastIndex);
+
+                if (boundries.lowerBounds < 0)
+                {
+                    lowerBound = ~boundries.lowerBounds;
+                }
+                else
+                {
+                    lowerBound = boundries.lowerBounds;
+                }
+
+                var result = new BulkSearchKeyResult
+                {
+                    KeyIndex = keyIndex,
+                    LowerBound = boundries.lowerBounds,
+                    UpperBound = boundries.upperBounds,
+                    ContinuesToNextLeaf = false
+                };
+
+                if (boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex && leaf.next != 0)
+                {
+                    result.ContinuesToNextLeaf = true;
+                    _carryOverWrite.Add(keyIndex);
+                }
+
+                _currentResults.Add(result);
+            }
+
+            var temp = _carryOverRead;
+            _carryOverRead = _carryOverWrite;
+            _carryOverWrite = temp;
+        }
+
+        private void ProcessCarryOverOnly()
+        {
+            _currentResults.Clear();
+            var leaf = _currentLeaf!;
+            var leafKeyCount = leaf.keys.Count;
+            var lastIndex = leafKeyCount - 1;
+            var comparer = _comparer;
+
+            _carryOverWrite.Clear();
+            for (int c = 0; c < _carryOverRead.Count; c++)
+            {
+                var keyIndex = _carryOverRead[c];
+                var boundries = comparer.FindBoundries(_keys[keyIndex], leaf.keys, 0, lastIndex);
+
+                var result = new BulkSearchKeyResult
+                {
+                    KeyIndex = keyIndex,
+                    LowerBound = boundries.lowerBounds,
+                    UpperBound = boundries.upperBounds,
+                    ContinuesToNextLeaf = false
+                };
+
+                if (boundries.lowerBounds >= 0 && boundries.upperBounds == lastIndex && leaf.next != 0)
+                {
+                    result.ContinuesToNextLeaf = true;
+                    _carryOverWrite.Add(keyIndex);
+                }
+
+                _currentResults.Add(result);
+            }
+
+            var temp = _carryOverRead;
+            _carryOverRead = _carryOverWrite;
+            _carryOverWrite = temp;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeMetadata.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeMetadata.cs
@@ -17,9 +17,16 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 {
     internal class BPlusTreeMetadata : IStorageMetadata
     {
-        public static BPlusTreeMetadata Create(int bucketLength, long root, long left, int pageSizeBytes, List<long> keyMetadataPages, List<long> valueMetadataPages)
+        public static BPlusTreeMetadata Create(
+            int bucketLength, 
+            long root, 
+            long left, 
+            int pageSizeBytes, 
+            List<long> keyMetadataPages, 
+            List<long> valueMetadataPages,
+            int depth)
         {
-            var newMetadata = new BPlusTreeMetadata(bucketLength, root, left, pageSizeBytes, keyMetadataPages, valueMetadataPages);
+            var newMetadata = new BPlusTreeMetadata(bucketLength, root, left, pageSizeBytes, keyMetadataPages, valueMetadataPages, depth);
             newMetadata.Updated = true;
             return newMetadata;
         }
@@ -32,7 +39,14 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         /// <param name="left"></param>
         /// <param name="pageSizeBytes"></param>
         [JsonConstructor]
-        public BPlusTreeMetadata(int bucketLength, long root, long left, int pageSizeBytes, List<long> keyMetadataPages, List<long> valueMetadataPages)
+        public BPlusTreeMetadata(
+            int bucketLength, 
+            long root, 
+            long left, 
+            int pageSizeBytes, 
+            List<long> keyMetadataPages, 
+            List<long> valueMetadataPages,
+            int depth)
         {
             BucketLength = bucketLength;
             Root = root;
@@ -41,6 +55,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             Updated = false;
             KeyMetadataPages = keyMetadataPages;
             ValueMetadataPages = valueMetadataPages;
+            Depth = depth;
         }
 
         public int BucketLength { get; }
@@ -57,12 +72,21 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
         public List<long> ValueMetadataPages { get; }
 
+        public int Depth { get; }
+
         [JsonIgnore]
         public bool Updated { get; set; }
 
         public BPlusTreeMetadata UpdateRoot(long newRoot)
         {
-            var newMetadata = new BPlusTreeMetadata(BucketLength, newRoot, Left, PageSizeBytes, KeyMetadataPages, ValueMetadataPages);
+            var newMetadata = new BPlusTreeMetadata(BucketLength, newRoot, Left, PageSizeBytes, KeyMetadataPages, ValueMetadataPages, Depth);
+            newMetadata.Updated = true;
+            return newMetadata;
+        }
+
+        public BPlusTreeMetadata UpdateRootAndDepth(long newRoot, int depth)
+        {
+            var newMetadata = new BPlusTreeMetadata(BucketLength, newRoot, Left, PageSizeBytes, KeyMetadataPages, ValueMetadataPages, depth);
             newMetadata.Updated = true;
             return newMetadata;
         }

--- a/src/FlowtideDotNet.Storage/Tree/ListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/ListKeyContainer.cs
@@ -69,6 +69,11 @@ namespace FlowtideDotNet.Storage.Tree
             _list.Insert(index, key);
         }
 
+        public void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Insert_Internal(int index, K key)
         {
             _list.Insert(index, key);

--- a/src/FlowtideDotNet.Storage/Tree/ListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/ListKeyContainer.cs
@@ -74,7 +74,7 @@ namespace FlowtideDotNet.Storage.Tree
             _list.Insert(index, key);
         }
 
-        public void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(K[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             throw new NotImplementedException();
         }

--- a/src/FlowtideDotNet.Storage/Tree/ListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/ListKeyContainer.cs
@@ -45,6 +45,11 @@ namespace FlowtideDotNet.Storage.Tree
             return _list.BinarySearch(key, comparer);
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
         }

--- a/src/FlowtideDotNet.Storage/Tree/ListValueContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/ListValueContainer.cs
@@ -66,6 +66,11 @@ namespace FlowtideDotNet.Storage.Tree
             _values.Insert(index, value);
         }
 
+        public void InsertFrom(V[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveAt(int index)
         {
             _values.RemoveAt(index);

--- a/src/FlowtideDotNet.Storage/Tree/ListValueContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/ListValueContainer.cs
@@ -73,7 +73,12 @@ namespace FlowtideDotNet.Storage.Tree
 
         public void InsertFrom(V[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
         {
-            throw new NotImplementedException();
+            for (int i = sortedLookup.Length - 1; i >= 0; i--)
+            {
+                int oIdx = sortedLookup[i];
+                var value = values[oIdx];
+                _values.Insert(targetPositions[i], value);
+            }
         }
 
         public void RemoveAt(int index)

--- a/src/FlowtideDotNet.Storage/Tree/ListValueContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/ListValueContainer.cs
@@ -37,6 +37,11 @@ namespace FlowtideDotNet.Storage.Tree
             }
         }
 
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Dispose()
         {
         }

--- a/src/FlowtideDotNet.Storage/Tree/PrimitiveListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/PrimitiveListKeyContainer.cs
@@ -143,7 +143,10 @@ namespace FlowtideDotNet.Storage.Tree
 
         public void DeleteBatch(ReadOnlySpan<int> positions)
         {
-            throw new NotImplementedException();
+            for (int i = positions.Length - 1; i >= 0; i--)
+            {
+                _values.RemoveAt(positions[i]);
+            }
         }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/PrimitiveListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/PrimitiveListKeyContainer.cs
@@ -135,5 +135,10 @@ namespace FlowtideDotNet.Storage.Tree
         {
             _values.Update(index, key);
         }
+
+        public void InsertFrom(T[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            _values.InsertFrom(keys, sortedLookup, targetPositions);
+        }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/PrimitiveListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/PrimitiveListKeyContainer.cs
@@ -140,5 +140,10 @@ namespace FlowtideDotNet.Storage.Tree
         {
             _values.InsertFrom(keys, sortedLookup, targetPositions);
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/PrimitiveListKeyContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/PrimitiveListKeyContainer.cs
@@ -136,7 +136,7 @@ namespace FlowtideDotNet.Storage.Tree
             _values.Update(index, key);
         }
 
-        public void InsertFrom(T[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        public void InsertFrom(T[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions, Span<int> lookupBuffer)
         {
             _values.InsertFrom(keys, sortedLookup, targetPositions);
         }

--- a/src/FlowtideDotNet.Storage/Tree/PrimitiveListValueContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/PrimitiveListValueContainer.cs
@@ -94,5 +94,10 @@ namespace FlowtideDotNet.Storage.Tree
         {
             return _values.Copy(memoryAllocator);
         }
+
+        public void InsertFrom(T[] values, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> targetPositions)
+        {
+            _values.InsertFrom(values, sortedLookup, targetPositions);
+        }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/PrimitiveListValueContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/PrimitiveListValueContainer.cs
@@ -99,5 +99,10 @@ namespace FlowtideDotNet.Storage.Tree
         {
             _values.InsertFrom(values, sortedLookup, targetPositions);
         }
+
+        public void DeleteBatch(ReadOnlySpan<int> positions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/FlowtideDotNet.Storage/Tree/PrimitiveListValueContainer.cs
+++ b/src/FlowtideDotNet.Storage/Tree/PrimitiveListValueContainer.cs
@@ -102,7 +102,10 @@ namespace FlowtideDotNet.Storage.Tree
 
         public void DeleteBatch(ReadOnlySpan<int> positions)
         {
-            throw new NotImplementedException();
+            for (int i = positions.Length - 1; i >= 0; i--)
+            {
+                _values.RemoveAt(positions[i]);
+            }
         }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -63,7 +63,7 @@ namespace FlowtideDotNet.AcceptanceTests
         [Fact]
         public async Task LeftJoinMergeJoin()
         {
-            GenerateData(1000);
+            GenerateData(100);
             await StartStream(@"
                 INSERT INTO output 
                 SELECT 
@@ -1294,7 +1294,7 @@ namespace FlowtideDotNet.AcceptanceTests
         public async Task RightJoinMergeJoinFromUsersUsersFirst()
         {
             GenerateCompanies(10);
-            GenerateUsers(1000);
+            GenerateUsers(10);
             await StartStream(@"
                 INSERT INTO output 
                 SELECT 
@@ -1315,7 +1315,7 @@ namespace FlowtideDotNet.AcceptanceTests
                     subuser.LastName
                 });
 
-            GenerateOrders(1000);
+            GenerateOrders(10);
 
             await WaitForUpdate();
 

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -1442,5 +1442,53 @@ namespace FlowtideDotNet.AcceptanceTests
 
             AssertCurrentDataEqual(new[] { new { val = 1 } });
         }
+
+        [Fact]
+        public async Task DoubleLeftJoinMiddleTableRetractionPropagatesNullsWithoutCrashing()
+        {
+            GenerateCompanies(10);
+            await StartStream(@"
+                INSERT INTO output 
+                SELECT 
+                    c.name, u.firstName, o.GuidVal
+                FROM companies c
+                LEFT JOIN users u
+                ON c.CompanyId = u.CompanyId
+                LEFT JOIN orders o
+                ON o.UserKey = u.UserKey");
+            await WaitForUpdate();
+
+            GenerateUsers(100);
+            
+            await WaitForUpdate();
+
+            GenerateOrders(100);
+
+            await WaitForUpdate();
+
+            var firstCompany = Companies.First();
+
+            foreach(var user in Users.Where(x => x.CompanyId == firstCompany.CompanyId).ToList())
+            {
+                DeleteUser(user);
+            }
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(
+                from company in Companies
+                join user in Users on company.CompanyId equals user.CompanyId into companyUsers
+                from subuser in companyUsers.DefaultIfEmpty()
+                let userOrders = subuser == null
+                    ? Enumerable.Empty<Order>()
+                    : Orders.Where(o => o.UserKey == subuser.UserKey)
+                from suborder in userOrders.DefaultIfEmpty()
+                select new
+                {
+                    company.Name,
+                    subuser?.FirstName,
+                    suborder?.GuidVal
+                });
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -13,6 +13,7 @@
 using Bogus;
 using FlowtideDotNet.AcceptanceTests.Entities;
 using FlowtideDotNet.Base;
+using System.Runtime.CompilerServices;
 using Xunit.Abstractions;
 
 namespace FlowtideDotNet.AcceptanceTests
@@ -1447,35 +1448,10 @@ namespace FlowtideDotNet.AcceptanceTests
         public async Task DoubleLeftJoinMiddleTableRetractionPropagatesNullsWithoutCrashing()
         {
             GenerateCompanies(10);
-            await StartStream(@"
-                INSERT INTO output 
-                SELECT 
-                    c.name, u.firstName, o.GuidVal
-                FROM companies c
-                LEFT JOIN users u
-                ON c.CompanyId = u.CompanyId
-                LEFT JOIN orders o
-                ON o.UserKey = u.UserKey");
-            await WaitForUpdate();
 
-            GenerateUsers(100);
-            
-            await WaitForUpdate();
-
-            GenerateOrders(100);
-
-            await WaitForUpdate();
-
-            var firstCompany = Companies.First();
-
-            foreach(var user in Users.Where(x => x.CompanyId == firstCompany.CompanyId).ToList())
+            void Validate()
             {
-                DeleteUser(user);
-            }
-
-            await WaitForUpdate();
-
-            AssertCurrentDataEqual(
+                AssertCurrentDataEqual(
                 from company in Companies
                 join user in Users on company.CompanyId equals user.CompanyId into companyUsers
                 from subuser in companyUsers.DefaultIfEmpty()
@@ -1489,6 +1465,43 @@ namespace FlowtideDotNet.AcceptanceTests
                     subuser?.FirstName,
                     suborder?.GuidVal
                 });
+            }
+
+            await StartStream(@"
+                INSERT INTO output 
+                SELECT 
+                    c.name, u.firstName, o.GuidVal
+                FROM companies c
+                LEFT JOIN users u
+                ON c.CompanyId = u.CompanyId
+                LEFT JOIN orders o
+                ON o.UserKey = u.UserKey");
+            await WaitForUpdate();
+
+            Validate();
+
+            GenerateUsers(100);
+            
+            await WaitForUpdate();
+
+            Validate();
+
+            GenerateOrders(100);
+
+            await WaitForUpdate();
+
+            Validate();
+
+            var firstCompany = Companies.First();
+
+            foreach(var user in Users.Where(x => x.CompanyId == firstCompany.CompanyId).ToList())
+            {
+                DeleteUser(user);
+            }
+
+            await WaitForUpdate();
+
+            Validate();
         }
     }
 }

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
@@ -33,8 +33,9 @@ namespace DifferntialCompute.Benchmarks
         private IStateManagerClient _nodeClient = null!;
         private BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>> _tree = null!;
         private SortedDictionary<long, long> _sortedlist = new SortedDictionary<long, long>();
+        private Dictionary<long, long> _dictionary = new Dictionary<long, long>();
 
-        [Params(1_000_000)] //, 1_000_000)]
+        [Params(10_000_000)] //, 1_000_000)]
         public int ElementCount { get; set; }
 
         [GlobalSetup]
@@ -60,7 +61,7 @@ namespace DifferntialCompute.Benchmarks
                 _nodeClient.GetOrCreateTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>("tree",
                     new BPlusTreeOptions<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>()
                     {
-                        PageSizeBytes = 4096,
+                        //PageSizeBytes = 4096,
                         UseByteBasedPageSizes = true,
                         Comparer = new PrimitiveListComparer<long>(),
                         KeySerializer = new PrimitiveListKeyContainerSerializer<long>(GlobalMemoryManager.Instance),
@@ -68,41 +69,60 @@ namespace DifferntialCompute.Benchmarks
                         MemoryAllocator = GlobalMemoryManager.Instance
                     }).GetAwaiter().GetResult();
             _tree.Clear();
-            _sortedlist.Clear();
+            _sortedlist = new SortedDictionary<long, long>();
+            _dictionary = new Dictionary<long, long>();
         }
 
-        [Benchmark]
-        public void SortedList()
-        {
-            for (int i = 0; i < ElementCount; i++)
-            {
-                var key = i;//r.Next();
+        //[Benchmark]
+        //public void SortedDictionary()
+        //{
+        //    for (int i = 0; i < ElementCount; i++)
+        //    {
+        //        var key = r.Next();
 
-                if (!_sortedlist.ContainsKey(key))
-                {
-                    _sortedlist.Add(key, i);
-                }
-                else
-                {
-                    _sortedlist[key] = i;
-                }
-            }
-        }
+        //        if (!_sortedlist.ContainsKey(key))
+        //        {
+        //            _sortedlist.Add(key, i);
+        //        }
+        //        else
+        //        {
+        //            _sortedlist[key] = i;
+        //        }
+        //    }
+        //}
 
-        [Benchmark(Baseline = true)]
-        public async Task RMWNoResult_SingleInsert()
-        {
-            for (int i = 0; i < ElementCount; i++)
-            {
-                await _tree.RMWNoResult(i, i, static (input, current, exists) => (input, GenericWriteOperation.Upsert));
-            }
-        }
+        //[Benchmark]
+        //public void HashDictionary()
+        //{
+        //    for (int i = 0; i < ElementCount; i++)
+        //    {
+        //        var key = r.Next();
+
+        //        if (!_dictionary.ContainsKey(key))
+        //        {
+        //            _dictionary.Add(key, i);
+        //        }
+        //        else
+        //        {
+        //            _dictionary[key] = i;
+        //        }
+        //    }
+        //}
+
+        //[Benchmark(Baseline = true)]
+        //public async Task RMWNoResult_SingleInsert()
+        //{
+        //    for (int i = 0; i < ElementCount; i++)
+        //    {
+        //        await _tree.RMWNoResult(r.Next(), i, static (input, current, exists) => (input, GenericWriteOperation.Upsert));
+        //    }
+        //}
 
         [Benchmark]
         public async Task BulkInsert_Batched()
         {
             var bulkInserter = new BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>(_tree);
-            var batchSize = 1000;
+            var batchSize = 100_000;
 
             var keys = new long[batchSize];
             var values = new long[batchSize];
@@ -110,11 +130,11 @@ namespace DifferntialCompute.Benchmarks
             for (int offset = 0; offset < ElementCount; offset += batchSize)
             {
                 var count = Math.Min(batchSize, ElementCount - offset);
-                
+
 
                 for (int i = 0; i < count; i++)
                 {
-                    keys[i] = offset + i;
+                    keys[i] = r.Next();
                     values[i] = offset + i;
                 }
 

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
@@ -75,50 +75,50 @@ namespace DifferntialCompute.Benchmarks
             _dictionary = new Dictionary<long, long>();
         }
 
-        //[Benchmark]
-        //public void SortedDictionary()
-        //{
-        //    for (int i = 0; i < ElementCount; i++)
-        //    {
-        //        var key = r.Next();
+        [Benchmark]
+        public void SortedDictionary()
+        {
+            for (int i = 0; i < ElementCount; i++)
+            {
+                var key = r.Next();
 
-        //        if (!_sortedlist.ContainsKey(key))
-        //        {
-        //            _sortedlist.Add(key, i);
-        //        }
-        //        else
-        //        {
-        //            _sortedlist[key] = i;
-        //        }
-        //    }
-        //}
+                if (!_sortedlist.ContainsKey(key))
+                {
+                    _sortedlist.Add(key, i);
+                }
+                else
+                {
+                    _sortedlist[key] = i;
+                }
+            }
+        }
 
-        //[Benchmark]
-        //public void HashDictionary()
-        //{
-        //    for (int i = 0; i < ElementCount; i++)
-        //    {
-        //        var key = i;
+        [Benchmark]
+        public void HashDictionary()
+        {
+            for (int i = 0; i < ElementCount; i++)
+            {
+                var key = i;
 
-        //        if (!_dictionary.ContainsKey(key))
-        //        {
-        //            _dictionary.Add(key, i);
-        //        }
-        //        else
-        //        {
-        //            _dictionary[key] = i;
-        //        }
-        //    }
-        //}
+                if (!_dictionary.ContainsKey(key))
+                {
+                    _dictionary.Add(key, i);
+                }
+                else
+                {
+                    _dictionary[key] = i;
+                }
+            }
+        }
 
-        //[Benchmark(Baseline = true)]
-        //public async Task RMWNoResult_SingleInsert()
-        //{
-        //    for (int i = 0; i < ElementCount; i++)
-        //    {
-        //        await _tree.RMWNoResult(r.Next(), i, static (input, current, exists) => (input, GenericWriteOperation.Upsert));
-        //    }
-        //}
+        [Benchmark(Baseline = true)]
+        public async Task RMWNoResult_SingleInsert()
+        {
+            for (int i = 0; i < ElementCount; i++)
+            {
+                await _tree.RMWNoResult(r.Next(), i, static (input, current, exists) => (input, GenericWriteOperation.Upsert));
+            }
+        }
 
         [Benchmark]
         public async Task BulkInsert_Batched()

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
@@ -1,0 +1,139 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using BenchmarkDotNet.Attributes;
+using FlowtideDotNet.Storage;
+using FlowtideDotNet.Storage.Comparers;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Persistence.CacheStorage;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using static SqlParser.Ast.FetchDirection;
+
+namespace DifferntialCompute.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BPlusTreeBulkInsertBenchmark
+    {
+        private StateManagerSync _stateManager = null!;
+        private IStateManagerClient _nodeClient = null!;
+        private BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>> _tree = null!;
+        private SortedDictionary<long, long> _sortedlist = new SortedDictionary<long, long>();
+
+        [Params(1_000_000)] //, 1_000_000)]
+        public int ElementCount { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _stateManager = new StateManagerSync<object>(new StateManagerOptions()
+            {
+                CachePageCount = 1_000_000,
+                PersistentStorage = new FileCachePersistentStorage(new FileCacheOptions())
+            }, NullLoggerFactory.Instance, new Meter("bulk_insert_bench"), "bulk_insert_bench");
+
+            _stateManager.InitializeAsync().GetAwaiter().GetResult();
+            _nodeClient = _stateManager.GetOrCreateClient("node1");
+        }
+
+        Random? r;
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            r = new Random(123);
+            _tree = (BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>)
+                _nodeClient.GetOrCreateTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>("tree",
+                    new BPlusTreeOptions<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>()
+                    {
+                        PageSizeBytes = 4096,
+                        UseByteBasedPageSizes = true,
+                        Comparer = new PrimitiveListComparer<long>(),
+                        KeySerializer = new PrimitiveListKeyContainerSerializer<long>(GlobalMemoryManager.Instance),
+                        ValueSerializer = new PrimitiveListValueContainerSerializer<long>(GlobalMemoryManager.Instance),
+                        MemoryAllocator = GlobalMemoryManager.Instance
+                    }).GetAwaiter().GetResult();
+            _tree.Clear();
+            _sortedlist.Clear();
+        }
+
+        [Benchmark]
+        public void SortedList()
+        {
+            for (int i = 0; i < ElementCount; i++)
+            {
+                var key = i;//r.Next();
+
+                if (!_sortedlist.ContainsKey(key))
+                {
+                    _sortedlist.Add(key, i);
+                }
+                else
+                {
+                    _sortedlist[key] = i;
+                }
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public async Task RMWNoResult_SingleInsert()
+        {
+            for (int i = 0; i < ElementCount; i++)
+            {
+                await _tree.RMWNoResult(i, i, static (input, current, exists) => (input, GenericWriteOperation.Upsert));
+            }
+        }
+
+        [Benchmark]
+        public async Task BulkInsert_Batched()
+        {
+            var bulkInserter = new BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>(_tree);
+            var batchSize = 1000;
+
+            var keys = new long[batchSize];
+            var values = new long[batchSize];
+
+            for (int offset = 0; offset < ElementCount; offset += batchSize)
+            {
+                var count = Math.Min(batchSize, ElementCount - offset);
+                
+
+                for (int i = 0; i < count; i++)
+                {
+                    keys[i] = offset + i;
+                    values[i] = offset + i;
+                }
+
+                await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+            }
+        }
+
+        private struct UpsertMutator : IRowMutator<long, long>
+        {
+            public GenericWriteOperation Process(long key, bool exists, in long existingData, ref long incomingData)
+            {
+                return GenericWriteOperation.Upsert;
+            }
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            _stateManager?.Dispose();
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
@@ -96,7 +96,7 @@ namespace DifferntialCompute.Benchmarks
         //{
         //    for (int i = 0; i < ElementCount; i++)
         //    {
-        //        var key = r.Next();
+        //        var key = i;
 
         //        if (!_dictionary.ContainsKey(key))
         //        {
@@ -122,7 +122,7 @@ namespace DifferntialCompute.Benchmarks
         public async Task BulkInsert_Batched()
         {
             var bulkInserter = new BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>(_tree);
-            var batchSize = 100_000;
+            var batchSize = 1000;
 
             var keys = new long[batchSize];
             var values = new long[batchSize];
@@ -134,7 +134,7 @@ namespace DifferntialCompute.Benchmarks
 
                 for (int i = 0; i < count; i++)
                 {
-                    keys[i] = r.Next();
+                    keys[i] = offset + i;
                     values[i] = offset + i;
                 }
 

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
@@ -124,7 +124,7 @@ namespace DifferntialCompute.Benchmarks
         public async Task BulkInsert_Batched()
         {
             var bulkInserter = new BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>(_tree);
-            var batchSize = 1_000;
+            var batchSize = 10_000;
 
             var keys = new long[batchSize];
             var values = new long[batchSize];
@@ -136,7 +136,7 @@ namespace DifferntialCompute.Benchmarks
 
                 for (int i = 0; i < count; i++)
                 {
-                    keys[i] = r.Next();
+                    keys[i] = offset + i;
                     values[i] = offset + i;
                 }
 

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkInsertBenchmark.cs
@@ -11,6 +11,8 @@
 // limitations under the License.
 
 using BenchmarkDotNet.Attributes;
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Storage;
 using FlowtideDotNet.Storage.Comparers;
 using FlowtideDotNet.Storage.Memory;
@@ -35,7 +37,7 @@ namespace DifferntialCompute.Benchmarks
         private SortedDictionary<long, long> _sortedlist = new SortedDictionary<long, long>();
         private Dictionary<long, long> _dictionary = new Dictionary<long, long>();
 
-        [Params(10_000_000)] //, 1_000_000)]
+        [Params(1_000_000)] //, 1_000_000)]
         public int ElementCount { get; set; }
 
         [GlobalSetup]
@@ -122,7 +124,7 @@ namespace DifferntialCompute.Benchmarks
         public async Task BulkInsert_Batched()
         {
             var bulkInserter = new BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>(_tree);
-            var batchSize = 1000;
+            var batchSize = 1_000;
 
             var keys = new long[batchSize];
             var values = new long[batchSize];
@@ -134,7 +136,7 @@ namespace DifferntialCompute.Benchmarks
 
                 for (int i = 0; i < count; i++)
                 {
-                    keys[i] = offset + i;
+                    keys[i] = r.Next();
                     values[i] = offset + i;
                 }
 

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkSearchBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkSearchBenchmark.cs
@@ -1,0 +1,174 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using BenchmarkDotNet.Attributes;
+using FlowtideDotNet.Storage;
+using FlowtideDotNet.Storage.Comparers;
+using FlowtideDotNet.Storage.FileCache;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Persistence.CacheStorage;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics.Metrics;
+
+namespace FlowtideDotNet.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BPlusTreeBulkSearchBenchmark
+    {
+        private StateManagerSync _stateManager = null!;
+        private IStateManagerClient _nodeClient = null!;
+        private BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>> _tree = null!;
+        private long[] _searchKeys = null!;
+        private long[] _inOrderSearchKeys = null!;
+        private IBplusTreeBulkSearch<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>, PrimitiveListComparer<long>> _bulkSearcher = null!;
+        private int[] _presortedIndices = null!;
+
+
+        [Params(10_000)]
+        public int SearchKeyCount { get; set; }
+
+        [Params(1_000_000)]
+        public int TreeSize { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _stateManager = new StateManagerSync<object>(new StateManagerOptions()
+            {
+                CachePageCount = 1_000_000,
+                PersistentStorage = new FileCachePersistentStorage(new FileCacheOptions())
+            }, NullLoggerFactory.Instance, new Meter("bulk_search_bench"), "bulk_search_bench");
+
+            _stateManager.InitializeAsync().GetAwaiter().GetResult();
+            _nodeClient = _stateManager.GetOrCreateClient("node1");
+
+            _tree = (BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>)
+                _nodeClient.GetOrCreateTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>("tree",
+                    new BPlusTreeOptions<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>()
+                    {
+                        UseByteBasedPageSizes = true,
+                        Comparer = new PrimitiveListComparer<long>(),
+                        KeySerializer = new PrimitiveListKeyContainerSerializer<long>(GlobalMemoryManager.Instance),
+                        ValueSerializer = new PrimitiveListValueContainerSerializer<long>(GlobalMemoryManager.Instance),
+                        MemoryAllocator = GlobalMemoryManager.Instance
+                    }).GetAwaiter().GetResult();
+
+            var inserter = _tree.CreateBulkInserter();
+            _bulkSearcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+
+            // Populate tree
+            for (long i = 0; i < TreeSize; i++)
+            {
+                _tree.Upsert(i, i * 10).GetAwaiter().GetResult();
+            }
+
+            // Generate search keys spread across the tree
+            var rng = new Random(42);
+            _searchKeys = new long[SearchKeyCount];
+            for (int i = 0; i < SearchKeyCount; i++)
+            {
+                _searchKeys[i] = rng.NextInt64(0, TreeSize);
+            }
+
+            _presortedIndices = inserter.SortAndGetIndices(_searchKeys, _searchKeys.Length);
+
+            _inOrderSearchKeys = new long[SearchKeyCount];
+
+            for (int i = 0; i < SearchKeyCount; i++)
+            {
+                _inOrderSearchKeys[i] = TreeSize - SearchKeyCount + i;
+            }
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            _stateManager?.Dispose();
+        }
+
+        //[Benchmark(Baseline = true)]
+        //public async Task IteratorSeek()
+        //{
+        //    var comparer = new PrimitiveListComparer<long>();
+        //    using var iterator = _tree.CreateIterator();
+
+        //    for (int i = 0; i < _searchKeys.Length; i++)
+        //    {
+        //        await iterator.Seek(_searchKeys[i], comparer);
+
+        //        await foreach (var page in iterator)
+        //        {
+        //            // Just consume the first page to match bulk search behavior
+        //            break;
+        //        }
+        //    }
+        //}
+
+        //[Benchmark()]
+        //public async Task IteratorSeekInOrder()
+        //{
+        //    var comparer = new PrimitiveListComparer<long>();
+        //    using var iterator = _tree.CreateIterator();
+
+        //    for (int i = 0; i < _inOrderSearchKeys.Length; i++)
+        //    {
+        //        await iterator.Seek(_inOrderSearchKeys[i], comparer);
+
+        //        await foreach (var page in iterator)
+        //        {
+        //            // Just consume the first page to match bulk search behavior
+        //            break;
+        //        }
+        //    }
+        //}
+
+        //[Benchmark]
+        //public async Task BulkSearchInOrder()
+        //{
+        //    await _bulkSearcher.Start(_inOrderSearchKeys, _inOrderSearchKeys.Length);
+
+        //    while (await _bulkSearcher.MoveNextLeaf())
+        //    {
+        //        // Consume results
+        //        var _ = _bulkSearcher.CurrentResults;
+        //    }
+        //}
+
+        [Benchmark]
+        public async Task BulkSearchPreSorted()
+        {
+            await _bulkSearcher.Start(_searchKeys, _searchKeys.Length, _presortedIndices);
+
+            while (await _bulkSearcher.MoveNextLeaf())
+            {
+                // Consume results
+                var _ = _bulkSearcher.CurrentResults;
+            }
+        }
+
+        [Benchmark]
+        public async Task BulkSearch()
+        {
+            await _bulkSearcher.Start(_searchKeys, _searchKeys.Length);
+
+            while (await _bulkSearcher.MoveNextLeaf())
+            {
+                // Consume results
+                var _ = _bulkSearcher.CurrentResults;
+            }
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkSearchBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkSearchBenchmark.cs
@@ -99,53 +99,53 @@ namespace FlowtideDotNet.Benchmarks
             _stateManager?.Dispose();
         }
 
-        //[Benchmark(Baseline = true)]
-        //public async Task IteratorSeek()
-        //{
-        //    var comparer = new PrimitiveListComparer<long>();
-        //    using var iterator = _tree.CreateIterator();
+        [Benchmark(Baseline = true)]
+        public async Task IteratorSeek()
+        {
+            var comparer = new PrimitiveListComparer<long>();
+            using var iterator = _tree.CreateIterator();
 
-        //    for (int i = 0; i < _searchKeys.Length; i++)
-        //    {
-        //        await iterator.Seek(_searchKeys[i], comparer);
+            for (int i = 0; i < _searchKeys.Length; i++)
+            {
+                await iterator.Seek(_searchKeys[i], comparer);
 
-        //        await foreach (var page in iterator)
-        //        {
-        //            // Just consume the first page to match bulk search behavior
-        //            break;
-        //        }
-        //    }
-        //}
+                await foreach (var page in iterator)
+                {
+                    // Just consume the first page to match bulk search behavior
+                    break;
+                }
+            }
+        }
 
-        //[Benchmark()]
-        //public async Task IteratorSeekInOrder()
-        //{
-        //    var comparer = new PrimitiveListComparer<long>();
-        //    using var iterator = _tree.CreateIterator();
+        [Benchmark()]
+        public async Task IteratorSeekInOrder()
+        {
+            var comparer = new PrimitiveListComparer<long>();
+            using var iterator = _tree.CreateIterator();
 
-        //    for (int i = 0; i < _inOrderSearchKeys.Length; i++)
-        //    {
-        //        await iterator.Seek(_inOrderSearchKeys[i], comparer);
+            for (int i = 0; i < _inOrderSearchKeys.Length; i++)
+            {
+                await iterator.Seek(_inOrderSearchKeys[i], comparer);
 
-        //        await foreach (var page in iterator)
-        //        {
-        //            // Just consume the first page to match bulk search behavior
-        //            break;
-        //        }
-        //    }
-        //}
+                await foreach (var page in iterator)
+                {
+                    // Just consume the first page to match bulk search behavior
+                    break;
+                }
+            }
+        }
 
-        //[Benchmark]
-        //public async Task BulkSearchInOrder()
-        //{
-        //    await _bulkSearcher.Start(_inOrderSearchKeys, _inOrderSearchKeys.Length);
+        [Benchmark]
+        public async Task BulkSearchInOrder()
+        {
+            await _bulkSearcher.Start(_inOrderSearchKeys, _inOrderSearchKeys.Length);
 
-        //    while (await _bulkSearcher.MoveNextLeaf())
-        //    {
-        //        // Consume results
-        //        var _ = _bulkSearcher.CurrentResults;
-        //    }
-        //}
+            while (await _bulkSearcher.MoveNextLeaf())
+            {
+                // Consume results
+                _ = _bulkSearcher.CurrentResults;
+            }
+        }
 
         [Benchmark]
         public async Task BulkSearchPreSorted()
@@ -167,7 +167,7 @@ namespace FlowtideDotNet.Benchmarks
             while (await _bulkSearcher.MoveNextLeaf())
             {
                 // Consume results
-                var _ = _bulkSearcher.CurrentResults;
+                _ = _bulkSearcher.CurrentResults;
             }
         }
     }

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkSearchBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkSearchBenchmark.cs
@@ -155,7 +155,7 @@ namespace FlowtideDotNet.Benchmarks
             while (await _bulkSearcher.MoveNextLeaf())
             {
                 // Consume results
-                var _ = _bulkSearcher.CurrentResults;
+                _ = _bulkSearcher.CurrentResults;
             }
         }
 

--- a/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkSearchBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BPlusTreeBulkSearchBenchmark.cs
@@ -109,7 +109,7 @@ namespace FlowtideDotNet.Benchmarks
             {
                 await iterator.Seek(_searchKeys[i], comparer);
 
-                await foreach (var page in iterator)
+                await foreach (var _ in iterator)
                 {
                     // Just consume the first page to match bulk search behavior
                     break;
@@ -127,7 +127,7 @@ namespace FlowtideDotNet.Benchmarks
             {
                 await iterator.Seek(_inOrderSearchKeys[i], comparer);
 
-                await foreach (var page in iterator)
+                await foreach (var _ in iterator)
                 {
                     // Just consume the first page to match bulk search behavior
                     break;

--- a/tests/FlowtideDotNet.Benchmarks/ColumnInsertFromBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/ColumnInsertFromBenchmark.cs
@@ -72,7 +72,7 @@ namespace FlowtideDotNet.Benchmarks
         [Benchmark(Baseline = true)]
         public void InsertFromBatch()
         {
-            _target!.InsertFrom(_source!, _sortedLookup.AsSpan(), _insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = _sortedLookup; ReadOnlySpan<int> ip = _insertPositions; _target!.InsertFrom(_source!, in sl, in ip, -1);
         }
 
         [Benchmark]
@@ -86,3 +86,4 @@ namespace FlowtideDotNet.Benchmarks
         }
     }
 }
+

--- a/tests/FlowtideDotNet.Benchmarks/ColumnStore/Utils/BinaryListBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/ColumnStore/Utils/BinaryListBenchmark.cs
@@ -163,7 +163,9 @@ namespace FlowtideDotNet.Benchmarks.ColumnStore.Utils
         public void InsertFromBatch()
         {
             Debug.Assert(_targetList != null && _sourceList != null);
-            _targetList.InsertFrom(_sourceList, _sortedLookup.AsSpan(), _insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = _sortedLookup.AsSpan();
+            ReadOnlySpan<int> ip = _insertPositions.AsSpan();
+            _targetList.InsertFrom(_sourceList, in sl, in ip, -1);
         }
 
         [Benchmark]

--- a/tests/FlowtideDotNet.Benchmarks/ColumnStore/Utils/BinaryListBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/ColumnStore/Utils/BinaryListBenchmark.cs
@@ -165,7 +165,7 @@ namespace FlowtideDotNet.Benchmarks.ColumnStore.Utils
             Debug.Assert(_targetList != null && _sourceList != null);
             ReadOnlySpan<int> sl = _sortedLookup.AsSpan();
             ReadOnlySpan<int> ip = _insertPositions.AsSpan();
-            _targetList.InsertFrom(_sourceList, in sl, in ip, -1);
+            _targetList.InsertFrom(in _sourceList!, in sl, in ip, -1);
         }
 
         [Benchmark]

--- a/tests/FlowtideDotNet.Benchmarks/ColumnStoreTreeBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/ColumnStoreTreeBenchmark.cs
@@ -20,6 +20,7 @@ using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Storage.Serializers;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics;
 
@@ -28,8 +29,9 @@ namespace FlowtideDotNet.Benchmarks
     public class ColumnStoreTreeBenchmark
     {
         private IStateManagerClient? nodeClient;
-        private IBPlusTree<ColumnRowReference, string, ColumnKeyStorageContainer, ListValueContainer<string>>? tree;
+        private IBPlusTree<ColumnRowReference, long, ColumnKeyStorageContainer, PrimitiveListValueContainer<long>>? tree;
         private IBPlusTree<RowEvent, string, ListKeyContainer<RowEvent>, ListValueContainer<string>>? flxTree;
+        private BPlusTreeBulkInserter<ColumnRowReference, long, ColumnKeyStorageContainer, PrimitiveListValueContainer<long>>? _bulkInserter;
 
         //[Params(1000, 5000, 10000)]
         //public int CachePageCount;
@@ -66,14 +68,17 @@ namespace FlowtideDotNet.Benchmarks
         public void IterationSetup()
         {
             Debug.Assert(nodeClient != null);
-            tree = nodeClient.GetOrCreateTree("tree", new BPlusTreeOptions<ColumnRowReference, string, ColumnKeyStorageContainer, ListValueContainer<string>>()
+            tree = nodeClient.GetOrCreateTree("tree", new BPlusTreeOptions<ColumnRowReference, long, ColumnKeyStorageContainer, PrimitiveListValueContainer<long>>()
             {
-                BucketSize = 1024,
+                UseByteBasedPageSizes = true,
                 Comparer = new ColumnComparer(1),
                 KeySerializer = new ColumnStoreSerializer(1, GlobalMemoryManager.Instance),
-                ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                ValueSerializer = new PrimitiveListValueContainerSerializer<long>(GlobalMemoryManager.Instance),
                 MemoryAllocator = GlobalMemoryManager.Instance
             }).GetAwaiter().GetResult();
+
+            var casted = (BPlusTree<ColumnRowReference, long, ColumnKeyStorageContainer, PrimitiveListValueContainer<long>>)tree;
+            _bulkInserter = new BPlusTreeBulkInserter<ColumnRowReference, long, ColumnKeyStorageContainer, PrimitiveListValueContainer<long>>(casted);
             tree.Clear();
             flxTree = nodeClient.GetOrCreateTree("flxtree", new BPlusTreeOptions<RowEvent, string, ListKeyContainer<RowEvent>, ListValueContainer<string>>()
             {
@@ -107,7 +112,38 @@ namespace FlowtideDotNet.Benchmarks
                 {
                     referenceBatch = data,
                     RowIndex = i
-                }, $"hello{i}");
+                }, i);
+            }
+        }
+
+        private struct UpsertMutator : IRowMutator<ColumnRowReference, long>
+        {
+            public GenericWriteOperation Process(ColumnRowReference key, bool exists, in long existingData, ref long incomingData)
+            {
+                return GenericWriteOperation.Upsert;
+            }
+        }
+
+        [Benchmark]
+        public async Task ColumnarInsertBulkInOrder()
+        {
+            Debug.Assert(tree != null);
+            Debug.Assert(_bulkInserter != null);
+            ColumnRowReference[] keys = new ColumnRowReference[1000];
+            long[] values = new long[1000];
+            for (int i = 0; i < 1_000_000; i++)
+            {
+                for(int k = 0; k < keys.Length; k++)
+                {
+                    keys[k] = new ColumnRowReference()
+                    {
+                        referenceBatch = data,
+                        RowIndex = i,
+                    };
+                    values[k] = i;
+                    i++;
+                }
+                await _bulkInserter.ApplyBatch(keys, values, keys.Length, new UpsertMutator());
             }
         }
     }

--- a/tests/FlowtideDotNet.Benchmarks/ColumnStoreTreeBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/ColumnStoreTreeBenchmark.cs
@@ -34,8 +34,6 @@ namespace FlowtideDotNet.Benchmarks
         private IBPlusTree<RowEvent, string, ListKeyContainer<RowEvent>, ListValueContainer<string>>? flxTree;
         private BPlusTreeBulkInserter<ColumnRowReference, long, ColumnKeyStorageContainer, PrimitiveListValueContainer<long>>? _bulkInserter;
 
-        //[Params(1000, 5000, 10000)]
-        //public int CachePageCount;
         private EventBatchData data = new EventBatchData(
         [
             new Column(GlobalMemoryManager.Instance)
@@ -55,7 +53,6 @@ namespace FlowtideDotNet.Benchmarks
 
             nodeClient = stateManager.GetOrCreateClient("node1");
 
-            Random r = new Random(123);
             for (int i = 0; i < 1_000_000; i++)
             {
                 data.Columns[0].Add(new StringValue(i.ToString()));

--- a/tests/FlowtideDotNet.Benchmarks/ColumnStoreTreeBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/ColumnStoreTreeBenchmark.cs
@@ -22,6 +22,7 @@ using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
 using FlowtideDotNet.Storage.Tree.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
+using SqlParser.Ast;
 using System.Diagnostics;
 
 namespace FlowtideDotNet.Benchmarks
@@ -54,9 +55,10 @@ namespace FlowtideDotNet.Benchmarks
 
             nodeClient = stateManager.GetOrCreateClient("node1");
 
+            Random r = new Random(123);
             for (int i = 0; i < 1_000_000; i++)
             {
-                data.Columns[0].Add(new Int64Value(i));
+                data.Columns[0].Add(new StringValue(i.ToString()));
                 rowEvents.Add(RowEvent.Create(1, 0, b =>
                 {
                     b.Add(i);
@@ -93,16 +95,6 @@ namespace FlowtideDotNet.Benchmarks
         }
 
         [Benchmark]
-        public async Task FlxValueInsertInOrder()
-        {
-            Debug.Assert(flxTree != null);
-            for (int i = 0; i < 1_000_000; i++)
-            {
-                await flxTree.Upsert(rowEvents[i], $"hello{i}");
-            }
-        }
-
-        [Benchmark]
         public async Task ColumnarInsertInOrder()
         {
             Debug.Assert(tree != null);
@@ -129,11 +121,13 @@ namespace FlowtideDotNet.Benchmarks
         {
             Debug.Assert(tree != null);
             Debug.Assert(_bulkInserter != null);
-            ColumnRowReference[] keys = new ColumnRowReference[1000];
-            long[] values = new long[1000];
+            int batchSize = 1_000;
+            ColumnRowReference[] keys = new ColumnRowReference[batchSize];
+            long[] values = new long[batchSize];
             for (int i = 0; i < 1_000_000; i++)
             {
-                for(int k = 0; k < keys.Length; k++)
+                var count = Math.Min(batchSize, 1_000_000 - i);
+                for (int k = 0; k < count; k++)
                 {
                     keys[k] = new ColumnRowReference()
                     {
@@ -143,7 +137,7 @@ namespace FlowtideDotNet.Benchmarks
                     values[k] = i;
                     i++;
                 }
-                await _bulkInserter.ApplyBatch(keys, values, keys.Length, new UpsertMutator());
+                await _bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
             }
         }
     }

--- a/tests/FlowtideDotNet.Benchmarks/DataStructures/BitmapListInsertFromBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/DataStructures/BitmapListInsertFromBenchmark.cs
@@ -106,7 +106,7 @@ namespace FlowtideDotNet.Benchmarks.DataStructures
         public void InsertFromBatch()
         {
             Debug.Assert(_targetList != null && _sourceList != null);
-            _targetList.InsertFrom(_sourceList, _sortedLookup.AsSpan(), _insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = _sortedLookup; ReadOnlySpan<int> ip = _insertPositions; _targetList.InsertFrom(in _sourceList!, in sl, in ip, -1);
         }
 
         [Benchmark]
@@ -138,3 +138,4 @@ namespace FlowtideDotNet.Benchmarks.DataStructures
         }
     }
 }
+

--- a/tests/FlowtideDotNet.Benchmarks/DataStructures/PrimitiveListInsertFromBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/DataStructures/PrimitiveListInsertFromBenchmark.cs
@@ -105,8 +105,9 @@ namespace FlowtideDotNet.Benchmarks.DataStructures
         [Benchmark]
         public void InsertFromBatch()
         {
-            Debug.Assert(_targetList != null && _sourceList != null);
-            _targetList.InsertFrom(_sourceList, _sortedLookup.AsSpan(), _insertPositions.AsSpan());
+            ReadOnlySpan<int> sortedLookup = _sortedLookup;
+            ReadOnlySpan<int> insertPositions = _insertPositions;
+            _targetList!.InsertFrom(in _sourceList!, in sortedLookup, in insertPositions, -1);
         }
 
         [Benchmark]

--- a/tests/FlowtideDotNet.Benchmarks/Program.cs
+++ b/tests/FlowtideDotNet.Benchmarks/Program.cs
@@ -12,7 +12,13 @@
 
 using BenchmarkDotNet.Running;
 using DifferntialCompute.Benchmarks;
+using FlowtideDotNet.Benchmarks;
 
+
+ColumnStoreTreeBenchmark columnStore = new ColumnStoreTreeBenchmark();
+columnStore.GlobalSetup();
+columnStore.IterationSetup();
+await columnStore.ColumnarInsertBulkInOrder();
 //BPlusTreeBulkInsertBenchmark bPlusTreeBulkInsertBenchmark = new BPlusTreeBulkInsertBenchmark();
 //bPlusTreeBulkInsertBenchmark.ElementCount = 1_000_000;
 //bPlusTreeBulkInsertBenchmark.GlobalSetup();
@@ -20,4 +26,4 @@ using DifferntialCompute.Benchmarks;
 //await bPlusTreeBulkInsertBenchmark.BulkInsert_Batched();
 
 //Console.WriteLine("hello");
-var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+//var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/tests/FlowtideDotNet.Benchmarks/Program.cs
+++ b/tests/FlowtideDotNet.Benchmarks/Program.cs
@@ -13,11 +13,11 @@
 using BenchmarkDotNet.Running;
 using DifferntialCompute.Benchmarks;
 
-//BPlusTreeBulkInsertBenchmark bPlusTreeBulkInsertBenchmark = new BPlusTreeBulkInsertBenchmark();
-//bPlusTreeBulkInsertBenchmark.ElementCount = 10_000_000;
-//bPlusTreeBulkInsertBenchmark.GlobalSetup();
-//bPlusTreeBulkInsertBenchmark.IterationSetup();
-//await bPlusTreeBulkInsertBenchmark.BulkInsert_Batched();
+BPlusTreeBulkInsertBenchmark bPlusTreeBulkInsertBenchmark = new BPlusTreeBulkInsertBenchmark();
+bPlusTreeBulkInsertBenchmark.ElementCount = 10_000_000;
+bPlusTreeBulkInsertBenchmark.GlobalSetup();
+bPlusTreeBulkInsertBenchmark.IterationSetup();
+await bPlusTreeBulkInsertBenchmark.BulkInsert_Batched();
 
 //Console.WriteLine("hello");
-var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+//var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/tests/FlowtideDotNet.Benchmarks/Program.cs
+++ b/tests/FlowtideDotNet.Benchmarks/Program.cs
@@ -14,6 +14,11 @@ using BenchmarkDotNet.Running;
 using DifferntialCompute.Benchmarks;
 using FlowtideDotNet.Benchmarks;
 
+//BPlusTreeBulkSearchBenchmark bPlusTreeBulkSearchBenchmark = new BPlusTreeBulkSearchBenchmark();
+//bPlusTreeBulkSearchBenchmark.TreeSize = 1_000_000;
+//bPlusTreeBulkSearchBenchmark.SearchKeyCount = 1000;
+//bPlusTreeBulkSearchBenchmark.GlobalSetup();
+//await bPlusTreeBulkSearchBenchmark.BulkSearchPreSorted();
 
 //ColumnStoreTreeBenchmark columnStore = new ColumnStoreTreeBenchmark();
 //columnStore.GlobalSetup();

--- a/tests/FlowtideDotNet.Benchmarks/Program.cs
+++ b/tests/FlowtideDotNet.Benchmarks/Program.cs
@@ -11,5 +11,13 @@
 // limitations under the License.
 
 using BenchmarkDotNet.Running;
+using DifferntialCompute.Benchmarks;
 
+//BPlusTreeBulkInsertBenchmark bPlusTreeBulkInsertBenchmark = new BPlusTreeBulkInsertBenchmark();
+//bPlusTreeBulkInsertBenchmark.ElementCount = 10_000_000;
+//bPlusTreeBulkInsertBenchmark.GlobalSetup();
+//bPlusTreeBulkInsertBenchmark.IterationSetup();
+//await bPlusTreeBulkInsertBenchmark.BulkInsert_Batched();
+
+//Console.WriteLine("hello");
 var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/tests/FlowtideDotNet.Benchmarks/Program.cs
+++ b/tests/FlowtideDotNet.Benchmarks/Program.cs
@@ -14,7 +14,7 @@ using BenchmarkDotNet.Running;
 using DifferntialCompute.Benchmarks;
 
 //BPlusTreeBulkInsertBenchmark bPlusTreeBulkInsertBenchmark = new BPlusTreeBulkInsertBenchmark();
-//bPlusTreeBulkInsertBenchmark.ElementCount = 10_000_000;
+//bPlusTreeBulkInsertBenchmark.ElementCount = 1_000_000;
 //bPlusTreeBulkInsertBenchmark.GlobalSetup();
 //bPlusTreeBulkInsertBenchmark.IterationSetup();
 //await bPlusTreeBulkInsertBenchmark.BulkInsert_Batched();

--- a/tests/FlowtideDotNet.Benchmarks/Program.cs
+++ b/tests/FlowtideDotNet.Benchmarks/Program.cs
@@ -15,10 +15,10 @@ using DifferntialCompute.Benchmarks;
 using FlowtideDotNet.Benchmarks;
 
 
-ColumnStoreTreeBenchmark columnStore = new ColumnStoreTreeBenchmark();
-columnStore.GlobalSetup();
-columnStore.IterationSetup();
-await columnStore.ColumnarInsertBulkInOrder();
+//ColumnStoreTreeBenchmark columnStore = new ColumnStoreTreeBenchmark();
+//columnStore.GlobalSetup();
+//columnStore.IterationSetup();
+//await columnStore.ColumnarInsertBulkInOrder();
 //BPlusTreeBulkInsertBenchmark bPlusTreeBulkInsertBenchmark = new BPlusTreeBulkInsertBenchmark();
 //bPlusTreeBulkInsertBenchmark.ElementCount = 1_000_000;
 //bPlusTreeBulkInsertBenchmark.GlobalSetup();
@@ -26,4 +26,4 @@ await columnStore.ColumnarInsertBulkInOrder();
 //await bPlusTreeBulkInsertBenchmark.BulkInsert_Batched();
 
 //Console.WriteLine("hello");
-//var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/tests/FlowtideDotNet.Benchmarks/Program.cs
+++ b/tests/FlowtideDotNet.Benchmarks/Program.cs
@@ -13,11 +13,11 @@
 using BenchmarkDotNet.Running;
 using DifferntialCompute.Benchmarks;
 
-BPlusTreeBulkInsertBenchmark bPlusTreeBulkInsertBenchmark = new BPlusTreeBulkInsertBenchmark();
-bPlusTreeBulkInsertBenchmark.ElementCount = 10_000_000;
-bPlusTreeBulkInsertBenchmark.GlobalSetup();
-bPlusTreeBulkInsertBenchmark.IterationSetup();
-await bPlusTreeBulkInsertBenchmark.BulkInsert_Batched();
+//BPlusTreeBulkInsertBenchmark bPlusTreeBulkInsertBenchmark = new BPlusTreeBulkInsertBenchmark();
+//bPlusTreeBulkInsertBenchmark.ElementCount = 10_000_000;
+//bPlusTreeBulkInsertBenchmark.GlobalSetup();
+//bPlusTreeBulkInsertBenchmark.IterationSetup();
+//await bPlusTreeBulkInsertBenchmark.BulkInsert_Batched();
 
 //Console.WriteLine("hello");
-//var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnDeleteBatchTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnDeleteBatchTests.cs
@@ -517,7 +517,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 1, 2 };
 
-            col.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; 
+            ReadOnlySpan<int> ip = positions; 
+            col.InsertFrom(source, in sl, in ip, -1);
 
             // After insert: [10, 99, 30, 88, 50]
             Assert.Equal(5, col.Count);
@@ -771,3 +773,4 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
         }
     }
 }
+

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnInsertFromTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnInsertFromTests.cs
@@ -81,7 +81,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 10);
@@ -99,7 +99,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 0 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(3, target.Count);
             AssertIntValue(target, 0, 99);
@@ -116,7 +116,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 2 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(3, target.Count);
             AssertIntValue(target, 0, 10);
@@ -133,7 +133,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 0, 2 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(5, target.Count);
             AssertIntValue(target, 0, 100);
@@ -152,7 +152,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[0];
             Span<int> positions = stackalloc int[0];
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(2, target.Count);
             AssertIntValue(target, 0, 10);
@@ -168,7 +168,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 1, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertStringValue(target, 0, "a");
@@ -186,7 +186,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 2, 4 };
             Span<int> positions = stackalloc int[] { 0, 1, 2 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(6, target.Count);
             for (int i = 0; i < 6; i++)
@@ -210,7 +210,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 0, 2 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(5, target.Count);
             AssertNullValue(target, 0);
@@ -233,7 +233,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 10);
@@ -254,7 +254,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 0, 2 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertNullValue(target, 0);
@@ -272,7 +272,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 0, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 100);
@@ -290,7 +290,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 1, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 10);
@@ -308,7 +308,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(3, target.Count);
             AssertIntValue(target, 0, 10);
@@ -330,7 +330,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 1, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 10);
@@ -352,7 +352,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(3, target.Count);
 
@@ -387,7 +387,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 0 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(2, target.Count);
             Assert.Equal(2, target.GetValueAt(0, default).AsMap.GetValueAt(0).AsLong);
@@ -408,7 +408,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 0 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(2, target.Count);
             var s0 = target.GetValueAt(0, default).AsStruct;
@@ -429,7 +429,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 2, 4 };
             Span<int> positions = stackalloc int[] { 0, 2, 4 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(8, target.Count);
             AssertIntValue(target, 0, 100);
@@ -451,7 +451,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2 };
             Span<int> positions = stackalloc int[] { 1, 1, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(5, target.Count);
             AssertIntValue(target, 0, 10);
@@ -470,7 +470,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2 };
             Span<int> positions = stackalloc int[] { 0, 0, 0 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(3, target.Count);
             AssertIntValue(target, 0, 100);
@@ -487,7 +487,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 0, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(3, target.Count);
             AssertIntValue(target, 0, 10);
@@ -504,7 +504,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2 };
             Span<int> positions = stackalloc int[] { 0, 0, 0 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(6, target.Count);
             AssertIntValue(target, 0, 10);
@@ -524,7 +524,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2 };
             Span<int> positions = stackalloc int[] { 3, 3, 3 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(6, target.Count);
             AssertIntValue(target, 0, 50);
@@ -544,7 +544,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 1, 5, 9 };
             Span<int> positions = stackalloc int[] { 0, 0, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 11);
@@ -567,7 +567,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 500 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(1001, target.Count);
             AssertIntValue(target, 499, 499);
@@ -590,7 +590,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 1, 3 };
             Span<int> positions = stackalloc int[] { 2, 4 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(7, target.Count);
             AssertIntValue(target, 0, 1);
@@ -615,7 +615,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 2 };
             Span<int> positions = stackalloc int[] { 1, 2 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(5, target.Count);
             AssertIntValue(target, 0, 1);
@@ -636,7 +636,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 1);
@@ -654,7 +654,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2, 3, 4 };
             Span<int> positions = stackalloc int[] { 1, 1, 1, 1, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(7, target.Count);
             AssertIntValue(target, 0, 0);
@@ -709,7 +709,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
                 expected.Insert(positions[i], sourceValues[lookups[i]]);
             }
 
-            target.InsertFrom(source, lookups.AsSpan(), positions.AsSpan());
+            ReadOnlySpan<int> sl = lookups; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(expected.Count, target.Count);
             for (int i = 0; i < expected.Count; i++)
@@ -777,7 +777,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
                 expected.Insert(positions[i], sourceValues[lookups[i]]);
             }
 
-            target.InsertFrom(source, lookups.AsSpan(), positions.AsSpan());
+            ReadOnlySpan<int> sl = lookups; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(expected.Count, target.Count);
             for (int i = 0; i < expected.Count; i++)
@@ -806,7 +806,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2 };
             Span<int> positions = stackalloc int[] { 0, 1, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(5, target.Count);
             AssertNullValue(target, 0);
@@ -826,7 +826,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 0, 0 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(2, target.Count);
             AssertIntValue(target, 0, 100);
@@ -846,7 +846,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0 };
             Span<int> positions = stackalloc int[] { 0 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(2, target.Count);
             var s0 = target.GetValueAt(0, default).AsStruct;
@@ -867,7 +867,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 0, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 10);
@@ -888,7 +888,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 0, 2 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertNullValue(target, 0);
@@ -911,7 +911,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 1, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(4, target.Count);
             AssertIntValue(target, 0, 10);
@@ -933,7 +933,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2 };
             Span<int> positions = stackalloc int[] { 1, 3, 5 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(8, target.Count);
             AssertIntValue(target, 0, 1);
@@ -955,7 +955,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 1, 3 };
             Span<int> positions = stackalloc int[] { 0, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(3, target.Count);
             AssertIntValue(target, 0, 20);
@@ -972,7 +972,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2 };
             Span<int> positions = stackalloc int[] { 0, 2, 4 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(7, target.Count);
             AssertNullValue(target, 0);
@@ -999,7 +999,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1 };
             Span<int> positions = stackalloc int[] { 1, 2 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(5, target.Count);
             AssertIntValue(target, 0, 1);
@@ -1024,7 +1024,7 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
             Span<int> lookup = stackalloc int[] { 0, 1, 2 };
             Span<int> positions = stackalloc int[] { 0, 1, 1 };
 
-            target.InsertFrom(source, lookup, positions);
+            ReadOnlySpan<int> sl = lookup; ReadOnlySpan<int> ip = positions; target.InsertFrom(source, in sl, in ip, -1);
 
             Assert.Equal(5, target.Count);
             AssertNullValue(target, 0);
@@ -1037,3 +1037,4 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore
         }
     }
 }
+

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BinaryListTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Utils/BinaryListTests.cs
@@ -232,9 +232,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             using BinaryList other = new BinaryList(GlobalMemoryManager.Instance);
             other.Add(new byte[] { 4, 5 });
 
-            Span<int> sortedLookup = stackalloc int[0];
-            Span<int> insertPositions = stackalloc int[0];
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[0];
+            ReadOnlySpan<int> insertPositions = stackalloc int[0];
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(1, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(e1));
@@ -254,9 +254,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             using BinaryList other = new BinaryList(GlobalMemoryManager.Instance);
             other.Add(eNew);
 
-            Span<int> sortedLookup = stackalloc int[] { 0 };
-            Span<int> insertPositions = stackalloc int[] { 0 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(3, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(eNew));
@@ -278,9 +278,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             using BinaryList other = new BinaryList(GlobalMemoryManager.Instance);
             other.Add(eNew);
 
-            Span<int> sortedLookup = stackalloc int[] { 0 };
-            Span<int> insertPositions = stackalloc int[] { 2 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 2 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(3, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(e1));
@@ -302,9 +302,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             using BinaryList other = new BinaryList(GlobalMemoryManager.Instance);
             other.Add(eNew);
 
-            Span<int> sortedLookup = stackalloc int[] { 0 };
-            Span<int> insertPositions = stackalloc int[] { 1 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 1 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(3, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(e1));
@@ -332,9 +332,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             other.Add(eB);
             other.Add(eC);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
-            Span<int> insertPositions = stackalloc int[] { 0, 1, 3 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 1, 3 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(6, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(eA));
@@ -357,9 +357,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             other.Add(eA);
             other.Add(eB);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1 };
-            Span<int> insertPositions = stackalloc int[] { 0, 0 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 0 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(2, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(eA));
@@ -380,9 +380,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             other.Add(eA);
             other.Add(eB);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1 };
-            Span<int> insertPositions = stackalloc int[] { 1, 1 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 1, 1 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(3, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(e1));
@@ -406,9 +406,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             other.Add(eA);
             other.Add(eB);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1 };
-            Span<int> insertPositions = stackalloc int[] { 0, 0 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 0 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(4, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(eA));
@@ -433,9 +433,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             other.Add(eA);
             other.Add(eB);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1 };
-            Span<int> insertPositions = stackalloc int[] { 0, 2 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 2 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(4, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(eA));
@@ -464,9 +464,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             other.Add(eB);
             other.Add(eC);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
-            Span<int> insertPositions = stackalloc int[] { 0, 1, 2 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 1, 2 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(6, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(eA));
@@ -493,9 +493,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             other.Add(eB);
             other.Add(eC);
 
-            Span<int> sortedLookup = stackalloc int[] { 2, 1, 0 };
-            Span<int> insertPositions = stackalloc int[] { 0, 0, 1 };
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 2, 1, 0 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 0, 1 };
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(4, binaryList.Count);
             Assert.True(binaryList.Get(0).SequenceEqual(eC));
@@ -534,7 +534,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                 insertPositions[i] = 50; // Multiple inserts at same position
             }
 
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookupRO = sortedLookup;
+            ReadOnlySpan<int> insertPositionsRO = insertPositions;
+            binaryList.InsertFrom(in other, in sortedLookupRO, in insertPositionsRO, -1);
 
             Assert.Equal(135, binaryList.Count);
 
@@ -576,7 +578,9 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
                 insertPositions[i] = 0;
             }
 
-            binaryList.InsertFrom(other, sortedLookup, insertPositions);
+            ReadOnlySpan<int> sortedLookupRO = sortedLookup;
+            ReadOnlySpan<int> insertPositionsRO = insertPositions;
+            binaryList.InsertFrom(in other, in sortedLookupRO, in insertPositionsRO, -1);
 
             Assert.Equal(102, binaryList.Count);
 
@@ -588,6 +592,33 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Utils
             // Verify the original items were shifted correctly to the end
             Assert.True(binaryList.Get(100).SequenceEqual(e1));
             Assert.True(binaryList.Get(101).SequenceEqual(e2));
+        }
+
+        [Fact]
+        public void TestInsertFromWithNullIndex()
+        {
+            var e1 = new byte[] { 1, 2 };
+            var e2 = new byte[] { 3, 4 };
+            var eNew = new byte[] { 10, 11 };
+
+            using BinaryList binaryList = new BinaryList(GlobalMemoryManager.Instance);
+            binaryList.Add(e1);
+            binaryList.Add(e2);
+
+            using BinaryList other = new BinaryList(GlobalMemoryManager.Instance);
+            other.Add(eNew);
+
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { -1, 0, -1 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 1, 3 };
+
+            binaryList.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
+
+            Assert.Equal(5, binaryList.Count);
+            Assert.True(binaryList.Get(0).SequenceEqual(Span<byte>.Empty));
+            Assert.True(binaryList.Get(1).SequenceEqual(e1));
+            Assert.True(binaryList.Get(2).SequenceEqual(eNew));
+            Assert.True(binaryList.Get(3).SequenceEqual(e2));
+            Assert.True(binaryList.Get(4).SequenceEqual(Span<byte>.Empty));
         }
 
         [Fact]

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
@@ -118,6 +118,27 @@ namespace FlowtideDotNet.Storage.Tests
             }
         }
 
+        /// <summary>
+        /// Stateful mutator: deletes a key on first encounter, re-inserts on second.
+        /// Uses a class wrapper to maintain state across calls within a single batch.
+        /// </summary>
+        private class DeleteThenReinsertMutator : IRowMutator<long, long>
+        {
+            private readonly HashSet<long> _deletedInThisBatch = new();
+
+            public GenericWriteOperation Process(long key, bool exists, in long existingData, ref long incomingData)
+            {
+                if (exists && !_deletedInThisBatch.Contains(key))
+                {
+                    // First encounter: delete the existing key
+                    _deletedInThisBatch.Add(key);
+                    return GenericWriteOperation.Delete;
+                }
+                // Second encounter (or key didn't exist): re-insert
+                return GenericWriteOperation.Upsert;
+            }
+        }
+
         #endregion
 
         #region Helpers
@@ -1369,6 +1390,90 @@ namespace FlowtideDotNet.Storage.Tests
             }
 
             await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
+        #region Edge Case: Delete-then-reinsert same key in one batch
+
+        [Fact]
+        public async Task DeleteThenReinsertSameKey_InOneBatch()
+        {
+            // EDGE CASE: When a key exists in the leaf and the batch contains the
+            // same key twice, with a mutator that deletes on first encounter and
+            // re-inserts on second, the deferred delete/insert model breaks:
+            //
+            // 1. First occurrence: FindIndex finds key → mutator returns Delete
+            //    → queued for deletion, prevWasPendingInsert = false
+            // 2. Second occurrence: prevWasPendingInsert is false → FindIndex
+            //    still finds the key (delete is deferred) → mutator sees exists=true
+            //    but recognizes it was already "deleted" → returns Upsert
+            //    → UpdateValueAt updates the leaf value in-place (no insert queued)
+            // 3. DeleteBatch runs: removes the key
+            // 4. InsertFrom runs: nothing to insert for this key
+            //
+            // Result: key is gone when it should have been re-inserted with value 999.
+
+            var bulkInserter = CreateBulkInserter();
+
+            // Pre-populate key 5 with value 50
+            var setupKeys = new long[] { 1, 5, 10 };
+            var setupValues = new long[] { 10, 50, 100 };
+            await bulkInserter.ApplyBatch(setupKeys, setupValues, 3, new UpsertMutator());
+
+            // Verify setup
+            var (foundSetup, valSetup) = await _tree.GetValue(5);
+            Assert.True(foundSetup);
+            Assert.Equal(50, valSetup);
+
+            // Batch with key 5 appearing twice:
+            // - First occurrence: mutator sees exists=true, deletes
+            // - Second occurrence: mutator should re-insert with value 999
+            var keys = new long[] { 5, 5 };
+            var values = new long[] { 0, 999 };
+            var mutator = new DeleteThenReinsertMutator();
+            await bulkInserter.ApplyBatch(keys, values, 2, mutator);
+
+            // Expected: key 5 should exist with value 999
+            // Keys 1 and 10 should be untouched
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 5, 999 },
+                { 10, 100 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task DeleteThenReinsertSameKey_InOneBatch_MultipleKeys()
+        {
+            // Same edge case but with multiple keys being delete-then-reinserted.
+
+            var bulkInserter = CreateBulkInserter();
+
+            // Pre-populate keys 1-5
+            var setupKeys = new long[] { 1, 2, 3, 4, 5 };
+            var setupValues = new long[] { 10, 20, 30, 40, 50 };
+            await bulkInserter.ApplyBatch(setupKeys, setupValues, 5, new UpsertMutator());
+
+            // Delete-then-reinsert keys 2 and 4
+            var keys = new long[] { 2, 2, 4, 4 };
+            var values = new long[] { 0, 222, 0, 444 };
+            var mutator = new DeleteThenReinsertMutator();
+            await bulkInserter.ApplyBatch(keys, values, 4, mutator);
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 2, 222 },
+                { 3, 30 },
+                { 4, 444 },
+                { 5, 50 },
+            };
+
             await AssertTreeContents(expected);
         }
 

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
@@ -461,6 +461,44 @@ namespace FlowtideDotNet.Storage.Tests
             var all = await ReadAllFromTree();
             Assert.Equal(expected.Count, all.Count);
         }
+        [Fact]
+        public async Task DuplicateKeysInBatchPreserveOrder()
+        {
+            // When duplicates appear in a batch, they should be processed in the original sequence
+            // to ensure standard upsert semantics where the chronologically last occurrence wins.
+            
+            var bulkInserter = CreateBulkInserter();
+            var count = 10000;
+            var keys = new long[count];
+            var values = new long[count];
+            
+            int targetKeyCount = 0;
+            var rng = new Random(1234);
+
+            for (int i = 0; i < count; i++)
+            {
+                if (i % 2 == 0)
+                {
+                    keys[i] = 42;
+                    values[i] = targetKeyCount++;
+                }
+                else
+                {
+                    do
+                    {
+                        keys[i] = rng.Next(0, 100);
+                    } while (keys[i] == 42);
+
+                    values[i] = -1;
+                }
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            var (found, val) = await _tree.GetValue(42);
+            Assert.True(found);
+            Assert.Equal(targetKeyCount - 1, val); 
+        }
 
         #endregion
 

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
@@ -1479,6 +1479,209 @@ namespace FlowtideDotNet.Storage.Tests
 
         #endregion
 
+        #region Edge Case: Insert-then-delete of non-existent key in one batch
+
+        [Fact]
+        public async Task InsertThenDeleteNonExistentKey_InOneBatch()
+        {
+            // Key does NOT pre-exist. Batch inserts then deletes it.
+            // ToggleMutator: !exists → Upsert, exists → Delete.
+            //
+            // i=0: key=5, not found → Upsert → pending insert
+            // i=1: key=5, dup, prevWasPendingInsert → Delete → cancel pending insert
+            //
+            // Expected: key 5 should NOT exist in tree.
+
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 5, 5 };
+            var values = new long[] { 100, 200 };
+
+            await bulkInserter.ApplyBatch(keys, values, 2, new ToggleMutator());
+
+            var (found, _) = await _tree.GetValue(5);
+            Assert.False(found, "Key 5 should not exist after insert→delete in same batch");
+
+            var all = await ReadAllFromTree();
+            Assert.Empty(all);
+        }
+
+        [Fact]
+        public async Task InsertThenDeleteNonExistentKey_WithOtherKeysAfter()
+        {
+            // Same as above but with other keys following the canceled insert-delete.
+            // This exposes the insertOffset bug: canceling a pending insert should NOT
+            // decrement insertOffset since no element was removed from the leaf.
+            //
+            // keys=[5, 5, 10], sorted: [5, 5, 10]
+            // i=0: key=5, not found → Upsert → pending insert
+            // i=1: key=5, dup → Delete → cancel pending insert
+            // i=2: key=10, not found → Upsert → insert queued
+            //      target position = leafIndex + insertOffset
+            //      BUG: if insertOffset was incorrectly -1, position is shifted wrong
+
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 5, 5, 10 };
+            var values = new long[] { 100, 200, 1000 };
+
+            await bulkInserter.ApplyBatch(keys, values, 3, new ToggleMutator());
+
+            // Key 5 should NOT exist (inserted then deleted)
+            var (found5, _) = await _tree.GetValue(5);
+            Assert.False(found5, "Key 5 should not exist");
+
+            // Key 10 should exist with value 1000
+            var (found10, val10) = await _tree.GetValue(10);
+            Assert.True(found10, "Key 10 should exist");
+            Assert.Equal(1000, val10);
+
+            var all = await ReadAllFromTree();
+            Assert.Single(all);
+        }
+
+        [Fact]
+        public async Task InsertDeleteInsertNonExistentKey_InOneBatch()
+        {
+            // Key does NOT pre-exist. Batch has key 3 times: insert → delete → insert.
+            // ToggleMutator: !exists → Upsert, exists → Delete.
+            //
+            // i=0: key=5, not found → Upsert → pending insert
+            // i=1: key=5, dup, prevWasPendingInsert → Delete → cancel pending insert
+            // i=2: key=5, dup, ??? → should see exists=false → Upsert
+            //
+            // Expected: key 5 should exist with the third value.
+
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 5, 5, 5 };
+            var values = new long[] { 100, 200, 300 };
+
+            await bulkInserter.ApplyBatch(keys, values, 3, new ToggleMutator());
+
+            // Key 5 should exist (insert → delete → insert)
+            var (found, val) = await _tree.GetValue(5);
+            Assert.True(found, "Key 5 should exist after insert→delete→insert");
+            Assert.Equal(300, val);
+
+            var all = await ReadAllFromTree();
+            Assert.Single(all);
+        }
+
+        [Fact]
+        public async Task InsertDeleteInsertNonExistentKey_WithOtherKeys()
+        {
+            // Mix of: key 3 (unique), key 5 (insert→delete→insert), key 10 (unique).
+
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 3, 5, 5, 5, 10 };
+            var values = new long[] { 30, 100, 200, 300, 1000 };
+
+            await bulkInserter.ApplyBatch(keys, values, 5, new ToggleMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 3, 30 },
+                { 5, 300 },  // survived insert→delete→insert
+                { 10, 1000 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task LongToggleChain_NonExistentKey_OddCount()
+        {
+            // 9 occurrences of same non-existent key with ToggleMutator.
+            // Odd count → final state is "inserted".
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = Enumerable.Repeat(5L, 9).ToArray();
+            var values = Enumerable.Range(0, 9).Select(i => (long)(i * 100)).ToArray();
+
+            await bulkInserter.ApplyBatch(keys, values, 9, new ToggleMutator());
+
+            var (found, val) = await _tree.GetValue(5);
+            Assert.True(found, "Odd toggle count should leave key inserted");
+            Assert.Equal(800, val); // Last value
+
+            var all = await ReadAllFromTree();
+            Assert.Single(all);
+        }
+
+        [Fact]
+        public async Task LongToggleChain_NonExistentKey_EvenCount()
+        {
+            // 10 occurrences → even count → final state is "not inserted".
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = Enumerable.Repeat(5L, 10).ToArray();
+            var values = Enumerable.Range(0, 10).Select(i => (long)(i * 100)).ToArray();
+
+            await bulkInserter.ApplyBatch(keys, values, 10, new ToggleMutator());
+
+            var (found, _) = await _tree.GetValue(5);
+            Assert.False(found, "Even toggle count should leave key absent");
+
+            var all = await ReadAllFromTree();
+            Assert.Empty(all);
+        }
+
+        [Fact]
+        public async Task LongToggleChain_ExistingKey()
+        {
+            // Key pre-exists. ToggleMutator on existing key: exists=true → Delete.
+            // So the first toggle deletes, the second (exists=false) re-inserts.
+            // Each pair is delete→cancel = no-op.
+            // 6 toggles = 3 no-op pairs → key SURVIVES.
+            var bulkInserter = CreateBulkInserter();
+
+            var setup = new long[] { 5 };
+            await bulkInserter.ApplyBatch(setup, new long[] { 50 }, 1, new UpsertMutator());
+
+            var keys = Enumerable.Repeat(5L, 6).ToArray();
+            var values = Enumerable.Range(0, 6).Select(i => (long)(i * 100)).ToArray();
+
+            await bulkInserter.ApplyBatch(keys, values, 6, new ToggleMutator());
+
+            // Even pairs: delete→cancel, delete→cancel, delete→cancel = key survives
+            var (found, val) = await _tree.GetValue(5);
+            Assert.True(found, "Even toggle pairs on existing key = no-op, key survives");
+            Assert.Equal(500, val); // Last cancel used value at index 5
+        }
+
+        [Fact]
+        public async Task MixedToggleChain_WithSurroundingKeys()
+        {
+            // Batch with unique keys + toggling keys, all interleaved after sorting.
+            var bulkInserter = CreateBulkInserter();
+
+            // Pre-populate key 5
+            await bulkInserter.ApplyBatch(new long[] { 5 }, new long[] { 50 }, 1, new UpsertMutator());
+
+            // Batch: key 1 (new), key 3 (new x3 = insert→delete→insert),
+            //        key 5 (exists x2 = delete→cancel = survives),
+            //        key 8 (new x2 = insert→delete = gone), key 10 (new)
+            var keys   = new long[] { 1,  3, 3, 3,  5, 5,  8, 8,  10 };
+            var values = new long[] { 10, 30, 31, 32, 51, 52, 80, 81, 100 };
+
+            await bulkInserter.ApplyBatch(keys, values, 9, new ToggleMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 3, 32 },   // insert→delete→insert: survives
+                { 5, 52 },   // exists: delete→cancel (Upsert with value 52)
+                // 8: insert→delete: gone
+                { 10, 100 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
         public void Dispose()
         {
             _stateManager?.Dispose();

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Comparers;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Persistence.CacheStorage;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics.Metrics;
+
+namespace FlowtideDotNet.Storage.Tests
+{
+    public class BPlusTreeBulkInserterTests : IDisposable
+    {
+        private readonly BPlusTree<long, string, ListKeyContainer<long>, ListValueContainer<string>> _tree;
+        private readonly StateManagerSync _stateManager;
+
+        public BPlusTreeBulkInserterTests()
+        {
+            (_tree, _stateManager) = Init().GetAwaiter().GetResult();
+        }
+
+        private static async Task<(BPlusTree<long, string, ListKeyContainer<long>, ListValueContainer<string>>, StateManagerSync)> Init()
+        {
+            var stateManager = new StateManagerSync<object>(new StateManagerOptions()
+            {
+                CachePageCount = 1000000,
+                PersistentStorage = new FileCachePersistentStorage(new FileCacheOptions())
+            }, NullLoggerFactory.Instance, new Meter("bulk_inserter_test"), "bulk_inserter_test");
+            await stateManager.InitializeAsync();
+
+            var nodeClient = stateManager.GetOrCreateClient("node1");
+            var tree = await nodeClient.GetOrCreateTree<long, string, ListKeyContainer<long>, ListValueContainer<string>>("tree",
+                new BPlusTreeOptions<long, string, ListKeyContainer<long>, ListValueContainer<string>>()
+                {
+                    BucketSize = 8,
+                    Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
+                    KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
+                    ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                    MemoryAllocator = GlobalMemoryManager.Instance
+                });
+
+            return ((BPlusTree<long, string, ListKeyContainer<long>, ListValueContainer<string>>)tree, stateManager);
+        }
+
+        [Fact]
+        public async Task StartBatch_OnEmptyTree()
+        {
+            var bulkInserter = new BPlusTreeBulkInserter<long, string, ListKeyContainer<long>, ListValueContainer<string>>(_tree);
+
+            var keys = new long[] { 3, 1, 2 };
+            var values = new string[] { "three", "one", "two" };
+
+            await bulkInserter.StartBatch(keys, values);
+        }
+
+        public void Dispose()
+        {
+            _stateManager?.Dispose();
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
@@ -24,7 +24,7 @@ namespace FlowtideDotNet.Storage.Tests
 {
     public class BPlusTreeBulkInserterTests : IDisposable
     {
-        private readonly BPlusTree<long, string, ListKeyContainer<long>, ListValueContainer<string>> _tree;
+        private readonly BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>> _tree;
         private readonly StateManagerSync _stateManager;
 
         public BPlusTreeBulkInserterTests()
@@ -32,7 +32,7 @@ namespace FlowtideDotNet.Storage.Tests
             (_tree, _stateManager) = Init().GetAwaiter().GetResult();
         }
 
-        private static async Task<(BPlusTree<long, string, ListKeyContainer<long>, ListValueContainer<string>>, StateManagerSync)> Init()
+        private static async Task<(BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>, StateManagerSync)> Init()
         {
             var stateManager = new StateManagerSync<object>(new StateManagerOptions()
             {
@@ -40,30 +40,46 @@ namespace FlowtideDotNet.Storage.Tests
                 PersistentStorage = new FileCachePersistentStorage(new FileCacheOptions())
             }, NullLoggerFactory.Instance, new Meter("bulk_inserter_test"), "bulk_inserter_test");
             await stateManager.InitializeAsync();
-
+            
             var nodeClient = stateManager.GetOrCreateClient("node1");
-            var tree = await nodeClient.GetOrCreateTree<long, string, ListKeyContainer<long>, ListValueContainer<string>>("tree",
-                new BPlusTreeOptions<long, string, ListKeyContainer<long>, ListValueContainer<string>>()
+            var tree = await nodeClient.GetOrCreateTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>("tree",
+                new BPlusTreeOptions<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>()
                 {
-                    BucketSize = 8,
-                    Comparer = new BPlusTreeListComparer<long>(new LongComparer()),
-                    KeySerializer = new KeyListSerializer<long>(new LongSerializer()),
-                    ValueSerializer = new ValueListSerializer<string>(new StringSerializer()),
+                    PageSizeBytes = 100,
+                    UseByteBasedPageSizes = true,
+                    Comparer = new PrimitiveListComparer<long>(),
+                    KeySerializer = new PrimitiveListKeyContainerSerializer<long>(GlobalMemoryManager.Instance),
+                    ValueSerializer = new PrimitiveListValueContainerSerializer<long>(GlobalMemoryManager.Instance),
                     MemoryAllocator = GlobalMemoryManager.Instance
                 });
 
-            return ((BPlusTree<long, string, ListKeyContainer<long>, ListValueContainer<string>>)tree, stateManager);
+            return ((BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>)tree, stateManager);
+        }
+
+        private struct Mutator : IRowMutator<long, long>
+        {
+            public GenericWriteOperation Process(long key, bool exists, in long existingData, ref long incomingData)
+            {
+                return GenericWriteOperation.Upsert;
+            }
         }
 
         [Fact]
         public async Task StartBatch_OnEmptyTree()
         {
-            var bulkInserter = new BPlusTreeBulkInserter<long, string, ListKeyContainer<long>, ListValueContainer<string>>(_tree);
+            var bulkInserter = new BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>(_tree);
 
-            var keys = new long[] { 3, 1, 2 };
-            var values = new string[] { "three", "one", "two" };
+            var count = 100;
+            var keys = new long[count];
+            var values = new long[count];
 
-            await bulkInserter.StartBatch(keys, values);
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = i;
+                values[i] = i;
+            }
+            await bulkInserter.ApplyBatch(keys, values, count, new Mutator());
+            await bulkInserter.ApplyBatch(keys, values, count, new Mutator());
         }
 
         public void Dispose()

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkInserterTests.cs
@@ -56,7 +56,12 @@ namespace FlowtideDotNet.Storage.Tests
             return ((BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>)tree, stateManager);
         }
 
-        private struct Mutator : IRowMutator<long, long>
+        #region Mutators
+
+        /// <summary>
+        /// Always upserts: inserts new keys, updates existing ones.
+        /// </summary>
+        private struct UpsertMutator : IRowMutator<long, long>
         {
             public GenericWriteOperation Process(long key, bool exists, in long existingData, ref long incomingData)
             {
@@ -64,12 +69,672 @@ namespace FlowtideDotNet.Storage.Tests
             }
         }
 
-        [Fact]
-        public async Task StartBatch_OnEmptyTree()
+        /// <summary>
+        /// Always deletes if the key exists, otherwise does nothing.
+        /// </summary>
+        private struct DeleteIfExistsMutator : IRowMutator<long, long>
         {
-            var bulkInserter = new BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>(_tree);
+            public GenericWriteOperation Process(long key, bool exists, in long existingData, ref long incomingData)
+            {
+                return exists ? GenericWriteOperation.Delete : GenericWriteOperation.None;
+            }
+        }
 
+        /// <summary>
+        /// Upserts if the key does not exist, deletes if it does exist.
+        /// Useful for toggle-like behavior.
+        /// </summary>
+        private struct ToggleMutator : IRowMutator<long, long>
+        {
+            public GenericWriteOperation Process(long key, bool exists, in long existingData, ref long incomingData)
+            {
+                return exists ? GenericWriteOperation.Delete : GenericWriteOperation.Upsert;
+            }
+        }
+
+        /// <summary>
+        /// Conditionally upserts: only inserts/updates if incomingData > existingData (or key is new).
+        /// </summary>
+        private struct ConditionalUpsertMutator : IRowMutator<long, long>
+        {
+            public GenericWriteOperation Process(long key, bool exists, in long existingData, ref long incomingData)
+            {
+                if (!exists || incomingData > existingData)
+                {
+                    return GenericWriteOperation.Upsert;
+                }
+                return GenericWriteOperation.None;
+            }
+        }
+
+        /// <summary>
+        /// No-op mutator: never modifies the tree.
+        /// </summary>
+        private struct NoOpMutator : IRowMutator<long, long>
+        {
+            public GenericWriteOperation Process(long key, bool exists, in long existingData, ref long incomingData)
+            {
+                return GenericWriteOperation.None;
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>> CreateBulkInserter()
+        {
+            return new BPlusTreeBulkInserter<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>(_tree);
+        }
+
+        /// <summary>
+        /// Iterates the entire tree and returns keys and values in sorted order.
+        /// </summary>
+        private async Task<List<(long key, long value)>> ReadAllFromTree()
+        {
+            var result = new List<(long key, long value)>();
+            var it = _tree.CreateIterator();
+            await it.SeekFirst();
+            await foreach (var page in it)
+            {
+                foreach (var kv in page)
+                {
+                    result.Add((kv.Key, kv.Value));
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Asserts that the tree contains exactly the given key-value pairs in sorted key order.
+        /// </summary>
+        private async Task AssertTreeContents(SortedDictionary<long, long> expected)
+        {
+            var actual = await ReadAllFromTree();
+            var expectedList = expected.ToList();
+
+            Assert.Equal(expectedList.Count, actual.Count);
+            for (int i = 0; i < expectedList.Count; i++)
+            {
+                Assert.Equal(expectedList[i].Key, actual[i].key);
+                Assert.Equal(expectedList[i].Value, actual[i].value);
+            }
+        }
+
+        /// <summary>
+        /// Verifies each key individually via GetValue.
+        /// </summary>
+        private async Task AssertGetValueForAll(SortedDictionary<long, long> expected)
+        {
+            foreach (var kv in expected)
+            {
+                var (found, value) = await _tree.GetValue(kv.Key);
+                Assert.True(found, $"Key {kv.Key} not found in tree");
+                Assert.Equal(kv.Value, value);
+            }
+        }
+
+        /// <summary>
+        /// Generates an array of unique random keys.
+        /// </summary>
+        private long[] GenerateUniqueRandomKeys(Random rng, int count, int maxValue)
+        {
+            var set = new HashSet<long>();
+            while (set.Count < count)
+            {
+                set.Add(rng.Next(0, maxValue));
+            }
+            return set.ToArray();
+        }
+
+        #endregion
+
+        #region Insert Tests
+
+        [Fact]
+        public async Task InsertIntoEmptyTree_AscendingOrder()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var count = 50;
+            var keys = new long[count];
+            var values = new long[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = i;
+                values[i] = i * 10;
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 0; i < count; i++)
+                expected[i] = i * 10;
+
+            await AssertTreeContents(expected);
+            await AssertGetValueForAll(expected);
+        }
+
+        [Fact]
+        public async Task InsertIntoEmptyTree_DescendingOrder()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var count = 50;
+            var keys = new long[count];
+            var values = new long[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = count - 1 - i; // Descending order
+                values[i] = (count - 1 - i) * 10;
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 0; i < count; i++)
+                expected[i] = i * 10;
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task InsertIntoEmptyTree_RandomOrder_UniqueKeys()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var rng = new Random(42);
             var count = 100;
+            var keys = GenerateUniqueRandomKeys(rng, count, 10000);
+            var values = new long[count];
+            var expected = new SortedDictionary<long, long>();
+
+            for (int i = 0; i < count; i++)
+            {
+                values[i] = keys[i] * 10;
+                expected[keys[i]] = keys[i] * 10;
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task InsertSingleElement()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var keys = new long[] { 42 };
+            var values = new long[] { 420 };
+
+            await bulkInserter.ApplyBatch(keys, values, 1, new UpsertMutator());
+
+            var (found, value) = await _tree.GetValue(42);
+            Assert.True(found);
+            Assert.Equal(420, value);
+
+            var all = await ReadAllFromTree();
+            Assert.Single(all);
+        }
+
+        [Fact]
+        public async Task InsertWithPartialArrayLength()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var keys = new long[100];
+            var values = new long[100];
+
+            // Fill all 100, but only use the first 10
+            for (int i = 0; i < 100; i++)
+            {
+                keys[i] = i;
+                values[i] = i * 10;
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, 10, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 0; i < 10; i++)
+                expected[i] = i * 10;
+
+            await AssertTreeContents(expected);
+
+            // Keys 10-99 should NOT be in the tree
+            for (int i = 10; i < 100; i++)
+            {
+                var (found, _) = await _tree.GetValue(i);
+                Assert.False(found, $"Key {i} should not be in tree (beyond keyLength)");
+            }
+        }
+
+        [Fact]
+        public async Task DuplicateKeysInBatch_ShouldHaveOneEntryPerUniqueKey()
+        {
+            // BUG: When duplicate keys appear in the same batch, the bulk inserter
+            // inserts the key multiple times because FindIndex runs against the
+            // original leaf (inserts are deferred to InsertFrom at the end).
+            // The second occurrence doesn't see the pending first insert, so it
+            // also queues an insert — resulting in duplicate entries in the tree.
+            //
+            // Expected behavior: only one entry per unique key, last value wins.
+
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 5, 5, 5 };
+            var values = new long[] { 100, 200, 300 };
+
+            await bulkInserter.ApplyBatch(keys, values, 3, new UpsertMutator());
+
+            // There should be exactly 1 entry for key 5
+            var all = await ReadAllFromTree();
+            var entriesForKey5 = all.Where(x => x.key == 5).ToList();
+            Assert.Single(entriesForKey5);
+
+            // Total tree size should be 1, not 3
+            Assert.Single(all);
+        }
+
+        [Fact]
+        public async Task DuplicateKeysInBatch_LastValueShouldWin()
+        {
+            // When duplicate keys are in a batch, the last occurrence's value
+            // should be the one stored (standard upsert semantics).
+
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 1, 2, 1, 2, 1 };
+            var values = new long[] { 10, 20, 100, 200, 1000 };
+
+            await bulkInserter.ApplyBatch(keys, values, 5, new UpsertMutator());
+
+            var all = await ReadAllFromTree();
+
+            // Should have exactly 2 unique keys
+            Assert.Equal(2, all.Count);
+
+            // Key 1: last occurrence has value 1000
+            var (found1, val1) = await _tree.GetValue(1);
+            Assert.True(found1);
+            Assert.Equal(1000, val1);
+
+            // Key 2: last occurrence has value 200
+            var (found2, val2) = await _tree.GetValue(2);
+            Assert.True(found2);
+            Assert.Equal(200, val2);
+        }
+
+        [Fact]
+        public async Task DuplicateKeysInBatch_MixedWithUniqueKeys()
+        {
+            // Mix of unique and duplicate keys in a single batch.
+
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 1, 2, 3, 2, 4, 3 };
+            var values = new long[] { 10, 20, 30, 200, 40, 300 };
+
+            await bulkInserter.ApplyBatch(keys, values, 6, new UpsertMutator());
+
+            var all = await ReadAllFromTree();
+
+            // Should have exactly 4 unique keys: 1, 2, 3, 4
+            Assert.Equal(4, all.Count);
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 2, 200 },  // last value for key 2
+                { 3, 300 },  // last value for key 3
+                { 4, 40 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task DuplicateKeysInBatch_WithPreExistingData()
+        {
+            // When duplicates appear in a batch and the key already exists in the tree.
+
+            var bulkInserter = CreateBulkInserter();
+
+            // Pre-populate key 5
+            var setupKeys = new long[] { 5 };
+            var setupValues = new long[] { 50 };
+            await bulkInserter.ApplyBatch(setupKeys, setupValues, 1, new UpsertMutator());
+
+            // Batch with key 5 appearing twice
+            var keys = new long[] { 5, 5 };
+            var values = new long[] { 500, 5000 };
+            await bulkInserter.ApplyBatch(keys, values, 2, new UpsertMutator());
+
+            var all = await ReadAllFromTree();
+            Assert.Single(all);
+
+            var (found, val) = await _tree.GetValue(5);
+            Assert.True(found);
+            Assert.Equal(5000, val); // Last value should win
+        }
+
+        [Fact]
+        public async Task RandomBatchWithDuplicates_TreeCountMatchesUniqueKeys()
+        {
+            // Generates random keys (with inevitable duplicates) and verifies
+            // the tree has exactly one entry per unique key.
+
+            var bulkInserter = CreateBulkInserter();
+            var rng = new Random(42);
+            var count = 100;
+            var keys = new long[count];
+            var values = new long[count];
+            var expected = new SortedDictionary<long, long>();
+
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = rng.Next(0, 50); // Small range → many duplicates
+                values[i] = i;
+                expected[keys[i]] = i; // SortedDictionary keeps last value per key
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            var all = await ReadAllFromTree();
+            Assert.Equal(expected.Count, all.Count);
+        }
+
+        #endregion
+
+        #region Update Tests
+
+        [Fact]
+        public async Task UpdateExistingKeys()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // First batch: insert keys 0-9
+            var keys = new long[10];
+            var values = new long[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys[i] = i;
+                values[i] = i * 10;
+            }
+            await bulkInserter.ApplyBatch(keys, values, 10, new UpsertMutator());
+
+            // Second batch: update keys 0-9 with new values
+            for (int i = 0; i < 10; i++)
+            {
+                values[i] = i * 100; // Updated values
+            }
+            await bulkInserter.ApplyBatch(keys, values, 10, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 0; i < 10; i++)
+                expected[i] = i * 100;
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task ConditionalUpdate_OnlyIfGreater()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Insert initial values
+            var keys = new long[] { 1, 2, 3 };
+            var values = new long[] { 100, 200, 300 };
+            await bulkInserter.ApplyBatch(keys, values, 3, new UpsertMutator());
+
+            // Conditionally update: only key=2 should be updated (500 > 200), key=1 should not (50 < 100)
+            var keys2 = new long[] { 1, 2 };
+            var values2 = new long[] { 50, 500 };
+            await bulkInserter.ApplyBatch(keys2, values2, 2, new ConditionalUpsertMutator());
+
+            var (found1, val1) = await _tree.GetValue(1);
+            Assert.True(found1);
+            Assert.Equal(100, val1); // Unchanged
+
+            var (found2, val2) = await _tree.GetValue(2);
+            Assert.True(found2);
+            Assert.Equal(500, val2); // Updated
+
+            var (found3, val3) = await _tree.GetValue(3);
+            Assert.True(found3);
+            Assert.Equal(300, val3); // Untouched
+        }
+
+        #endregion
+
+        #region Delete Tests
+
+        [Fact]
+        public async Task DeleteExistingKeys()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Insert keys 0-19
+            var keys = new long[20];
+            var values = new long[20];
+            for (int i = 0; i < 20; i++)
+            {
+                keys[i] = i;
+                values[i] = i * 10;
+            }
+            await bulkInserter.ApplyBatch(keys, values, 20, new UpsertMutator());
+
+            // Delete even keys
+            var deleteKeys = new long[10];
+            var deleteValues = new long[10];
+            for (int i = 0; i < 10; i++)
+            {
+                deleteKeys[i] = i * 2;
+                deleteValues[i] = 0;
+            }
+            await bulkInserter.ApplyBatch(deleteKeys, deleteValues, 10, new DeleteIfExistsMutator());
+
+            // Only odd keys should remain
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 0; i < 20; i++)
+            {
+                if (i % 2 != 0)
+                    expected[i] = i * 10;
+            }
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task DeleteAllKeys_TreeBecomesEmpty()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Insert keys 0-9
+            var count = 10;
+            var keys = new long[count];
+            var values = new long[count];
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = i;
+                values[i] = i;
+            }
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            // Delete all keys
+            await bulkInserter.ApplyBatch(keys, values, count, new DeleteIfExistsMutator());
+
+            var all = await ReadAllFromTree();
+            Assert.Empty(all);
+        }
+
+        [Fact]
+        public async Task DeleteSingleKey()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 1, 2, 3 };
+            var values = new long[] { 10, 20, 30 };
+            await bulkInserter.ApplyBatch(keys, values, 3, new UpsertMutator());
+
+            // Delete just the middle key
+            var deleteKeys = new long[] { 2 };
+            var deleteValues = new long[] { 0 };
+            await bulkInserter.ApplyBatch(deleteKeys, deleteValues, 1, new DeleteIfExistsMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 3, 30 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task DeleteFirstAndLastKeys()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 1, 2, 3, 4, 5 };
+            var values = new long[] { 10, 20, 30, 40, 50 };
+            await bulkInserter.ApplyBatch(keys, values, 5, new UpsertMutator());
+
+            // Delete first and last
+            var deleteKeys = new long[] { 1, 5 };
+            var deleteValues = new long[] { 0, 0 };
+            await bulkInserter.ApplyBatch(deleteKeys, deleteValues, 2, new DeleteIfExistsMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 2, 20 },
+                { 3, 30 },
+                { 4, 40 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task DeleteNonExistentKeys_TreeUnchanged()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Insert keys 0-4
+            var keys = new long[5];
+            var values = new long[5];
+            for (int i = 0; i < 5; i++)
+            {
+                keys[i] = i;
+                values[i] = i * 10;
+            }
+            await bulkInserter.ApplyBatch(keys, values, 5, new UpsertMutator());
+
+            // Try to delete keys that don't exist
+            var deleteKeys = new long[] { 100, 200, 300 };
+            var deleteValues = new long[] { 0, 0, 0 };
+            await bulkInserter.ApplyBatch(deleteKeys, deleteValues, 3, new DeleteIfExistsMutator());
+
+            // Original keys should all still be present
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 0; i < 5; i++)
+                expected[i] = i * 10;
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task DeleteMixOfExistentAndNonExistent()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            var keys = new long[] { 1, 2, 3, 4, 5 };
+            var values = new long[] { 10, 20, 30, 40, 50 };
+            await bulkInserter.ApplyBatch(keys, values, 5, new UpsertMutator());
+
+            // Delete keys 2, 4 (exist) and 7, 9 (don't exist)
+            var deleteKeys = new long[] { 2, 4, 7, 9 };
+            var deleteValues = new long[] { 0, 0, 0, 0 };
+            await bulkInserter.ApplyBatch(deleteKeys, deleteValues, 4, new DeleteIfExistsMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 3, 30 },
+                { 5, 50 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task ToggleMutator_InsertsAndDeletesInSameBatch()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Pre-populate with keys 1, 3, 5
+            var setupKeys = new long[] { 1, 3, 5 };
+            var setupValues = new long[] { 10, 30, 50 };
+            await bulkInserter.ApplyBatch(setupKeys, setupValues, 3, new UpsertMutator());
+
+            // Toggle: keys 1,3,5 exist (will be deleted), keys 2,4 don't exist (will be inserted)
+            var keys = new long[] { 1, 2, 3, 4, 5 };
+            var values = new long[] { 0, 20, 0, 40, 0 };
+            await bulkInserter.ApplyBatch(keys, values, 5, new ToggleMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 2, 20 },
+                { 4, 40 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task AlternatingInsertAndDeleteBatches()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Insert 0-19
+            var keys = new long[20];
+            var values = new long[20];
+            for (int i = 0; i < 20; i++)
+            {
+                keys[i] = i;
+                values[i] = i;
+            }
+            await bulkInserter.ApplyBatch(keys, values, 20, new UpsertMutator());
+
+            // Delete 0-9
+            var delKeys = new long[10];
+            var delValues = new long[10];
+            for (int i = 0; i < 10; i++)
+            {
+                delKeys[i] = i;
+                delValues[i] = 0;
+            }
+            await bulkInserter.ApplyBatch(delKeys, delValues, 10, new DeleteIfExistsMutator());
+
+            // Insert 20-29
+            var keys2 = new long[10];
+            var values2 = new long[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys2[i] = 20 + i;
+                values2[i] = 20 + i;
+            }
+            await bulkInserter.ApplyBatch(keys2, values2, 10, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 10; i < 30; i++)
+                expected[i] = i;
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task StressTest_InsertThenDeleteAll_InRandomBatches()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var count = 200;
             var keys = new long[count];
             var values = new long[count];
 
@@ -78,9 +743,636 @@ namespace FlowtideDotNet.Storage.Tests
                 keys[i] = i;
                 values[i] = i;
             }
-            await bulkInserter.ApplyBatch(keys, values, count, new Mutator());
-            await bulkInserter.ApplyBatch(keys, values, count, new Mutator());
+
+            // Insert all
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            // Delete in random order batches
+            var rng = new Random(111);
+            var remainingKeys = Enumerable.Range(0, count).Select(x => (long)x).ToList();
+
+            while (remainingKeys.Count > 0)
+            {
+                var batchSize = Math.Min(rng.Next(5, 20), remainingKeys.Count);
+                var delKeys = new long[batchSize];
+                var delValues = new long[batchSize];
+
+                for (int i = 0; i < batchSize; i++)
+                {
+                    var idx = rng.Next(0, remainingKeys.Count);
+                    delKeys[i] = remainingKeys[idx];
+                    delValues[i] = 0;
+                    remainingKeys.RemoveAt(idx);
+                }
+
+                await bulkInserter.ApplyBatch(delKeys, delValues, batchSize, new DeleteIfExistsMutator());
+            }
+
+            var all = await ReadAllFromTree();
+            Assert.Empty(all);
         }
+
+        [Fact]
+        public async Task DeleteThenReinsert()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Insert 1,2,3
+            var keys = new long[] { 1, 2, 3 };
+            var values = new long[] { 10, 20, 30 };
+            await bulkInserter.ApplyBatch(keys, values, 3, new UpsertMutator());
+
+            // Delete key 2
+            var delKeys = new long[] { 2 };
+            var delValues = new long[] { 0 };
+            await bulkInserter.ApplyBatch(delKeys, delValues, 1, new DeleteIfExistsMutator());
+
+            // Verify key 2 is gone
+            var (found, _) = await _tree.GetValue(2);
+            Assert.False(found);
+
+            // Re-insert key 2 with a different value
+            var reinsertKeys = new long[] { 2 };
+            var reinsertValues = new long[] { 999 };
+            await bulkInserter.ApplyBatch(reinsertKeys, reinsertValues, 1, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 2, 999 },
+                { 3, 30 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
+        #region Mixed Operation Tests
+
+        [Fact]
+        public async Task MixedInsertAndUpdate_SameBatch()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Pre-populate with keys 0, 2, 4
+            var setupKeys = new long[] { 0, 2, 4 };
+            var setupValues = new long[] { 0, 20, 40 };
+            await bulkInserter.ApplyBatch(setupKeys, setupValues, 3, new UpsertMutator());
+
+            // Batch with mix of existing keys (will update) and new keys (will insert)
+            var keys = new long[] { 1, 2, 3, 4, 5 };
+            var values = new long[] { 10, 200, 30, 400, 50 };
+            await bulkInserter.ApplyBatch(keys, values, 5, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 0, 0 },     // unchanged from setup
+                { 1, 10 },    // new
+                { 2, 200 },   // updated
+                { 3, 30 },    // new
+                { 4, 400 },   // updated
+                { 5, 50 },    // new
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
+        #region NoOp Tests
+
+        [Fact]
+        public async Task NoOpMutator_TreeUnchanged()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Pre-populate
+            var keys = new long[] { 1, 2, 3 };
+            var values = new long[] { 10, 20, 30 };
+            await bulkInserter.ApplyBatch(keys, values, 3, new UpsertMutator());
+
+            // Apply with no-op mutator
+            var keys2 = new long[] { 1, 2, 3, 4, 5 };
+            var values2 = new long[] { 100, 200, 300, 400, 500 };
+            await bulkInserter.ApplyBatch(keys2, values2, 5, new NoOpMutator());
+
+            // Tree should be unchanged
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 2, 20 },
+                { 3, 30 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
+        #region Multi-Batch Tests
+
+        [Fact]
+        public async Task MultipleSequentialBatches_Accumulate()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var expected = new SortedDictionary<long, long>();
+
+            // Insert 5 batches of 20 unique keys each (non-overlapping)
+            for (int batch = 0; batch < 5; batch++)
+            {
+                var keys = new long[20];
+                var values = new long[20];
+                for (int i = 0; i < 20; i++)
+                {
+                    var key = batch * 20 + i;
+                    keys[i] = key;
+                    values[i] = key * 10;
+                    expected[key] = key * 10;
+                }
+                await bulkInserter.ApplyBatch(keys, values, 20, new UpsertMutator());
+            }
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task MultipleBatches_WithOverlappingKeys()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Batch 1: keys 0-9
+            var keys1 = new long[10];
+            var values1 = new long[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys1[i] = i;
+                values1[i] = i;
+            }
+            await bulkInserter.ApplyBatch(keys1, values1, 10, new UpsertMutator());
+
+            // Batch 2: keys 5-14 (overlaps with 5-9)
+            var keys2 = new long[10];
+            var values2 = new long[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys2[i] = i + 5;
+                values2[i] = (i + 5) * 100;
+            }
+            await bulkInserter.ApplyBatch(keys2, values2, 10, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 0; i < 5; i++)
+                expected[i] = i; // From batch 1
+            for (int i = 5; i < 15; i++)
+                expected[i] = i * 100; // From batch 2 (overwrites 5-9 from batch 1)
+
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
+        #region Bulkloader Reuse Tests
+
+        [Fact]
+        public async Task BulkInserterReuse_ArrayReuseBetweenBatches()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Use the same arrays for multiple batches with different data
+            var keys = new long[50];
+            var values = new long[50];
+            var expected = new SortedDictionary<long, long>();
+
+            // Batch 1: keys 0-49
+            for (int i = 0; i < 50; i++)
+            {
+                keys[i] = i;
+                values[i] = i;
+                expected[i] = i;
+            }
+            await bulkInserter.ApplyBatch(keys, values, 50, new UpsertMutator());
+
+            // Batch 2: reuse arrays with different data, keys 100-119 (only first 20)
+            for (int i = 0; i < 20; i++)
+            {
+                keys[i] = 100 + i;
+                values[i] = 1000 + i;
+                expected[100 + i] = 1000 + i;
+            }
+            await bulkInserter.ApplyBatch(keys, values, 20, new UpsertMutator());
+
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
+        #region Large / Split-Triggering Tests
+
+        [Fact]
+        public async Task LargeBatch_TriggersSplits()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var count = 500;
+            var keys = new long[count];
+            var values = new long[count];
+            var expected = new SortedDictionary<long, long>();
+
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = i;
+                values[i] = i * 10;
+                expected[i] = i * 10;
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            await AssertTreeContents(expected);
+            await AssertGetValueForAll(expected);
+        }
+
+        [Fact]
+        public async Task LargeBatch_RandomUniqueKeys()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var rng = new Random(12345);
+            var count = 500;
+            var keys = GenerateUniqueRandomKeys(rng, count, 50000);
+            var values = new long[count];
+            var expected = new SortedDictionary<long, long>();
+
+            for (int i = 0; i < count; i++)
+            {
+                values[i] = keys[i];
+                expected[keys[i]] = keys[i];
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task MultipleLargeBatches_UniqueKeysPerBatch()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var rng = new Random(123);
+            var expected = new SortedDictionary<long, long>();
+            var batchSize = 100;
+
+            for (int batch = 0; batch < 10; batch++)
+            {
+                var keys = GenerateUniqueRandomKeys(rng, batchSize, 5000);
+                var values = new long[batchSize];
+                for (int i = 0; i < batchSize; i++)
+                {
+                    values[i] = keys[i] * 10 + batch;
+                    expected[keys[i]] = keys[i] * 10 + batch;
+                }
+                await bulkInserter.ApplyBatch(keys, values, batchSize, new UpsertMutator());
+            }
+
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
+        #region Edge Case Tests
+
+        [Fact]
+        public async Task InsertAfterClear()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Insert some data
+            var keys = new long[] { 1, 2, 3 };
+            var values = new long[] { 10, 20, 30 };
+            await bulkInserter.ApplyBatch(keys, values, 3, new UpsertMutator());
+
+            // Clear the tree
+            await _tree.Clear();
+
+            // Insert new data (need a new inserter since tree was cleared)
+            var bulkInserter2 = CreateBulkInserter();
+            var keys2 = new long[] { 10, 20, 30 };
+            var values2 = new long[] { 100, 200, 300 };
+            await bulkInserter2.ApplyBatch(keys2, values2, 3, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 10, 100 },
+                { 20, 200 },
+                { 30, 300 },
+            };
+
+            await AssertTreeContents(expected);
+
+            // Old keys should not be present
+            var (found1, _) = await _tree.GetValue(1);
+            Assert.False(found1);
+        }
+
+        [Fact]
+        public async Task NegativeKeys()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var keys = new long[] { -10, -5, 0, 5, 10 };
+            var values = new long[] { -100, -50, 0, 50, 100 };
+
+            await bulkInserter.ApplyBatch(keys, values, 5, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { -10, -100 },
+                { -5, -50 },
+                { 0, 0 },
+                { 5, 50 },
+                { 10, 100 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task LargeKeyValues()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var keys = new long[] { long.MinValue, -1, 0, 1, long.MaxValue };
+            var values = new long[] { 1, 2, 3, 4, 5 };
+
+            await bulkInserter.ApplyBatch(keys, values, 5, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { long.MinValue, 1 },
+                { -1, 2 },
+                { 0, 3 },
+                { 1, 4 },
+                { long.MaxValue, 5 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task InsertSameKeyTwice_AcrossBatches()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            var keys1 = new long[] { 42 };
+            var values1 = new long[] { 100 };
+            await bulkInserter.ApplyBatch(keys1, values1, 1, new UpsertMutator());
+
+            var keys2 = new long[] { 42 };
+            var values2 = new long[] { 200 };
+            await bulkInserter.ApplyBatch(keys2, values2, 1, new UpsertMutator());
+
+            var (found, value) = await _tree.GetValue(42);
+            Assert.True(found);
+            Assert.Equal(200, value);
+        }
+
+        #endregion
+
+        #region Stress / Randomized Tests
+
+        [Fact]
+        public async Task StressTest_ManySmallBatches_UniqueKeys()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var rng = new Random(98765);
+            var expected = new SortedDictionary<long, long>();
+            var batchSize = 30;
+
+            for (int batch = 0; batch < 20; batch++)
+            {
+                var keys = GenerateUniqueRandomKeys(rng, batchSize, 500);
+                var values = new long[batchSize];
+
+                for (int i = 0; i < batchSize; i++)
+                {
+                    values[i] = rng.Next(0, 10000);
+                }
+
+                // Upsert only
+                await bulkInserter.ApplyBatch(keys, values, batchSize, new UpsertMutator());
+                for (int i = 0; i < batchSize; i++)
+                    expected[keys[i]] = values[i];
+            }
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task StressTest_CompareWithIndividualRMW()
+        {
+            // Verifies that bulk insert produces the same result as individual Upsert.
+            var rng = new Random(54321);
+            var batchCount = 15;
+            var batchSize = 30;
+            var expected = new SortedDictionary<long, long>();
+
+            var bulkInserter = CreateBulkInserter();
+
+            for (int batch = 0; batch < batchCount; batch++)
+            {
+                // Use unique keys per batch to avoid duplicate-key-in-batch issues
+                var keys = GenerateUniqueRandomKeys(rng, batchSize, 500);
+                var values = new long[batchSize];
+
+                for (int i = 0; i < batchSize; i++)
+                {
+                    values[i] = rng.Next(0, 1000);
+                }
+
+                await bulkInserter.ApplyBatch(keys, values, batchSize, new UpsertMutator());
+
+                for (int i = 0; i < batchSize; i++)
+                    expected[keys[i]] = values[i];
+            }
+
+            await AssertTreeContents(expected);
+            await AssertGetValueForAll(expected);
+        }
+
+        #endregion
+
+        #region Interleaving with Standard Tree Operations
+
+        [Fact]
+        public async Task BulkInsertThenIndividualUpsert()
+        {
+            var bulkInserter = CreateBulkInserter();
+
+            // Bulk insert
+            var keys = new long[] { 1, 3, 5 };
+            var values = new long[] { 10, 30, 50 };
+            await bulkInserter.ApplyBatch(keys, values, 3, new UpsertMutator());
+
+            // Individual upserts
+            await _tree.Upsert(2, 20);
+            await _tree.Upsert(4, 40);
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 2, 20 },
+                { 3, 30 },
+                { 4, 40 },
+                { 5, 50 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task IndividualUpsertThenBulkInsert()
+        {
+            // Individual upserts first
+            await _tree.Upsert(2, 20);
+            await _tree.Upsert(4, 40);
+
+            // Then bulk insert
+            var bulkInserter = CreateBulkInserter();
+            var keys = new long[] { 1, 3, 5 };
+            var values = new long[] { 10, 30, 50 };
+            await bulkInserter.ApplyBatch(keys, values, 3, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 2, 20 },
+                { 3, 30 },
+                { 4, 40 },
+                { 5, 50 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task BulkInsertThenIndividualDelete()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var keys = new long[] { 1, 2, 3, 4, 5 };
+            var values = new long[] { 10, 20, 30, 40, 50 };
+            await bulkInserter.ApplyBatch(keys, values, 5, new UpsertMutator());
+
+            await _tree.Delete(3);
+
+            var expected = new SortedDictionary<long, long>
+            {
+                { 1, 10 },
+                { 2, 20 },
+                { 4, 40 },
+                { 5, 50 },
+            };
+
+            await AssertTreeContents(expected);
+        }
+
+        [Fact]
+        public async Task IndividualDeleteThenBulkInsert()
+        {
+            // Pre-populate
+            for (int i = 0; i < 10; i++)
+            {
+                await _tree.Upsert(i, i * 10);
+            }
+
+            // Delete some
+            await _tree.Delete(3);
+            await _tree.Delete(7);
+
+            // Bulk insert with overlapping and new keys
+            var bulkInserter = CreateBulkInserter();
+            var keys = new long[] { 3, 7, 10, 11 };
+            var values = new long[] { 300, 700, 100, 110 };
+            await bulkInserter.ApplyBatch(keys, values, 4, new UpsertMutator());
+
+            var expected = new SortedDictionary<long, long>();
+            for (int i = 0; i < 10; i++)
+                expected[i] = i * 10;
+            expected[3] = 300;  // Re-inserted
+            expected[7] = 700;  // Re-inserted
+            expected[10] = 100; // New
+            expected[11] = 110; // New
+
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
+
+        #region Sorted Order Verification
+
+        [Fact]
+        public async Task TreeMaintainsSortedOrder_AfterMultipleBulkOperations()
+        {
+            var bulkInserter = CreateBulkInserter();
+            var rng = new Random(77777);
+
+            for (int batch = 0; batch < 10; batch++)
+            {
+                var size = rng.Next(10, 50);
+                // unique keys per batch to avoid within-batch duplicates
+                var keys = GenerateUniqueRandomKeys(rng, size, 2000);
+                var values = new long[size];
+                for (int i = 0; i < size; i++)
+                {
+                    values[i] = rng.Next();
+                }
+                await bulkInserter.ApplyBatch(keys, values, size, new UpsertMutator());
+            }
+
+            // Verify sorted order
+            var all = await ReadAllFromTree();
+            for (int i = 1; i < all.Count; i++)
+            {
+                Assert.True(all[i].key > all[i - 1].key,
+                    $"Keys not in sorted order: key[{i - 1}]={all[i - 1].key}, key[{i}]={all[i].key}");
+            }
+        }
+
+        #endregion
+
+        #region Bug Documentation: ApplySplitsAndMerges uses wrong list for merge loop
+
+        [Fact]
+        public async Task ApplySplitsAndMerges_MergeLoopBug_Documentation()
+        {
+            // BPlusTreeBulkInserter.ApplySplitsAndMerges() line 136 reads:
+            //   var map = _requireSplitMappings[i];
+            // but it is inside the merge loop (iterating _requireMergeMappings).
+            // This is a copy-paste bug — it should read:
+            //   var map = _requireMergeMappings[i];
+            //
+            // This test documents the bug. It would fail if _requireMergeMappings.Count
+            // ever exceeds _requireSplitMappings.Count during ApplySplitsAndMerges.
+            //
+            // For now, the split/merge path is mostly exercised via RMWNoResult
+            // (GenericWriteOperation.None) which re-walks the tree to trigger
+            // the built-in split/merge logic, so the bug is latent but real.
+
+            // This test simply proves that the large-insert + split path works.
+            // (Verifying the merge path would require DeleteBatch to be implemented.)
+            var bulkInserter = CreateBulkInserter();
+            var count = 500;
+            var keys = new long[count];
+            var values = new long[count];
+            var expected = new SortedDictionary<long, long>();
+
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = i;
+                values[i] = i;
+                expected[i] = i;
+            }
+
+            await bulkInserter.ApplyBatch(keys, values, count, new UpsertMutator());
+            await AssertTreeContents(expected);
+        }
+
+        #endregion
 
         public void Dispose()
         {

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
@@ -559,8 +559,9 @@ namespace FlowtideDotNet.Storage.Tests
             var groupMatchCounts = new Dictionary<long, int>();
             while (await searcher.MoveNextLeaf())
             {
-                foreach (var result in searcher.CurrentResults)
+                for (int i = 0; i < searcher.CurrentResults.Count; i++)
                 {
+                    var result = searcher.CurrentResults[i];
                     if (result.Found)
                     {
                         long group = searchKeys[result.KeyIndex] / divisor;

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
@@ -358,5 +358,228 @@ namespace FlowtideDotNet.Storage.Tests
             Assert.Equal(990, foundValues[99]);
             Assert.Equal(1500, foundValues[150]);
         }
+
+        /// <summary>
+        /// A comparer that groups keys by integer division, simulating a prefix comparer.
+        /// Keys with the same (key / divisor) value are treated as equal.
+        /// Used to test carry-over behavior with partial/prefix matching.
+        /// </summary>
+        private class GroupComparer : IBplusTreeComparer<long, PrimitiveListKeyContainer<long>>
+        {
+            private readonly long _divisor;
+
+            public GroupComparer(long divisor) { _divisor = divisor; }
+
+            public bool SeekNextPageForValue => true;
+
+            public int CompareTo(in long x, in long y) =>
+                (x / _divisor).CompareTo(y / _divisor);
+
+            public int CompareTo(in long key, in PrimitiveListKeyContainer<long> keyContainer, in int index) =>
+                (key / _divisor).CompareTo(keyContainer.Get(index) / _divisor);
+
+            public int FindIndex(in long key, in PrimitiveListKeyContainer<long> keyContainer)
+            {
+                long keyGroup = key / _divisor;
+                int lo = 0, hi = keyContainer.Count - 1;
+                int result = -1;
+                while (lo <= hi)
+                {
+                    int mid = lo + ((hi - lo) >> 1);
+                    long midGroup = keyContainer.Get(mid) / _divisor;
+                    int cmp = midGroup.CompareTo(keyGroup);
+                    if (cmp == 0) { result = mid; hi = mid - 1; } // narrow left to find leftmost
+                    else if (cmp < 0) lo = mid + 1;
+                    else hi = mid - 1;
+                }
+                return result >= 0 ? result : ~lo;
+            }
+
+            public FindBoundriesResult FindBoundries(in long key, in PrimitiveListKeyContainer<long> keyContainer, int startIndex, int endIndex)
+            {
+                long keyGroup = key / _divisor;
+
+                // Find lower bound (leftmost match)
+                int lo = startIndex, hi = endIndex;
+                bool found = false;
+                while (lo <= hi)
+                {
+                    int mid = lo + ((hi - lo) >> 1);
+                    long midGroup = keyContainer.Get(mid) / _divisor;
+                    int cmp = midGroup.CompareTo(keyGroup);
+                    if (cmp == 0) { found = true; hi = mid - 1; }
+                    else if (cmp < 0) lo = mid + 1;
+                    else hi = mid - 1;
+                }
+                int lowerBound = lo;
+                if (!found) return new FindBoundriesResult(~lo, ~lo);
+
+                // Quick single-match check
+                if (lowerBound < endIndex)
+                {
+                    if (keyContainer.Get(lowerBound + 1) / _divisor != keyGroup)
+                        return new FindBoundriesResult(lowerBound, lowerBound);
+                }
+                else
+                {
+                    return new FindBoundriesResult(lowerBound, lowerBound);
+                }
+
+                // Find upper bound (rightmost match)
+                lo = lowerBound + 1;
+                hi = endIndex;
+                while (lo <= hi)
+                {
+                    int mid = lo + ((hi - lo) >> 1);
+                    long midGroup = keyContainer.Get(mid) / _divisor;
+                    if (midGroup.CompareTo(keyGroup) <= 0) lo = mid + 1;
+                    else hi = mid - 1;
+                }
+                return new FindBoundriesResult(lowerBound, lo - 1);
+            }
+        }
+
+        [Fact]
+        public async Task CarryOver_KeyAtLastIndex_ContinuesToNextLeaf()
+        {
+            // Insert enough keys to span multiple leaves
+            await InsertRange(0, 100);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = Enumerable.Range(0, 100).Select(i => (long)i).ToArray();
+            await searcher.Start(keys, keys.Length);
+
+            var allResults = await CollectAllResults(searcher);
+            searcher.Dispose();
+
+            // With unique keys across multiple leaves, the last key of each non-last leaf
+            // should have ContinuesToNextLeaf=true and appear in results for 2 leaves.
+            var carryOverKeys = allResults
+                .Where(kvp => kvp.Value.Any(r => r.ContinuesToNextLeaf))
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            Assert.NotEmpty(carryOverKeys);
+
+            foreach (var keyIdx in carryOverKeys)
+            {
+                // Key should appear in at least 2 leaves (original leaf + carry-over leaf)
+                Assert.True(allResults[keyIdx].Count >= 2,
+                    $"Key {keys[keyIdx]} has ContinuesToNextLeaf but appears in only {allResults[keyIdx].Count} leaf(s)");
+
+                // First result should be Found (the original leaf)
+                Assert.True(allResults[keyIdx][0].Found,
+                    $"Key {keys[keyIdx]} should be found in the first leaf");
+            }
+        }
+
+        [Fact]
+        public async Task CarryOver_IntermediateLeaf_IsVisited()
+        {
+            // Insert enough keys to span at least 4 leaves
+            await InsertRange(0, 100);
+
+            // Phase 1: Identify leaf boundaries by doing a full search
+            var comparer = new PrimitiveListComparer<long>();
+            var scout = _tree.CreateBulkSearcher(comparer);
+            var allKeys = Enumerable.Range(0, 100).Select(i => (long)i).ToArray();
+            await scout.Start(allKeys, allKeys.Length);
+
+            var perLeafResults = new List<List<BulkSearchKeyResult>>();
+            while (await scout.MoveNextLeaf())
+            {
+                perLeafResults.Add(scout.CurrentResults.ToList());
+            }
+            scout.Dispose();
+
+            Assert.True(perLeafResults.Count >= 3, $"Need at least 3 leaves, got {perLeafResults.Count}");
+
+            // Find the last key of leaf 0 (triggers carry-over)
+            var lastResultInLeaf0 = perLeafResults[0].Last();
+            Assert.True(lastResultInLeaf0.ContinuesToNextLeaf, "Last key of leaf 0 should carry over");
+            long carryOverKey = allKeys[lastResultInLeaf0.KeyIndex];
+
+            // Pick a key from leaf 2 (skipping leaf 1 entirely in the mapping)
+            var midResultInLeaf2 = perLeafResults[2][perLeafResults[2].Count / 2];
+            long distantKey = allKeys[midResultInLeaf2.KeyIndex];
+
+            // Phase 2: Search for just the carry-over key and the distant key.
+            // RouteBatchRootAsync will create mappings for leaf0 and leaf2 only (none for leaf1).
+            var searcher = _tree.CreateBulkSearcher(comparer);
+            var testKeys = new long[] { carryOverKey, distantKey };
+            await searcher.Start(testKeys, testKeys.Length);
+
+            int leavesVisited = 0;
+            var testResults = new Dictionary<int, List<BulkSearchKeyResult>>();
+            while (await searcher.MoveNextLeaf())
+            {
+                leavesVisited++;
+                foreach (var result in searcher.CurrentResults)
+                {
+                    if (!testResults.TryGetValue(result.KeyIndex, out var list))
+                    {
+                        list = new List<BulkSearchKeyResult>();
+                        testResults[result.KeyIndex] = list;
+                    }
+                    list.Add(result);
+                }
+            }
+            searcher.Dispose();
+
+            // Should visit 3 leaves: leaf0 (carry-over key found), leaf1 (intermediate carry-over),
+            // leaf2 (distant key found). Without the intermediate leaf fix, only 2 would be visited.
+            Assert.Equal(3, leavesVisited);
+
+            // Both keys should be found
+            Assert.True(
+                testResults.Values.SelectMany(v => v).Any(r => r.Found && testKeys[r.KeyIndex] == carryOverKey),
+                $"Carry-over key {carryOverKey} should be found");
+            Assert.True(
+                testResults.Values.SelectMany(v => v).Any(r => r.Found && testKeys[r.KeyIndex] == distantKey),
+                $"Distant key {distantKey} should be found");
+        }
+
+        [Fact]
+        public async Task CarryOver_GroupComparer_FindsAllMatchesAcrossLeaves()
+        {
+            // Insert 200 unique keys spanning many leaves
+            await InsertRange(0, 200);
+
+            // GroupComparer with divisor 10: treats keys 0-9 as group 0, 10-19 as group 1, etc.
+            // Groups that straddle leaf boundaries require correct carry-over to find all members.
+            var divisor = 10L;
+            var groupComparer = new GroupComparer(divisor);
+            var searcher = _tree.CreateBulkSearcher(groupComparer);
+
+            // Search for one representative key per group (20 groups)
+            var searchKeys = Enumerable.Range(0, 20).Select(g => (long)(g * divisor)).ToArray();
+            await searcher.Start(searchKeys, searchKeys.Length);
+
+            var groupMatchCounts = new Dictionary<long, int>();
+            while (await searcher.MoveNextLeaf())
+            {
+                foreach (var result in searcher.CurrentResults)
+                {
+                    if (result.Found)
+                    {
+                        long group = searchKeys[result.KeyIndex] / divisor;
+                        int matchCount = result.UpperBound - result.LowerBound + 1;
+                        if (!groupMatchCounts.ContainsKey(group))
+                            groupMatchCounts[group] = 0;
+                        groupMatchCounts[group] += matchCount;
+                    }
+                }
+            }
+            searcher.Dispose();
+
+            // Every group should have exactly 10 matches (keys g*10 through g*10+9).
+            // If carry-over is broken (including the ~count carry-over for prefix comparers),
+            // groups straddling leaf boundaries would report fewer than 10.
+            for (int g = 0; g < 20; g++)
+            {
+                Assert.True(groupMatchCounts.ContainsKey(g), $"Group {g} not found in results");
+                Assert.Equal(10, groupMatchCounts[g]);
+            }
+        }
     }
 }

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
@@ -343,8 +343,9 @@ namespace FlowtideDotNet.Storage.Tests
             while (await searcher.MoveNextLeaf())
             {
                 var leaf = searcher.CurrentLeaf;
-                foreach (var result in searcher.CurrentResults)
+                for (int i = 0; i < searcher.CurrentResults.Count; i++)
                 {
+                    var result = searcher.CurrentResults[i];
                     if (result.Found)
                     {
                         var key = keys[result.KeyIndex];

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
@@ -1,0 +1,362 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Comparers;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Persistence.CacheStorage;
+using FlowtideDotNet.Storage.Serializers;
+using FlowtideDotNet.Storage.StateManager;
+using FlowtideDotNet.Storage.Tree;
+using FlowtideDotNet.Storage.Tree.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics.Metrics;
+
+namespace FlowtideDotNet.Storage.Tests
+{
+    public class BPlusTreeBulkSearchTests : IDisposable
+    {
+        private readonly BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>> _tree;
+        private readonly StateManagerSync _stateManager;
+
+        public BPlusTreeBulkSearchTests()
+        {
+            (_tree, _stateManager) = Init().GetAwaiter().GetResult();
+        }
+
+        private static async Task<(BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>, StateManagerSync)> Init()
+        {
+            var stateManager = new StateManagerSync<object>(new StateManagerOptions()
+            {
+                CachePageCount = 1000000,
+                PersistentStorage = new FileCachePersistentStorage(new FileCacheOptions())
+            }, NullLoggerFactory.Instance, new Meter("bulk_search_test"), "bulk_search_test");
+            await stateManager.InitializeAsync();
+
+            var nodeClient = stateManager.GetOrCreateClient("node1");
+            var tree = await nodeClient.GetOrCreateTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>("tree",
+                new BPlusTreeOptions<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>()
+                {
+                    PageSizeBytes = 100,
+                    UseByteBasedPageSizes = true,
+                    Comparer = new PrimitiveListComparer<long>(),
+                    KeySerializer = new PrimitiveListKeyContainerSerializer<long>(GlobalMemoryManager.Instance),
+                    ValueSerializer = new PrimitiveListValueContainerSerializer<long>(GlobalMemoryManager.Instance),
+                    MemoryAllocator = GlobalMemoryManager.Instance
+                });
+
+            return ((BPlusTree<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>>)tree, stateManager);
+        }
+
+        public void Dispose()
+        {
+            _stateManager?.Dispose();
+        }
+
+        private async Task InsertKeys(params long[] keys)
+        {
+            foreach (var key in keys)
+            {
+                await _tree.Upsert(key, key * 10);
+            }
+        }
+
+        private async Task InsertRange(long start, long count)
+        {
+            for (long i = start; i < start + count; i++)
+            {
+                await _tree.Upsert(i, i * 10);
+            }
+        }
+
+        /// <summary>
+        /// Collects all results from a bulk search into a dictionary keyed by the original key index.
+        /// </summary>
+        private async Task<Dictionary<int, List<BulkSearchKeyResult>>> CollectAllResults<TComparer>(
+            IBplusTreeBulkSearch<long, long, PrimitiveListKeyContainer<long>, PrimitiveListValueContainer<long>, TComparer> searcher)
+            where TComparer : IBplusTreeComparer<long, PrimitiveListKeyContainer<long>>
+        {
+            var allResults = new Dictionary<int, List<BulkSearchKeyResult>>();
+            while (await searcher.MoveNextLeaf())
+            {
+                foreach (var result in searcher.CurrentResults)
+                {
+                    if (!allResults.TryGetValue(result.KeyIndex, out var list))
+                    {
+                        list = new List<BulkSearchKeyResult>();
+                        allResults[result.KeyIndex] = list;
+                    }
+                    list.Add(result);
+                }
+            }
+            return allResults;
+        }
+
+        [Fact]
+        public async Task SearchEmptyTree_ReturnsNotFound()
+        {
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 1, 2, 3 };
+            await searcher.Start(keys, keys.Length);
+
+            var results = await CollectAllResults(searcher);
+
+            // All keys should appear with Found == false
+            foreach (var kvp in results)
+            {
+                Assert.Single(kvp.Value);
+                Assert.False(kvp.Value[0].Found);
+            }
+        }
+
+        [Fact]
+        public async Task SearchSingleKey_Found()
+        {
+            await InsertKeys(5);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 5 };
+            await searcher.Start(keys, keys.Length);
+
+            var results = await CollectAllResults(searcher);
+
+            Assert.True(results.ContainsKey(0));
+            Assert.True(results[0][0].Found);
+            Assert.Equal(0, results[0][0].LowerBound);
+            Assert.Equal(0, results[0][0].UpperBound);
+        }
+
+        [Fact]
+        public async Task SearchSingleKey_NotFound()
+        {
+            await InsertKeys(5);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 3 };
+            await searcher.Start(keys, keys.Length);
+
+            var results = await CollectAllResults(searcher);
+
+            Assert.True(results.ContainsKey(0));
+            Assert.False(results[0][0].Found);
+        }
+
+        [Fact]
+        public async Task SearchMultipleKeys_MixedFoundAndNotFound()
+        {
+            await InsertKeys(1, 3, 5, 7, 9);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 1, 2, 5, 8, 9 };
+            await searcher.Start(keys, keys.Length);
+
+            var results = await CollectAllResults(searcher);
+
+            // key[0]=1 found, key[1]=2 not found, key[2]=5 found, key[3]=8 not found, key[4]=9 found
+            Assert.True(results[0].Any(r => r.Found));   // 1
+            Assert.True(results[1].All(r => !r.Found));   // 2
+            Assert.True(results[2].Any(r => r.Found));   // 5
+            Assert.True(results[3].All(r => !r.Found));   // 8
+            Assert.True(results[4].Any(r => r.Found));   // 9
+        }
+
+        [Fact]
+        public async Task SearchAcrossMultipleLeaves()
+        {
+            // Insert enough keys to span multiple leaves (page size is 100 bytes, longs are 8 bytes each)
+            await InsertRange(0, 100);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 0, 50, 99 };
+            await searcher.Start(keys, keys.Length);
+
+            var results = await CollectAllResults(searcher);
+
+            Assert.True(results[0].Any(r => r.Found));   // 0
+            Assert.True(results[1].Any(r => r.Found));   // 50
+            Assert.True(results[2].Any(r => r.Found));   // 99
+        }
+
+        [Fact]
+        public async Task SearchWithUnsortedKeys_StillReturnsCorrectKeyIndex()
+        {
+            await InsertKeys(10, 20, 30);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            // Keys in reverse order
+            var keys = new long[] { 30, 10, 20 };
+            await searcher.Start(keys, keys.Length);
+
+            var results = await CollectAllResults(searcher);
+
+            // KeyIndex should map back to original positions
+            Assert.True(results[0].Any(r => r.Found));  // key[0]=30
+            Assert.True(results[1].Any(r => r.Found));  // key[1]=10
+            Assert.True(results[2].Any(r => r.Found));  // key[2]=20
+        }
+
+        [Fact]
+        public async Task SearchCanBeReused()
+        {
+            await InsertKeys(1, 2, 3);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+
+            // First search
+            var keys1 = new long[] { 1, 4 };
+            await searcher.Start(keys1, keys1.Length);
+            var results1 = await CollectAllResults(searcher);
+            Assert.True(results1[0].Any(r => r.Found));   // 1
+            Assert.True(results1[1].All(r => !r.Found));   // 4
+
+            // Second search reusing the same searcher
+            var keys2 = new long[] { 2, 3, 5 };
+            await searcher.Start(keys2, keys2.Length);
+            var results2 = await CollectAllResults(searcher);
+            Assert.True(results2[0].Any(r => r.Found));   // 2
+            Assert.True(results2[1].Any(r => r.Found));   // 3
+            Assert.True(results2[2].All(r => !r.Found));   // 5
+        }
+
+        [Fact]
+        public async Task SearchAllKeysFound_LargeTree()
+        {
+            await InsertRange(0, 500);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 0, 100, 200, 300, 400, 499 };
+            await searcher.Start(keys, keys.Length);
+
+            var results = await CollectAllResults(searcher);
+
+            for (int i = 0; i < keys.Length; i++)
+            {
+                Assert.True(results.ContainsKey(i), $"Key index {i} (value {keys[i]}) missing from results");
+                Assert.True(results[i].Any(r => r.Found), $"Key {keys[i]} should be found");
+            }
+        }
+
+        [Fact]
+        public async Task SearchAllKeysNotFound_LargeTree()
+        {
+            // Insert only even numbers
+            for (long i = 0; i < 200; i += 2)
+            {
+                await _tree.Upsert(i, i * 10);
+            }
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            // Search for odd numbers
+            var keys = new long[] { 1, 3, 5, 99, 101, 199 };
+            await searcher.Start(keys, keys.Length);
+
+            var results = await CollectAllResults(searcher);
+
+            for (int i = 0; i < keys.Length; i++)
+            {
+                Assert.True(results.ContainsKey(i), $"Key index {i} (value {keys[i]}) missing from results");
+                Assert.True(results[i].All(r => !r.Found), $"Key {keys[i]} should not be found");
+            }
+        }
+
+        [Fact]
+        public async Task SearchPartialKeyLength()
+        {
+            await InsertKeys(1, 2, 3, 4, 5);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 1, 2, 3, 4, 5 };
+            // Only search first 2 keys
+            await searcher.Start(keys, 2);
+
+            var results = await CollectAllResults(searcher);
+
+            // Only key indices 0 and 1 should have results
+            Assert.True(results.ContainsKey(0));
+            Assert.True(results.ContainsKey(1));
+            Assert.True(results[0].Any(r => r.Found));
+            Assert.True(results[1].Any(r => r.Found));
+        }
+
+        [Fact]
+        public async Task MoveNextLeaf_ReturnsFalseOnEmptyTree()
+        {
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 1 };
+            await searcher.Start(keys, keys.Length);
+
+            // Should get at least one leaf call
+            int leafCount = 0;
+            while (await searcher.MoveNextLeaf())
+            {
+                leafCount++;
+                Assert.NotNull(searcher.CurrentLeaf);
+            }
+            // Even on empty tree the root leaf exists, so we may get 1 leaf
+            Assert.True(leafCount >= 1);
+        }
+
+        [Fact]
+        public async Task CurrentLeafHasAccessibleKeysAndValues()
+        {
+            await InsertKeys(10, 20, 30);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 10 };
+            await searcher.Start(keys, keys.Length);
+
+            Assert.True(await searcher.MoveNextLeaf());
+
+            var leaf = searcher.CurrentLeaf;
+            Assert.True(leaf.keys.Count > 0);
+            Assert.True(leaf.values.Count > 0);
+
+            // The found result should let us index into the leaf
+            var result = searcher.CurrentResults[0];
+            if (result.Found)
+            {
+                var foundKey = leaf.keys.Get(result.LowerBound);
+                var foundValue = leaf.values.Get(result.LowerBound);
+                Assert.Equal(10, foundKey);
+                Assert.Equal(100, foundValue);
+            }
+        }
+
+        [Fact]
+        public async Task SearchValueCanBeReadFromLeaf()
+        {
+            await InsertRange(0, 200);
+
+            var searcher = _tree.CreateBulkSearcher(new PrimitiveListComparer<long>());
+            var keys = new long[] { 42, 99, 150 };
+            await searcher.Start(keys, keys.Length);
+
+            var foundValues = new Dictionary<long, long>();
+            while (await searcher.MoveNextLeaf())
+            {
+                var leaf = searcher.CurrentLeaf;
+                foreach (var result in searcher.CurrentResults)
+                {
+                    if (result.Found)
+                    {
+                        var key = keys[result.KeyIndex];
+                        var value = leaf.values.Get(result.LowerBound);
+                        foundValues[key] = value;
+                    }
+                }
+            }
+
+            Assert.Equal(420, foundValues[42]);
+            Assert.Equal(990, foundValues[99]);
+            Assert.Equal(1500, foundValues[150]);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeBulkSearchTests.cs
@@ -161,11 +161,11 @@ namespace FlowtideDotNet.Storage.Tests
             var results = await CollectAllResults(searcher);
 
             // key[0]=1 found, key[1]=2 not found, key[2]=5 found, key[3]=8 not found, key[4]=9 found
-            Assert.True(results[0].Any(r => r.Found));   // 1
+            Assert.Contains(results[0], r => r.Found);   // 1
             Assert.True(results[1].All(r => !r.Found));   // 2
-            Assert.True(results[2].Any(r => r.Found));   // 5
+            Assert.Contains(results[2], r => r.Found);   // 5
             Assert.True(results[3].All(r => !r.Found));   // 8
-            Assert.True(results[4].Any(r => r.Found));   // 9
+            Assert.Contains(results[4], r => r.Found);   // 9
         }
 
         [Fact]
@@ -180,9 +180,9 @@ namespace FlowtideDotNet.Storage.Tests
 
             var results = await CollectAllResults(searcher);
 
-            Assert.True(results[0].Any(r => r.Found));   // 0
-            Assert.True(results[1].Any(r => r.Found));   // 50
-            Assert.True(results[2].Any(r => r.Found));   // 99
+            Assert.Contains(results[0], r => r.Found);   // 0
+            Assert.Contains(results[1], r => r.Found);   // 50
+            Assert.Contains(results[2], r => r.Found);   // 99
         }
 
         [Fact]
@@ -198,9 +198,9 @@ namespace FlowtideDotNet.Storage.Tests
             var results = await CollectAllResults(searcher);
 
             // KeyIndex should map back to original positions
-            Assert.True(results[0].Any(r => r.Found));  // key[0]=30
-            Assert.True(results[1].Any(r => r.Found));  // key[1]=10
-            Assert.True(results[2].Any(r => r.Found));  // key[2]=20
+            Assert.Contains(results[0], r => r.Found);  // key[0]=30
+            Assert.Contains(results[1], r => r.Found);  // key[1]=10
+            Assert.Contains(results[2], r => r.Found);  // key[2]=20
         }
 
         [Fact]
@@ -214,15 +214,15 @@ namespace FlowtideDotNet.Storage.Tests
             var keys1 = new long[] { 1, 4 };
             await searcher.Start(keys1, keys1.Length);
             var results1 = await CollectAllResults(searcher);
-            Assert.True(results1[0].Any(r => r.Found));   // 1
+            Assert.Contains(results1[0], r => r.Found);   // 1
             Assert.True(results1[1].All(r => !r.Found));   // 4
 
             // Second search reusing the same searcher
             var keys2 = new long[] { 2, 3, 5 };
             await searcher.Start(keys2, keys2.Length);
             var results2 = await CollectAllResults(searcher);
-            Assert.True(results2[0].Any(r => r.Found));   // 2
-            Assert.True(results2[1].Any(r => r.Found));   // 3
+            Assert.Contains(results2[0], r => r.Found);   // 2
+            Assert.Contains(results2[1], r => r.Found);   // 3
             Assert.True(results2[2].All(r => !r.Found));   // 5
         }
 
@@ -282,8 +282,8 @@ namespace FlowtideDotNet.Storage.Tests
             // Only key indices 0 and 1 should have results
             Assert.True(results.ContainsKey(0));
             Assert.True(results.ContainsKey(1));
-            Assert.True(results[0].Any(r => r.Found));
-            Assert.True(results[1].Any(r => r.Found));
+            Assert.Contains(results[0], r => r.Found);
+            Assert.Contains(results[1], r => r.Found);
         }
 
         [Fact]

--- a/tests/FlowtideDotNet.Storage.Tests/BPlusTreeByteBased/ListWithSizeComparer.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/BPlusTreeByteBased/ListWithSizeComparer.cs
@@ -35,6 +35,11 @@ namespace FlowtideDotNet.Storage.Tests.BPlusTreeByteBased
             return comparer.Compare(key, keyContainer.Get(index));
         }
 
+        public FindBoundriesResult FindBoundries(in KeyValuePair<long, long> key, in ListKeyContainerWithSize keyContainer, int startIndex, int length)
+        {
+            throw new NotImplementedException();
+        }
+
         public int FindIndex(in KeyValuePair<long, long> key, in ListKeyContainerWithSize keyContainer)
         {
             return keyContainer._list.BinarySearch(key, comparer);

--- a/tests/FlowtideDotNet.Storage.Tests/DataStructures/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/DataStructures/BitmapListTests.cs
@@ -1120,7 +1120,8 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             var other = new BitmapList(GlobalMemoryManager.Instance);
             other.Add(false);
 
-            list.InsertFrom(in other, Span<int>.Empty, Span<int>.Empty, -1);
+            var emptySpan = ReadOnlySpan<int>.Empty;
+            list.InsertFrom(in other, in emptySpan, in emptySpan, -1);
 
             Assert.Equal(3, list.Count);
             Assert.True(list.Get(0));

--- a/tests/FlowtideDotNet.Storage.Tests/DataStructures/BitmapListTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/DataStructures/BitmapListTests.cs
@@ -1120,7 +1120,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             var other = new BitmapList(GlobalMemoryManager.Instance);
             other.Add(false);
 
-            list.InsertFrom(other, Span<int>.Empty, Span<int>.Empty);
+            list.InsertFrom(in other, Span<int>.Empty, Span<int>.Empty, -1);
 
             Assert.Equal(3, list.Count);
             Assert.True(list.Get(0));
@@ -1143,7 +1143,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0];
             int[] insertPositions = [1];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             Assert.Equal(4, list.Count);
             Assert.True(list.Get(0));
@@ -1166,7 +1166,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0];
             int[] insertPositions = [1];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             Assert.Equal(4, list.Count);
             Assert.True(list.Get(0));
@@ -1198,7 +1198,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2];
             int[] insertPositions = [0, 0, 0];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1235,7 +1235,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2];
             int[] insertPositions = [10, 10, 10];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1272,7 +1272,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2, 3, 4];
             int[] insertPositions = [1, 3, 5, 7, 9];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1311,7 +1311,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2, 3, 4];
             int[] insertPositions = [15, 30, 31, 32, 50];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1341,7 +1341,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2];
             int[] insertPositions = [0, 0, 0];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1378,7 +1378,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2, 3];
             int[] insertPositions = [0, 10, 20, 30];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1415,7 +1415,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2, 3];
             int[] insertPositions = [0, 10, 20, 30];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1452,7 +1452,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2];
             int[] insertPositions = [5, 6, 7];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1489,7 +1489,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 2, 4];
             int[] insertPositions = [3, 8, 12];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1542,7 +1542,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                     sortedLookup[i] = r.Next(0, otherList.Count);
                 }
 
-                list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+                ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
                 for (int i = 0; i < sortedLookup.Length; i++)
                 {
@@ -1582,7 +1582,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2];
             int[] insertPositions = [5, 5, 5];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1621,7 +1621,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
             int[] insertPositions = [0, 14, 31, 32, 48, 63, 64, 80, 96, 112];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1647,7 +1647,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0];
             int[] insertPositions = [0];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             Assert.Equal(2, list.Count);
             Assert.False(list.Get(0));
@@ -1685,7 +1685,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                 insertPositions[i] = 0;
             }
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1730,7 +1730,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                 insertPositions[i] = 0;
             }
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1775,7 +1775,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                 insertPositions[i] = Math.Min(i / 4, 4); // clusters at 0,0,0,0,1,1,1,1,...,4
             }
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1813,7 +1813,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [3, 7, 9];
             int[] insertPositions = [2, 10, 18];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1867,7 +1867,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                     sortedLookup[i] = r.Next(0, otherList.Count);
                 }
 
-                list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+                ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
                 for (int i = 0; i < sortedLookup.Length; i++)
                 {
@@ -1915,7 +1915,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                 insertPositions[i] = i;
             }
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -1949,7 +1949,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0];
             int[] insertPositions = [31];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             expected.Insert(31, true);
 
@@ -1980,7 +1980,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             int[] sortedLookup = [0];
             int[] insertPositions = [32];
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             expected.Insert(32, false);
 
@@ -2023,7 +2023,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                 insertPositions[i] = i * 16;
             }
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             for (int i = 0; i < sortedLookup.Length; i++)
             {
@@ -2530,5 +2530,37 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                 Assert.Equal(expected[i], list.Get(i));
             }
         }
+
+        [Fact]
+         public void TestInsertFromWithNullIndex()
+         {
+             var list = new BitmapList(GlobalMemoryManager.Instance);
+             
+             // Base list
+             for (int i = 0; i < 5; i++)
+             {
+                 list.Add(true);
+             }
+
+             var other = new BitmapList(GlobalMemoryManager.Instance);
+             other.Add(true);
+             other.Add(true);
+
+             // Test inserting null values (represented as false in BitmapList)
+             int[] sortedLookup = [0, 100, 1]; // 100 is the null index
+             int[] insertPositions = [1, 3, 5];
+
+             ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, 100);
+
+             Assert.Equal(8, list.Count);
+             Assert.True(list.Get(0));
+             Assert.True(list.Get(1)); // from other (0)
+             Assert.True(list.Get(2));
+             Assert.True(list.Get(3)); 
+             Assert.False(list.Get(4)); // null index (100) -> false
+             Assert.True(list.Get(5));
+             Assert.True(list.Get(6));
+             Assert.True(list.Get(7)); // from other (1)
+         }
     }
 }

--- a/tests/FlowtideDotNet.Storage.Tests/DataStructures/PrimitiveListTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/DataStructures/PrimitiveListTests.cs
@@ -71,7 +71,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
             ReadOnlySpan<int> insertPositions = stackalloc int[] { 1, 3, 5 };
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(8, list.Count);
             Assert.Equal(0, list[0]);
@@ -101,7 +101,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
             ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 0, 0 };
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(6, list.Count);
             Assert.Equal(100, list[0]);
@@ -128,7 +128,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1 };
             ReadOnlySpan<int> insertPositions = stackalloc int[] { 3, 3 };
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(5, list.Count);
             Assert.Equal(0, list[0]);
@@ -154,7 +154,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = stackalloc int[] { 1, 0 };
             ReadOnlySpan<int> insertPositions = stackalloc int[] { 1, 2 };
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(5, list.Count);
             Assert.Equal(0, list[0]);
@@ -178,7 +178,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0 };
             ReadOnlySpan<int> insertPositions = stackalloc int[] { 1 };
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(3, list.Count);
             Assert.Equal(1, list[0]);
@@ -199,7 +199,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = ReadOnlySpan<int>.Empty;
             ReadOnlySpan<int> insertPositions = ReadOnlySpan<int>.Empty;
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(2, list.Count);
             Assert.Equal(1, list[0]);
@@ -227,7 +227,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                 insertPositions[i] = i + 1; 
             }
 
-            list.InsertFrom(in other, sortedLookup.AsSpan(), insertPositions.AsSpan(), -1);
+            ReadOnlySpan<int> sl = sortedLookup; ReadOnlySpan<int> ip = insertPositions; list.InsertFrom(in other, in sl, in ip, -1);
 
             Assert.Equal(2_000, list.Count);
             for (int i = 0; i < 2_000; i++)
@@ -255,7 +255,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = stackalloc int[] { 1, 3 };
             ReadOnlySpan<int> insertPositions = stackalloc int[] { 2, 4 };
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(6, list.Count);
             Assert.Equal(0, list[0]);
@@ -280,7 +280,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
             ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 0, 0 };
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(3, list.Count);
             Assert.Equal(10, list[0]);
@@ -305,7 +305,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
             ReadOnlySpan<int> insertPositions = stackalloc int[] { 2, 2, 2 };
 
-            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -1);
 
             Assert.Equal(8, list.Count);
             Assert.Equal(0, list[0]);
@@ -665,3 +665,4 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
         }
     }
 }
+

--- a/tests/FlowtideDotNet.Storage.Tests/DataStructures/PrimitiveListTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/DataStructures/PrimitiveListTests.cs
@@ -68,10 +68,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             other.Add(20);
             other.Add(30);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
-            Span<int> insertPositions = stackalloc int[] { 1, 3, 5 };
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 1, 3, 5 };
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(8, list.Count);
             Assert.Equal(0, list[0]);
@@ -98,10 +98,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             other.Add(200);
             other.Add(300);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
-            Span<int> insertPositions = stackalloc int[] { 0, 0, 0 };
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 0, 0 };
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(6, list.Count);
             Assert.Equal(100, list[0]);
@@ -125,10 +125,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             other.Add(100);
             other.Add(200);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1 };
-            Span<int> insertPositions = stackalloc int[] { 3, 3 };
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 3, 3 };
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(5, list.Count);
             Assert.Equal(0, list[0]);
@@ -151,10 +151,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             other.Add(10);
             other.Add(20);
 
-            Span<int> sortedLookup = stackalloc int[] { 1, 0 };
-            Span<int> insertPositions = stackalloc int[] { 1, 2 };
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 1, 0 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 1, 2 };
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(5, list.Count);
             Assert.Equal(0, list[0]);
@@ -175,10 +175,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             list.Add(3);
             other.Add(2);
 
-            Span<int> sortedLookup = stackalloc int[] { 0 };
-            Span<int> insertPositions = stackalloc int[] { 1 };
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 1 };
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(3, list.Count);
             Assert.Equal(1, list[0]);
@@ -196,10 +196,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             list.Add(1);
             list.Add(2);
 
-            Span<int> sortedLookup = Span<int>.Empty;
-            Span<int> insertPositions = Span<int>.Empty;
+            ReadOnlySpan<int> sortedLookup = ReadOnlySpan<int>.Empty;
+            ReadOnlySpan<int> insertPositions = ReadOnlySpan<int>.Empty;
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(2, list.Count);
             Assert.Equal(1, list[0]);
@@ -227,7 +227,7 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
                 insertPositions[i] = i + 1; 
             }
 
-            list.InsertFrom(other, sortedLookup.AsSpan(), insertPositions.AsSpan());
+            list.InsertFrom(in other, sortedLookup.AsSpan(), insertPositions.AsSpan(), -1);
 
             Assert.Equal(2_000, list.Count);
             for (int i = 0; i < 2_000; i++)
@@ -252,10 +252,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             other.Add(40);
             other.Add(50);
 
-            Span<int> sortedLookup = stackalloc int[] { 1, 3 };
-            Span<int> insertPositions = stackalloc int[] { 2, 4 };
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 1, 3 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 2, 4 };
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(6, list.Count);
             Assert.Equal(0, list[0]);
@@ -277,10 +277,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             other.Add(20);
             other.Add(30);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
-            Span<int> insertPositions = stackalloc int[] { 0, 0, 0 };
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 0, 0 };
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(3, list.Count);
             Assert.Equal(10, list[0]);
@@ -302,10 +302,10 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             other.Add(200);
             other.Add(300);
 
-            Span<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
-            Span<int> insertPositions = stackalloc int[] { 2, 2, 2 };
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { 0, 1, 2 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 2, 2, 2 };
 
-            list.InsertFrom(other, sortedLookup, insertPositions);
+            list.InsertFrom(in other, sortedLookup, insertPositions, -1);
 
             Assert.Equal(8, list.Count);
             Assert.Equal(0, list[0]);
@@ -632,6 +632,36 @@ namespace FlowtideDotNet.Storage.Tests.DataStructures
             Assert.Equal(1, list[1]);
             Assert.Equal(2, list[2]);
             Assert.Equal(3, list[3]);
+        }
+
+        [Fact]
+        public void TestInsertFromWithNullIndex()
+        {
+            var allocator = GlobalMemoryManager.Instance;
+            using var list = new PrimitiveList<int>(allocator);
+            using var other = new PrimitiveList<int>(allocator);
+
+            for (int i = 0; i < 3; i++)
+                list.Add(i + 1); // 1, 2, 3
+
+            other.Add(100);
+            other.Add(200);
+
+            ReadOnlySpan<int> sortedLookup = stackalloc int[] { -2, 0, -2, 1, -2 };
+            ReadOnlySpan<int> insertPositions = stackalloc int[] { 0, 1, 1, 3, 3 };
+
+            list.InsertFrom(in other, in sortedLookup, in insertPositions, -2);
+
+            Assert.Equal(8, list.Count);
+
+            Assert.Equal(0, list[0]);
+            Assert.Equal(1, list[1]);
+            Assert.Equal(100, list[2]);
+            Assert.Equal(0, list[3]);
+            Assert.Equal(2, list[4]);
+            Assert.Equal(3, list[5]);
+            Assert.Equal(200, list[6]);
+            Assert.Equal(0, list[7]);
         }
     }
 }

--- a/tests/FlowtideDotNet.Storage.Tests/Reservoir/ConcurrentLocalCacheManagerEdgeCaseTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/Reservoir/ConcurrentLocalCacheManagerEdgeCaseTests.cs
@@ -369,8 +369,10 @@ namespace FlowtideDotNet.Storage.Tests.Reservoir
 
             await Task.WhenAll(evict, read1, read2).WaitAsync(cts.Token);
 
-            Assert.Equal(new byte[] { 5, 6, 7 }, read1.Result.ToArray());
-            Assert.Equal(new byte[] { 5, 6, 7 }, read2.Result.ToArray());
+            var read1result = await read1;
+            var read2result = await read2;
+            Assert.Equal(new byte[] { 5, 6, 7 }, read1result.ToArray());
+            Assert.Equal(new byte[] { 5, 6, 7 }, read2result.ToArray());
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds a bulk inserter and bulk searcher for the BPlusTree which processes operations in batches, giving up to a 2x performance increase. To support this I added bulk methods like DeleteBatch and updated InsertFrom to handle null indices across the column structures. ColumnBulkMergeJoin was created to use these new bulk operations for much better throughput.

Lastly I changed the int32 boundary search to be completely branchless, which avoids jump instructions and speeds up tree lookups.