### PR TITLE
Add prefix sum byte size method to column

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/AlwaysNullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/AlwaysNullColumn.cs
@@ -76,6 +76,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             return 0;
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            // Do nothing, no sizes
+        }
+
         public ArrowTypeId GetTypeAt(in int index, in ReferenceSegment? child)
         {
             return ArrowTypeId.Null;

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -909,6 +909,16 @@ namespace FlowtideDotNet.Core.ColumnStore
             return _dataColumn!.GetByteSize() + _validityList!.GetByteSize(0, Count - 1);
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            if (_type == ArrowTypeId.Null)
+            {
+                return;
+            }
+            _dataColumn!.GetPrefixSumByteSizes(indices, sizes);
+            _validityList!.GetPrefixSumByteSizes(indices, sizes);
+        }
+
         private bool CompareOtherColumnType(Column otherColumn)
         {
             if (_type != otherColumn.Type)

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -19,7 +19,10 @@ using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
+using SqlParser.Ast;
 using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace FlowtideDotNet.Core.ColumnStore
@@ -100,6 +103,41 @@ namespace FlowtideDotNet.Core.ColumnStore
                 }
             }
             return size;
+        }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            int length = indices.Length;
+            ref int indicesHead = ref MemoryMarshal.GetReference(indices);
+            ref int sizesHead = ref MemoryMarshal.GetReference(sizes);
+
+            int sum = 0;
+
+            int lastOffset = -2;
+            int lastSize = 0;
+
+            for (int i = 0; i < length; i++)
+            {
+                int idx = Unsafe.Add(ref indicesHead, i);
+                int offset = offsets.Get(idx);
+
+                if (offset == NullValueIndex)
+                {
+                    // Do nothing
+                }
+                else if (offset == lastOffset)
+                {
+                    sum += lastSize;
+                }
+                else
+                {
+                    lastSize = innerColumn.GetByteSize(offset, offset);
+                    lastOffset = offset;
+                    sum += lastSize;
+                }
+
+                Unsafe.Add(ref sizesHead, i) += sum;
+            }
         }
 
         public ArrowTypeId GetTypeAt(in int index, in ReferenceSegment? child)

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -19,7 +19,6 @@ using FlowtideDotNet.Core.ColumnStore.Utils;
 using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
-using SqlParser.Ast;
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BinaryColumn.cs
@@ -213,6 +213,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             return _data.GetByteSize(0, Count - 1);
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            _data.GetPrefixSumByteSizes(indices, sizes);
+        }
+
         public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
         {
             if (other is BinaryColumn binaryColumn)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/BoolColumn.cs
@@ -238,6 +238,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             return _data.GetByteSize(0, Count - 1);
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            _data.GetPrefixSumByteSizes(indices, sizes);
+        }
+
         public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
         {
             if (other is BoolColumn boolColumn)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DecimalColumn.cs
@@ -218,6 +218,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             return Count * sizeof(decimal);
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            _values.GetPrefixSumByteSizes(indices, sizes);
+        }
+
         public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
         {
             if (other is DecimalColumn decimalColumn)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/DoubleColumn.cs
@@ -217,6 +217,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             return Count * sizeof(double);
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            _data.GetPrefixSumByteSizes(indices, sizes);
+        }
+
         public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
         {
             if (other is DoubleColumn doubleColumn)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
@@ -69,6 +69,8 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         int GetByteSize();
 
+        void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes);
+
         void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList);
 
         /// <summary>

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/Int64Column.cs
@@ -363,6 +363,11 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             return CompareColumnStateBuilder.Create(ArrowTypeId.Int64);
         }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            throw new NotSupportedException("Int64Column is no longer in use");
+        }
     }
 }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -29,6 +29,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Hashing;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 
@@ -1253,6 +1255,26 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 return _data.GetColumnState();
             }
             return CompareColumnStateBuilder.Create(ArrowTypeId.Int8);
+        }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            if (_data != null)
+            {
+                int length = indices.Length;
+                var elementSize = _data.BitWidth / 8;
+                ref int sizesHead = ref MemoryMarshal.GetReference(sizes);
+
+                int cumulativeMass = elementSize;
+
+                for (int i = 0; i < length; i++)
+                {
+                    Unsafe.Add(ref sizesHead, i) += cumulativeMass;
+                    cumulativeMass += elementSize;
+                }
+                return;
+            }
+            throw new InvalidOperationException("Tried to get prefix sum byte sizes for an empty integer column, this should not happen.");
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -1272,9 +1272,7 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                     Unsafe.Add(ref sizesHead, i) += cumulativeMass;
                     cumulativeMass += elementSize;
                 }
-                return;
             }
-            throw new InvalidOperationException("Tried to get prefix sum byte sizes for an empty integer column, this should not happen.");
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/ListColumn.cs
@@ -25,6 +25,8 @@ using System.Buffers;
 using System.Collections;
 using System.Diagnostics;
 using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace FlowtideDotNet.Core.ColumnStore
@@ -465,6 +467,31 @@ namespace FlowtideDotNet.Core.ColumnStore
                 return sizeof(int);
             }
             return _internalColumn.GetByteSize(startOffset, endOffset - 1) + ((end - start + 1) * sizeof(int));
+        }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            int length = indices.Length;
+            ref int indicesHead = ref MemoryMarshal.GetReference(indices);
+            ref int sizesHead = ref MemoryMarshal.GetReference(sizes);
+
+            int sum = 0;
+            for (int i = 0; i < length; i++)
+            {
+                int idx = Unsafe.Add(ref indicesHead, i);
+
+                int startOffset = _offsets.Get(idx);
+                int endOffset = _offsets.Get(idx + 1);
+
+                sum += sizeof(int);
+
+                if (startOffset != endOffset)
+                {
+                    sum += _internalColumn.GetByteSize(startOffset, endOffset - 1);
+                }
+
+                Unsafe.Add(ref sizesHead, i) += sum;
+            }
         }
 
         public int GetByteSize()

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/MapColumn.cs
@@ -25,6 +25,8 @@ using FlowtideDotNet.Substrait.Expressions;
 using System.Buffers;
 using System.Collections;
 using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace FlowtideDotNet.Core.ColumnStore
@@ -575,6 +577,32 @@ namespace FlowtideDotNet.Core.ColumnStore
         public int GetByteSize()
         {
             return _keyColumn.GetByteSize() + _valueColumn.GetByteSize() + (_offsets.Count * sizeof(int));
+        }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            int length = indices.Length;
+            ref int indicesHead = ref MemoryMarshal.GetReference(indices);
+            ref int sizesHead = ref MemoryMarshal.GetReference(sizes);
+
+            int sum = 0;
+            for (int i = 0; i < length; i++)
+            {
+                int idx = Unsafe.Add(ref indicesHead, i);
+
+                int startOffset = _offsets.Get(idx);
+                int endOffset = _offsets.Get(idx + 1);
+
+                sum += sizeof(int);
+
+                if (startOffset != endOffset)
+                {
+                    sum += _keyColumn.GetByteSize(startOffset, endOffset - 1);
+                    sum += _valueColumn.GetByteSize(startOffset, endOffset - 1);
+                }
+
+                Unsafe.Add(ref sizesHead, i) += sum;
+            }
         }
 
         public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/NullColumn.cs
@@ -205,6 +205,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
         {
             return CompareColumnStateBuilder.Create(ArrowTypeId.Null);
         }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            // Null column has no data, so all sizes are 0
+        }
     }
 }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StringColumn.cs
@@ -229,6 +229,11 @@ namespace FlowtideDotNet.Core.ColumnStore
             return _binaryList.GetByteSize(0, Count - 1);
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            _binaryList.GetPrefixSumByteSizes(indices, sizes);
+        }
+
         public void InsertRangeFrom(int index, IDataColumn other, int start, int count, BitmapList? validityList)
         {
             if (other is StringColumn stringColumn)

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
@@ -20,10 +20,8 @@ using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
-using System.Drawing;
 using System.IO.Hashing;
 using System.Text.Json;
-using static SqlParser.Ast.MatchRecognizeSymbol;
 
 namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 {

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/StructColumn.cs
@@ -20,8 +20,10 @@ using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
+using System.Drawing;
 using System.IO.Hashing;
 using System.Text.Json;
+using static SqlParser.Ast.MatchRecognizeSymbol;
 
 namespace FlowtideDotNet.Core.ColumnStore.DataColumns
 {
@@ -250,6 +252,14 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 size += _columns[i].GetByteSize();
             }
             return size;
+        }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            for (int i = 0; i < _columns.Length; i++)
+            {
+                _columns[i].GetPrefixSumByteSizes(indices, sizes);
+            }
         }
 
         public SerializationEstimation GetSerializationEstimate()

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/TimestampTzColumn.cs
@@ -146,6 +146,11 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             return Count * sizeof(TimestampTzValue);
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            _values.GetPrefixSumByteSizes(indices, sizes);
+        }
+
         public ArrowTypeId GetTypeAt(in int index, in ReferenceSegment? child)
         {
             return ArrowTypeId.Timestamp;

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/UnionColumn.cs
@@ -26,6 +26,7 @@ using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace FlowtideDotNet.Core.ColumnStore.DataColumns
@@ -606,6 +607,24 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 size += _valueColumns[i].GetByteSize();
             }
             return size + (Count * sizeof(int));
+        }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            int length = indices.Length;
+            ref int indicesHead = ref MemoryMarshal.GetReference(indices);
+            ref int sizesHead = ref MemoryMarshal.GetReference(sizes);
+
+            int sum = 0;
+            for (int i = 0; i < length; i++)
+            {
+                int idx = Unsafe.Add(ref indicesHead, i);
+                sum += sizeof(int);
+                int typeIndex = _typeList[idx];
+                int childOffset = _offsets.Get(idx);
+                sum += _valueColumns[typeIndex].GetByteSize(childOffset, childOffset);
+                Unsafe.Add(ref sizesHead, i) += sum;
+            }
         }
 
         private sbyte CheckOtherDataColumnTypeExists(IDataColumn other, sbyte[] typeIds, List<IDataColumn> valueColumns)

--- a/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
@@ -78,6 +78,8 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         int GetByteSize(int start, int end);
 
+        void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes);
+
         void InsertRangeFrom(int index, IColumn otherColumn, int start, int count);
 
         void WriteToJson(ref readonly Utf8JsonWriter writer, in int index);

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/BinaryList.cs
@@ -13,6 +13,8 @@
 using FlowtideDotNet.Storage.Memory;
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace FlowtideDotNet.Core.ColumnStore.Utils
 {
@@ -352,6 +354,31 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             var startOffset = _offsets.Get(start);
             var endOffset = _offsets.Get(end + 1);
             return endOffset - startOffset + ((end - start + 1) * sizeof(int));
+        }
+
+        /// <summary>
+        /// Fetches sizes for each index and adds them to the sizes span. 
+        /// This is used to calculate the size of a batch of elements in bytes.
+        /// It adds instead of replaces so it can check multiple columns
+        /// </summary>
+        /// <param name="indices"></param>
+        /// <param name="sizes"></param>
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            int length = indices.Length;
+
+            ref int indicesHead = ref MemoryMarshal.GetReference(indices);
+            ref int sizesHead = ref MemoryMarshal.GetReference(sizes);
+            int sum = 0;
+            for (int i = 0; i < length; i++)
+            {
+                int idx = Unsafe.Add(ref indicesHead, i);
+
+                int startOffset = _offsets.Get(idx);
+                int endOffset = _offsets.Get(idx + 1);
+                sum += endOffset - startOffset + sizeof(int);
+                Unsafe.Add(ref sizesHead, i) += sum;
+            }
         }
 
         public void InsertRangeFrom(int index, BinaryList binaryList, int start, int count)

--- a/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Utils/IntList.cs
@@ -13,6 +13,7 @@
 using FlowtideDotNet.Storage.Memory;
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
@@ -306,6 +307,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Utils
             AvxUtils.AddValueToElements(AccessSpan.Slice(index + 1, _length - index - 1), additionOnAbove);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Get(in int index)
         {
             return _data[index];

--- a/src/FlowtideDotNet.Storage/DataStructures/BitmapList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/BitmapList.cs
@@ -1380,6 +1380,17 @@ namespace FlowtideDotNet.Storage.DataStructures
             return (((end - start) + 31) / 32) * 4;
         }
 
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            int length = indices.Length;
+            ref int sizesHead = ref MemoryMarshal.GetReference(sizes);
+
+            for (int i = 0; i < length; i++)
+            {
+                Unsafe.Add(ref sizesHead, i) += ((i + 8) >> 3);
+            }
+        }
+
         public BitmapList Copy(IMemoryAllocator memoryAllocator)
         {
             var mem = MemorySlice;

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -15,6 +15,7 @@ using System.Buffers;
 using System.Collections;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace FlowtideDotNet.Storage.DataStructures
 {
@@ -458,6 +459,22 @@ namespace FlowtideDotNet.Storage.DataStructures
         public void SetLength(int newLength)
         {
             _length = newLength;
+        }
+
+        public void GetPrefixSumByteSizes(ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            int length = indices.Length;
+            int elementSize = sizeof(T);
+
+            ref int sizesHead = ref MemoryMarshal.GetReference(sizes);
+
+            int cumulativeMass = elementSize;
+
+            for (int i = 0; i < length; i++)
+            {
+                Unsafe.Add(ref sizesHead, i) += cumulativeMass;
+                cumulativeMass += elementSize;
+            }
         }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnPrefixSumByteSizesTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnPrefixSumByteSizesTests.cs
@@ -1,0 +1,594 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Storage.Memory;
+using Xunit;
+
+namespace FlowtideDotNet.Core.Tests.ColumnStore
+{
+    public class ColumnPrefixSumByteSizesTests
+    {
+        [Fact]
+        public void NullOnlyColumnDoesNotModifySizes()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+            column.Add(NullValue.Instance);
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.Equal(0, sizes[0]);
+            Assert.Equal(0, sizes[1]);
+            Assert.Equal(0, sizes[2]);
+        }
+
+        [Fact]
+        public void Int64ColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(10));
+            column.Add(new Int64Value(20));
+            column.Add(new Int64Value(30));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void Int64ColumnPrefixSumHasUniformSteps()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+            column.Add(new Int64Value(4));
+
+            var indices = new int[] { 0, 1, 2, 3 };
+            var sizes = new int[4];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            var step = sizes[1] - sizes[0];
+            for (int i = 2; i < sizes.Length; i++)
+            {
+                Assert.Equal(step, sizes[i] - sizes[i - 1]);
+            }
+        }
+
+        [Fact]
+        public void StringColumnPrefixSumGrowsByVariableAmounts()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new StringValue("a"));
+            column.Add(new StringValue("hello"));
+            column.Add(new StringValue("world!!!!"));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void BoolColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new BoolValue(true));
+            column.Add(new BoolValue(false));
+            column.Add(new BoolValue(true));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] >= sizes[0]);
+            Assert.True(sizes[2] >= sizes[1]);
+        }
+
+        [Fact]
+        public void DoubleColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new DoubleValue(1.5));
+            column.Add(new DoubleValue(2.5));
+            column.Add(new DoubleValue(3.5));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void DecimalColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new DecimalValue(1.23m));
+            column.Add(new DecimalValue(4.56m));
+            column.Add(new DecimalValue(7.89m));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void TimestampColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new TimestampTzValue(100L, 0));
+            column.Add(new TimestampTzValue(200L, 0));
+            column.Add(new TimestampTzValue(300L, 0));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void BinaryColumnPrefixSumGrowsByVariableAmounts()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new BinaryValue(new byte[] { 1 }));
+            column.Add(new BinaryValue(new byte[] { 2, 3, 4, 5 }));
+            column.Add(new BinaryValue(new byte[] { 6, 7 }));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void ListColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new ListValue(new IDataValue[] { new Int64Value(1), new Int64Value(2) }));
+            column.Add(new ListValue(new IDataValue[] { new Int64Value(3) }));
+            column.Add(new ListValue(new IDataValue[] { new Int64Value(4), new Int64Value(5), new Int64Value(6) }));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void MapColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new MapValue(
+                new List<KeyValuePair<IDataValue, IDataValue>>
+                {
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("k1"), new Int64Value(1))
+                }
+            ));
+            column.Add(new MapValue(
+                new List<KeyValuePair<IDataValue, IDataValue>>
+                {
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("k2"), new Int64Value(2)),
+                    new KeyValuePair<IDataValue, IDataValue>(new StringValue("k3"), new Int64Value(3))
+                }
+            ));
+
+            var indices = new int[] { 0, 1 };
+            var sizes = new int[2];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+        }
+
+        [Fact]
+        public void StructColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            var header = StructHeader.Create("name", "age");
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new StructValue(header, new IDataValue[] { new StringValue("Alice"), new Int64Value(30) }));
+            column.Add(new StructValue(header, new IDataValue[] { new StringValue("Bob"), new Int64Value(25) }));
+
+            var indices = new int[] { 0, 1 };
+            var sizes = new int[2];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+        }
+
+        [Fact]
+        public void UnionColumnPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new StringValue("hello"));
+            column.Add(new Int64Value(2));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void SingleElementColumnHasNonZeroSize()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(42));
+
+            var indices = new int[] { 0 };
+            var sizes = new int[1];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+        }
+
+        [Fact]
+        public void EmptyIndicesDoesNotModifySizes()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+
+            var indices = Array.Empty<int>();
+            var sizes = Array.Empty<int>();
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+        }
+
+        [Fact]
+        public void SubsetIndicesProducesCorrectPrefixSum()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+            column.Add(new Int64Value(4));
+            column.Add(new Int64Value(5));
+
+            var allIndices = new int[] { 0, 1, 2, 3, 4 };
+            var allSizes = new int[5];
+            column.GetPrefixSumByteSizes(allIndices, allSizes);
+
+            var subsetIndices = new int[] { 0, 2, 4 };
+            var subsetSizes = new int[3];
+            column.GetPrefixSumByteSizes(subsetIndices, subsetSizes);
+
+            Assert.True(subsetSizes[0] > 0);
+            Assert.True(subsetSizes[1] > subsetSizes[0]);
+            Assert.True(subsetSizes[2] > subsetSizes[1]);
+        }
+
+        [Fact]
+        public void PrefixSumAddsToExistingValues()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+
+            var indices = new int[] { 0, 1 };
+            var sizes = new int[] { 100, 200 };
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 100);
+            Assert.True(sizes[1] > 200);
+        }
+
+        [Fact]
+        public void Int64WithNullsPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(NullValue.Instance);
+            column.Add(new Int64Value(3));
+            column.Add(NullValue.Instance);
+
+            var indices = new int[] { 0, 1, 2, 3 };
+            var sizes = new int[4];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] >= sizes[0]);
+            Assert.True(sizes[2] >= sizes[1]);
+            Assert.True(sizes[3] >= sizes[2]);
+        }
+
+        [Fact]
+        public void StringWithNullsPrefixSumIsMonotonicallyIncreasing()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new StringValue("hello"));
+            column.Add(NullValue.Instance);
+            column.Add(new StringValue("world"));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] >= sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void LargeColumnPrefixSumNeverDecreases()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            for (int i = 0; i < 1000; i++)
+            {
+                column.Add(new Int64Value(i));
+            }
+
+            var indices = new int[1000];
+            for (int i = 0; i < 1000; i++)
+            {
+                indices[i] = i;
+            }
+            var sizes = new int[1000];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            for (int i = 1; i < 1000; i++)
+            {
+                Assert.True(sizes[i] > sizes[i - 1]);
+            }
+        }
+
+        [Fact]
+        public void LargeStringColumnPrefixSumNeverDecreases()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            for (int i = 0; i < 200; i++)
+            {
+                column.Add(new StringValue($"value_{i}"));
+            }
+
+            var indices = new int[200];
+            for (int i = 0; i < 200; i++)
+            {
+                indices[i] = i;
+            }
+            var sizes = new int[200];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            for (int i = 1; i < 200; i++)
+            {
+                Assert.True(sizes[i] > sizes[i - 1]);
+            }
+        }
+
+        [Fact]
+        public void MultipleColumnsAccumulateIntoSameSizesSpan()
+        {
+            using var col1 = new Column(GlobalMemoryManager.Instance);
+            col1.Add(new Int64Value(1));
+            col1.Add(new Int64Value(2));
+
+            using var col2 = new Column(GlobalMemoryManager.Instance);
+            col2.Add(new StringValue("hello"));
+            col2.Add(new StringValue("world"));
+
+            var indices = new int[] { 0, 1 };
+            var sizes = new int[2];
+
+            col1.GetPrefixSumByteSizes(indices, sizes);
+
+            var afterCol1 = new int[] { sizes[0], sizes[1] };
+
+            col2.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > afterCol1[0]);
+            Assert.True(sizes[1] > afterCol1[1]);
+        }
+
+        [Fact]
+        public void EmptyStringPrefixSumStillIncreases()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new StringValue(""));
+            column.Add(new StringValue(""));
+            column.Add(new StringValue(""));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void EmptyBinaryPrefixSumStillIncreases()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new BinaryValue(Array.Empty<byte>()));
+            column.Add(new BinaryValue(Array.Empty<byte>()));
+
+            var indices = new int[] { 0, 1 };
+            var sizes = new int[2];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+        }
+
+        [Fact]
+        public void EmptyListPrefixSumStillIncreases()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new ListValue(Array.Empty<IDataValue>()));
+            column.Add(new ListValue(Array.Empty<IDataValue>()));
+
+            var indices = new int[] { 0, 1 };
+            var sizes = new int[2];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+        }
+
+        [Fact]
+        public void PrefixSumGrowsProportionallyToElementCount()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(42));
+
+            var indices = new int[] { 0 };
+            var sizes = new int[1];
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+        }
+
+        [Fact]
+        public void PrefixSumLastElementIsLargerThanPrevious()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+            column.Add(new Int64Value(3));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[2] > sizes[1]);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[0] > 0);
+        }
+
+        [Fact]
+        public void CallingTwiceDoublesContribution()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new StringValue("a"));
+            column.Add(new StringValue("bb"));
+            column.Add(new StringValue("ccc"));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            var firstPass = new int[] { sizes[0], sizes[1], sizes[2] };
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.Equal(firstPass[0] * 2, sizes[0]);
+            Assert.Equal(firstPass[1] * 2, sizes[1]);
+            Assert.Equal(firstPass[2] * 2, sizes[2]);
+        }
+
+        [Fact]
+        public void AlwaysNullColumnDoesNotModifySizes()
+        {
+            var column = AlwaysNullColumn.Instance;
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.Equal(0, sizes[0]);
+            Assert.Equal(0, sizes[1]);
+            Assert.Equal(0, sizes[2]);
+        }
+
+        [Fact]
+        public void StructWithMixedChildTypesPrefixSumIsMonotonicallyIncreasing()
+        {
+            var header = StructHeader.Create("id", "name", "score");
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new StructValue(header, new IDataValue[] { new Int64Value(1), new StringValue("Alice"), new DoubleValue(95.5) }));
+            column.Add(new StructValue(header, new IDataValue[] { new Int64Value(2), new StringValue("Bob"), new DoubleValue(87.3) }));
+            column.Add(new StructValue(header, new IDataValue[] { new Int64Value(3), new StringValue("Charlie"), new DoubleValue(92.1) }));
+
+            var indices = new int[] { 0, 1, 2 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+
+        [Fact]
+        public void RepeatedIndicesProducesIncreasingPrefixSum()
+        {
+            using var column = new Column(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(1));
+            column.Add(new Int64Value(2));
+
+            var indices = new int[] { 0, 0, 0 };
+            var sizes = new int[3];
+
+            column.GetPrefixSumByteSizes(indices, sizes);
+
+            Assert.True(sizes[0] > 0);
+            Assert.True(sizes[1] > sizes[0]);
+            Assert.True(sizes[2] > sizes[1]);
+        }
+    }
+}


### PR DESCRIPTION
This allows sending in a list of indices and get a prefix sum of the byte sizes, this will be used to do better splits in the B+ tree to find split points before merging data into the leaf.