### PR TITLE
Add support for expression clone

### DIFF
--- a/src/FlowtideDotNet.Substrait/Expressions/CastExpression.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/CastExpression.cs
@@ -25,6 +25,15 @@ namespace FlowtideDotNet.Substrait.Expressions
             return visitor.VisitCastExpression(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new CastExpression
+            {
+                Expression = Expression.Clone(),
+                Type = Type
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is CastExpression expression &&

--- a/src/FlowtideDotNet.Substrait/Expressions/DirectFieldReference.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/DirectFieldReference.cs
@@ -22,6 +22,14 @@ namespace FlowtideDotNet.Substrait.Expressions
             return visitor.VisitDirectFieldReference(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new DirectFieldReference()
+            {
+                ReferenceSegment = ReferenceSegment.Clone()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is DirectFieldReference reference &&

--- a/src/FlowtideDotNet.Substrait/Expressions/Expression.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/Expression.cs
@@ -16,5 +16,7 @@ namespace FlowtideDotNet.Substrait.Expressions
     {
 
         public abstract TOutput Accept<TOutput, TState>(ExpressionVisitor<TOutput, TState> visitor, TState state);
+
+        public abstract Expression Clone();
     }
 }

--- a/src/FlowtideDotNet.Substrait/Expressions/IfThen/IfClause.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/IfThen/IfClause.cs
@@ -49,5 +49,14 @@ namespace FlowtideDotNet.Substrait.Expressions.IfThen
         {
             return !(left == right);
         }
+
+        public IfClause Clone()
+        {
+            return new IfClause
+            {
+                If = If.Clone(),
+                Then = Then.Clone()
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Substrait/Expressions/IfThen/IfThenExpression.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/IfThen/IfThenExpression.cs
@@ -30,6 +30,15 @@ namespace FlowtideDotNet.Substrait.Expressions.IfThen
             return visitor.VisitIfThen(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new IfThenExpression
+            {
+                Ifs = Ifs.Select(ifClause => ifClause.Clone()).ToList(),
+                Else = Else?.Clone()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is IfThenExpression expression &&

--- a/src/FlowtideDotNet.Substrait/Expressions/ListNestedExpression.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/ListNestedExpression.cs
@@ -21,6 +21,14 @@ namespace FlowtideDotNet.Substrait.Expressions
             return visitor.VisitListNestedExpression(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new ListNestedExpression
+            {
+                Values = Values.Select(v => v.Clone()).ToList()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is ListNestedExpression expression &&

--- a/src/FlowtideDotNet.Substrait/Expressions/Literals/ArrayLiteral.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/Literals/ArrayLiteral.cs
@@ -23,6 +23,14 @@ namespace FlowtideDotNet.Substrait.Expressions.Literals
             return visitor.VisitArrayLiteral(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new ArrayLiteral
+            {
+                Expressions = Expressions.Select(expr => expr.Clone()).ToList()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is ArrayLiteral literal &&

--- a/src/FlowtideDotNet.Substrait/Expressions/Literals/BinaryLiteral.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/Literals/BinaryLiteral.cs
@@ -22,6 +22,14 @@ namespace FlowtideDotNet.Substrait.Expressions.Literals
             return visitor.VisitBinaryLiteral(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new BinaryLiteral
+            {
+                Value = (byte[])Value.Clone()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is BinaryLiteral literal &&

--- a/src/FlowtideDotNet.Substrait/Expressions/Literals/BoolLiteral.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/Literals/BoolLiteral.cs
@@ -24,6 +24,14 @@ namespace FlowtideDotNet.Substrait.Expressions.Literals
             return visitor.VisitBoolLiteral(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new BoolLiteral
+            {
+                Value = this.Value
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is BoolLiteral literal &&

--- a/src/FlowtideDotNet.Substrait/Expressions/Literals/NullLiteral.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/Literals/NullLiteral.cs
@@ -22,6 +22,11 @@ namespace FlowtideDotNet.Substrait.Expressions.Literals
             return visitor.VisitNullLiteral(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new NullLiteral();
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is NullLiteral;

--- a/src/FlowtideDotNet.Substrait/Expressions/Literals/NumericLiteral.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/Literals/NumericLiteral.cs
@@ -23,6 +23,14 @@ namespace FlowtideDotNet.Substrait.Expressions.Literals
             return visitor.VisitNumericLiteral(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new NumericLiteral
+            {
+                Value = Value
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is NumericLiteral literal &&

--- a/src/FlowtideDotNet.Substrait/Expressions/Literals/StringLiteral.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/Literals/StringLiteral.cs
@@ -24,6 +24,14 @@ namespace FlowtideDotNet.Substrait.Expressions.Literals
             return visitor.VisitStringLiteral(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new StringLiteral
+            {
+                Value = Value
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is StringLiteral literal &&

--- a/src/FlowtideDotNet.Substrait/Expressions/MapKeyReferenceSegment.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/MapKeyReferenceSegment.cs
@@ -20,7 +20,7 @@ namespace FlowtideDotNet.Substrait.Expressions
         {
             return new MapKeyReferenceSegment
             {
-                Child = Child,
+                Child = Child?.Clone(),
                 Key = Key
             };
         }

--- a/src/FlowtideDotNet.Substrait/Expressions/MapKeyReferenceSegment.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/MapKeyReferenceSegment.cs
@@ -16,6 +16,15 @@ namespace FlowtideDotNet.Substrait.Expressions
     {
         public required string Key { get; set; }
 
+        public override ReferenceSegment Clone()
+        {
+            return new MapKeyReferenceSegment
+            {
+                Child = Child,
+                Key = Key
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is MapKeyReferenceSegment segment &&

--- a/src/FlowtideDotNet.Substrait/Expressions/MapNestedExpression.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/MapNestedExpression.cs
@@ -22,6 +22,14 @@ namespace FlowtideDotNet.Substrait.Expressions
             return visitor.VisitMapNestedExpression(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new MapNestedExpression
+            {
+                KeyValues = KeyValues.Select(kv => new KeyValuePair<Expression, Expression>(kv.Key.Clone(), kv.Value.Clone())).ToList()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is MapNestedExpression expression &&

--- a/src/FlowtideDotNet.Substrait/Expressions/OrList/MultiOrListExpression.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/OrList/MultiOrListExpression.cs
@@ -23,6 +23,15 @@ namespace FlowtideDotNet.Substrait.Expressions
             throw new NotImplementedException();
         }
 
+        public override Expression Clone()
+        {
+            return new MultiOrListExpression
+            {
+                Value = Value.Select(v => v.Clone()).ToList(),
+                Options = Options.Select(o => o.Clone()).ToList()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is MultiOrListExpression expression &&

--- a/src/FlowtideDotNet.Substrait/Expressions/OrList/OrListRecord.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/OrList/OrListRecord.cs
@@ -53,5 +53,13 @@ namespace FlowtideDotNet.Substrait.Expressions
         {
             return !(left == right);
         }
+
+        public OrListRecord Clone()
+        {
+            return new OrListRecord
+            {
+                Fields = Fields.Select(f => f.Clone()).ToList()
+            };
+        }
     }
 }

--- a/src/FlowtideDotNet.Substrait/Expressions/OrList/SingularOrListExpression.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/OrList/SingularOrListExpression.cs
@@ -24,6 +24,15 @@ namespace FlowtideDotNet.Substrait.Expressions
             return visitor.VisitSingularOrList(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new SingularOrListExpression
+            {
+                Value = Value.Clone(),
+                Options = Options.Select(option => option.Clone()).ToList()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is SingularOrListExpression expression &&

--- a/src/FlowtideDotNet.Substrait/Expressions/ReferenceSegment.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/ReferenceSegment.cs
@@ -42,5 +42,7 @@ namespace FlowtideDotNet.Substrait.Expressions
         {
             return !(left == right);
         }
+
+        public abstract ReferenceSegment Clone();
     }
 }

--- a/src/FlowtideDotNet.Substrait/Expressions/ScalarFunction.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/ScalarFunction.cs
@@ -27,6 +27,17 @@ namespace FlowtideDotNet.Substrait.Expressions
             return visitor.VisitScalarFunction(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new ScalarFunction
+            {
+                ExtensionUri = ExtensionUri,
+                ExtensionName = ExtensionName,
+                Arguments = Arguments.Select(arg => arg.Clone()).ToList(),
+                Options = Options != null ? new SortedList<string, string>(Options) : null
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is ScalarFunction function &&

--- a/src/FlowtideDotNet.Substrait/Expressions/StructExpression.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/StructExpression.cs
@@ -21,6 +21,14 @@ namespace FlowtideDotNet.Substrait.Expressions
             return visitor.VisitStructExpression(this, state)!;
         }
 
+        public override Expression Clone()
+        {
+            return new StructExpression
+            {
+                Fields = Fields.Select(f => f.Clone()).ToList()
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is StructExpression expression &&

--- a/src/FlowtideDotNet.Substrait/Expressions/StructReferenceSegment.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/StructReferenceSegment.cs
@@ -17,6 +17,15 @@ namespace FlowtideDotNet.Substrait.Expressions
     {
         public int Field { get; set; }
 
+        public override ReferenceSegment Clone()
+        {
+            return new StructReferenceSegment()
+            {
+                Child = Child,
+                Field = Field
+            };
+        }
+
         public override bool Equals(object? obj)
         {
             return obj is StructReferenceSegment segment &&

--- a/src/FlowtideDotNet.Substrait/Expressions/StructReferenceSegment.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/StructReferenceSegment.cs
@@ -21,7 +21,7 @@ namespace FlowtideDotNet.Substrait.Expressions
         {
             return new StructReferenceSegment()
             {
-                Child = Child,
+                Child = Child?.Clone(),
                 Field = Field
             };
         }

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/CastExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/CastExpressionClone.cs
@@ -1,0 +1,54 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+using FlowtideDotNet.Substrait.Type;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class CastExpressionClone
+    {
+        private CastExpression root;
+
+        public CastExpressionClone()
+        {
+            root = new CastExpression()
+            {
+                Expression = new StringLiteral { Value = "hello" },
+                Type = new Fp32Type()
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (CastExpression)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneExpressionIsIndependent()
+        {
+            var clone = (CastExpression)root.Clone();
+            clone.Expression = new StringLiteral { Value = "other" };
+            Assert.NotEqual(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/CastExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/CastExpressionClone.cs
@@ -18,7 +18,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class CastExpressionClone
     {
-        private CastExpression root;
+        private readonly CastExpression root;
 
         public CastExpressionClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/DirectFieldReferenceClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/DirectFieldReferenceClone.cs
@@ -1,0 +1,54 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class DirectFieldReferenceClone
+    {
+        private DirectFieldReference root;
+
+        public DirectFieldReferenceClone()
+        {
+            root = new DirectFieldReference()
+            {
+                ReferenceSegment = new StructReferenceSegment()
+                {
+                    Field = 3
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (DirectFieldReference)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneReferenceSegmentIsIndependent()
+        {
+            var clone = (DirectFieldReference)root.Clone();
+            clone.ReferenceSegment = new StructReferenceSegment() { Field = 99 };
+            Assert.NotEqual(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/DirectFieldReferenceClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/DirectFieldReferenceClone.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class DirectFieldReferenceClone
     {
-        private DirectFieldReference root;
+        private readonly DirectFieldReference root;
 
         public DirectFieldReferenceClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/IfClauseClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/IfClauseClone.cs
@@ -1,0 +1,62 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.IfThen;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class IfClauseClone
+    {
+        private IfClause root;
+
+        public IfClauseClone()
+        {
+            root = new IfClause()
+            {
+                If = new BoolLiteral { Value = true },
+                Then = new StringLiteral { Value = "yes" }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneIfIsIndependent()
+        {
+            var clone = root.Clone();
+            clone.If = new BoolLiteral { Value = false };
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void CloneThenIsIndependent()
+        {
+            var clone = root.Clone();
+            clone.Then = new StringLiteral { Value = "no" };
+            Assert.NotEqual(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/IfClauseClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/IfClauseClone.cs
@@ -18,7 +18,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class IfClauseClone
     {
-        private IfClause root;
+        private readonly IfClause root;
 
         public IfClauseClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/IfThenExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/IfThenExpressionClone.cs
@@ -1,0 +1,81 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.IfThen;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class IfThenExpressionClone
+    {
+        private IfThenExpression root;
+
+        public IfThenExpressionClone()
+        {
+            root = new IfThenExpression()
+            {
+                Ifs = new List<IfClause>
+                {
+                    new IfClause()
+                    {
+                        If = new BoolLiteral { Value = true },
+                        Then = new StringLiteral { Value = "yes" }
+                    }
+                },
+                Else = new StringLiteral { Value = "no" }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (IfThenExpression)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneIfsListIsIndependent()
+        {
+            var clone = (IfThenExpression)root.Clone();
+            clone.Ifs.Add(new IfClause()
+            {
+                If = new BoolLiteral { Value = false },
+                Then = new StringLiteral { Value = "extra" }
+            });
+            Assert.NotEqual(root.Ifs.Count, clone.Ifs.Count);
+        }
+
+        [Fact]
+        public void CloneElseIsIndependent()
+        {
+            var clone = (IfThenExpression)root.Clone();
+            clone.Else = new StringLiteral { Value = "different" };
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void CloneWithNullElseIsEqualToOriginal()
+        {
+            root.Else = null;
+            var clone = (IfThenExpression)root.Clone();
+            Assert.Equal(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/IfThenExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/IfThenExpressionClone.cs
@@ -18,7 +18,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class IfThenExpressionClone
     {
-        private IfThenExpression root;
+        private readonly IfThenExpression root;
 
         public IfThenExpressionClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/ListNestedExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/ListNestedExpressionClone.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class ListNestedExpressionClone
     {
-        private ListNestedExpression root;
+        private readonly ListNestedExpression root;
 
         public ListNestedExpressionClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/ListNestedExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/ListNestedExpressionClone.cs
@@ -1,0 +1,56 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class ListNestedExpressionClone
+    {
+        private ListNestedExpression root;
+
+        public ListNestedExpressionClone()
+        {
+            root = new ListNestedExpression()
+            {
+                Values = new List<Expression>
+                {
+                    new StringLiteral { Value = "a" },
+                    new NumericLiteral { Value = 1 }
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (ListNestedExpression)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneValuesListIsIndependent()
+        {
+            var clone = (ListNestedExpression)root.Clone();
+            clone.Values.Add(new StringLiteral { Value = "extra" });
+            Assert.NotEqual(root.Values.Count, clone.Values.Count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MapKeyReferenceSegmentClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MapKeyReferenceSegmentClone.cs
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class MapKeyReferenceSegmentClone
+    {
+        private MapKeyReferenceSegment root;
+
+        public MapKeyReferenceSegmentClone()
+        {
+            root = new MapKeyReferenceSegment()
+            {
+                Key = "myKey",
+                Child = new StructReferenceSegment()
+                {
+                    Field = 1
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (MapKeyReferenceSegment)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneKeyIsIndependent()
+        {
+            var clone = (MapKeyReferenceSegment)root.Clone();
+            clone.Key = "otherKey";
+            Assert.NotEqual(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MapKeyReferenceSegmentClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MapKeyReferenceSegmentClone.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class MapKeyReferenceSegmentClone
     {
-        private MapKeyReferenceSegment root;
+        private readonly MapKeyReferenceSegment root;
 
         public MapKeyReferenceSegmentClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MapNestedExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MapNestedExpressionClone.cs
@@ -1,0 +1,61 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class MapNestedExpressionClone
+    {
+        private MapNestedExpression root;
+
+        public MapNestedExpressionClone()
+        {
+            root = new MapNestedExpression()
+            {
+                KeyValues = new List<KeyValuePair<Expression, Expression>>
+                {
+                    new KeyValuePair<Expression, Expression>(
+                        new StringLiteral { Value = "key1" },
+                        new NumericLiteral { Value = 10 }
+                    )
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (MapNestedExpression)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneKeyValuesListIsIndependent()
+        {
+            var clone = (MapNestedExpression)root.Clone();
+            clone.KeyValues.Add(new KeyValuePair<Expression, Expression>(
+                new StringLiteral { Value = "key2" },
+                new NumericLiteral { Value = 20 }
+            ));
+            Assert.NotEqual(root.KeyValues.Count, clone.KeyValues.Count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MapNestedExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MapNestedExpressionClone.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class MapNestedExpressionClone
     {
-        private MapNestedExpression root;
+        private readonly MapNestedExpression root;
 
         public MapNestedExpressionClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MultiOrListExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MultiOrListExpressionClone.cs
@@ -1,0 +1,79 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class MultiOrListExpressionClone
+    {
+        private MultiOrListExpression root;
+
+        public MultiOrListExpressionClone()
+        {
+            root = new MultiOrListExpression()
+            {
+                Value = new List<Expression>
+                {
+                    new DirectFieldReference()
+                    {
+                        ReferenceSegment = new StructReferenceSegment() { Field = 0 }
+                    }
+                },
+                Options = new List<OrListRecord>
+                {
+                    new OrListRecord()
+                    {
+                        Fields = new List<Expression>
+                        {
+                            new NumericLiteral { Value = 1 }
+                        }
+                    }
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (MultiOrListExpression)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneValueListIsIndependent()
+        {
+            var clone = (MultiOrListExpression)root.Clone();
+            clone.Value.Add(new NumericLiteral { Value = 99 });
+            Assert.NotEqual(root.Value.Count, clone.Value.Count);
+        }
+
+        [Fact]
+        public void CloneOptionsListIsIndependent()
+        {
+            var clone = (MultiOrListExpression)root.Clone();
+            clone.Options.Add(new OrListRecord()
+            {
+                Fields = new List<Expression> { new NumericLiteral { Value = 2 } }
+            });
+            Assert.NotEqual(root.Options.Count, clone.Options.Count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MultiOrListExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/MultiOrListExpressionClone.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class MultiOrListExpressionClone
     {
-        private MultiOrListExpression root;
+        private readonly MultiOrListExpression root;
 
         public MultiOrListExpressionClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/OrListRecordClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/OrListRecordClone.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class OrListRecordClone
     {
-        private OrListRecord root;
+        private readonly OrListRecord root;
 
         public OrListRecordClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/OrListRecordClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/OrListRecordClone.cs
@@ -1,0 +1,56 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class OrListRecordClone
+    {
+        private OrListRecord root;
+
+        public OrListRecordClone()
+        {
+            root = new OrListRecord()
+            {
+                Fields = new List<Expression>
+                {
+                    new StringLiteral { Value = "a" },
+                    new NumericLiteral { Value = 1 }
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneFieldsListIsIndependent()
+        {
+            var clone = root.Clone();
+            clone.Fields.Add(new StringLiteral { Value = "extra" });
+            Assert.NotEqual(root.Fields.Count, clone.Fields.Count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/ScalarFunctionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/ScalarFunctionClone.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class ScalarFunctionClone
     {
-        private ScalarFunction root;
+        private readonly ScalarFunction root;
 
         public ScalarFunctionClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/ScalarFunctionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/ScalarFunctionClone.cs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class ScalarFunctionClone
+    {
+        private ScalarFunction root;
+
+        public ScalarFunctionClone()
+        {
+            root = new ScalarFunction()
+            {
+                ExtensionUri = "http://example.com",
+                ExtensionName = "myFunc",
+                Arguments = new List<Expression>
+                {
+                    new StringLiteral { Value = "arg1" },
+                    new NumericLiteral { Value = 42 }
+                },
+                Options = new SortedList<string, string> { { "key", "value" } }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (ScalarFunction)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneArgumentsListIsIndependent()
+        {
+            var clone = (ScalarFunction)root.Clone();
+            clone.Arguments.Add(new StringLiteral { Value = "extra" });
+            Assert.NotEqual(root.Arguments.Count, clone.Arguments.Count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/SingularOrListExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/SingularOrListExpressionClone.cs
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class SingularOrListExpressionClone
+    {
+        private SingularOrListExpression root;
+
+        public SingularOrListExpressionClone()
+        {
+            root = new SingularOrListExpression()
+            {
+                Value = new DirectFieldReference()
+                {
+                    ReferenceSegment = new StructReferenceSegment() { Field = 0 }
+                },
+                Options = new List<Expression>
+                {
+                    new NumericLiteral { Value = 1 },
+                    new NumericLiteral { Value = 2 }
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (SingularOrListExpression)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneOptionsListIsIndependent()
+        {
+            var clone = (SingularOrListExpression)root.Clone();
+            clone.Options.Add(new NumericLiteral { Value = 99 });
+            Assert.NotEqual(root.Options.Count, clone.Options.Count);
+        }
+
+        [Fact]
+        public void CloneValueIsIndependent()
+        {
+            var clone = (SingularOrListExpression)root.Clone();
+            clone.Value = new NumericLiteral { Value = 0 };
+            Assert.NotEqual(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/SingularOrListExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/SingularOrListExpressionClone.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class SingularOrListExpressionClone
     {
-        private SingularOrListExpression root;
+        private readonly SingularOrListExpression root;
 
         public SingularOrListExpressionClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/StructExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/StructExpressionClone.cs
@@ -1,0 +1,56 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class StructExpressionClone
+    {
+        private StructExpression root;
+
+        public StructExpressionClone()
+        {
+            root = new StructExpression()
+            {
+                Fields = new List<Expression>
+                {
+                    new StringLiteral { Value = "field1" },
+                    new NumericLiteral { Value = 2 }
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (StructExpression)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneFieldsListIsIndependent()
+        {
+            var clone = (StructExpression)root.Clone();
+            clone.Fields.Add(new StringLiteral { Value = "extra" });
+            Assert.NotEqual(root.Fields.Count, clone.Fields.Count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/StructExpressionClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/StructExpressionClone.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class StructExpressionClone
     {
-        private StructExpression root;
+        private readonly StructExpression root;
 
         public StructExpressionClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/StructReferenceSegmentClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/StructReferenceSegmentClone.cs
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
+{
+    public class StructReferenceSegmentClone
+    {
+        private StructReferenceSegment root;
+
+        public StructReferenceSegmentClone()
+        {
+            root = new StructReferenceSegment()
+            {
+                Child = new StructReferenceSegment()
+                {
+                    Field = 1
+                },
+                Field = 2
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (StructReferenceSegment)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneFieldIsIndependent()
+        {
+            var clone = (StructReferenceSegment)root.Clone();
+            clone.Field = 99;
+            Assert.NotEqual(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/StructReferenceSegmentClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/ExpressionClone/StructReferenceSegmentClone.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.ExpressionClone
 {
     public class StructReferenceSegmentClone
     {
-        private StructReferenceSegment root;
+        private readonly StructReferenceSegment root;
 
         public StructReferenceSegmentClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/ArrayLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/ArrayLiteralClone.cs
@@ -1,0 +1,56 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
+{
+    public class ArrayLiteralClone
+    {
+        private ArrayLiteral root;
+
+        public ArrayLiteralClone()
+        {
+            root = new ArrayLiteral()
+            {
+                Expressions = new List<Expression>
+                {
+                    new StringLiteral { Value = "a" },
+                    new NumericLiteral { Value = 1 }
+                }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (ArrayLiteral)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneExpressionsListIsIndependent()
+        {
+            var clone = (ArrayLiteral)root.Clone();
+            clone.Expressions.Add(new StringLiteral { Value = "extra" });
+            Assert.NotEqual(root.Expressions.Count, clone.Expressions.Count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/ArrayLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/ArrayLiteralClone.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
 {
     public class ArrayLiteralClone
     {
-        private ArrayLiteral root;
+        private readonly ArrayLiteral root;
 
         public ArrayLiteralClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/BinaryLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/BinaryLiteralClone.cs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
+{
+    public class BinaryLiteralClone
+    {
+        private BinaryLiteral root;
+
+        public BinaryLiteralClone()
+        {
+            root = new BinaryLiteral()
+            {
+                Value = new byte[] { 1, 2, 3 }
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (BinaryLiteral)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneByteArrayIsIndependent()
+        {
+            var clone = (BinaryLiteral)root.Clone();
+            clone.Value[0] = 99;
+            Assert.NotEqual(root.Value[0], clone.Value[0]);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/BinaryLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/BinaryLiteralClone.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
 {
     public class BinaryLiteralClone
     {
-        private BinaryLiteral root;
+        private readonly BinaryLiteral root;
 
         public BinaryLiteralClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/BoolLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/BoolLiteralClone.cs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
+{
+    public class BoolLiteralClone
+    {
+        private BoolLiteral root;
+
+        public BoolLiteralClone()
+        {
+            root = new BoolLiteral()
+            {
+                Value = true
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (BoolLiteral)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneValueIsIndependent()
+        {
+            var clone = (BoolLiteral)root.Clone();
+            clone.Value = false;
+            Assert.NotEqual(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/BoolLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/BoolLiteralClone.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
 {
     public class BoolLiteralClone
     {
-        private BoolLiteral root;
+        private readonly BoolLiteral root;
 
         public BoolLiteralClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/NullLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/NullLiteralClone.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
 {
     public class NullLiteralClone
     {
-        private NullLiteral root;
+        private readonly NullLiteral root;
 
         public NullLiteralClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/NullLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/NullLiteralClone.cs
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
+{
+    public class NullLiteralClone
+    {
+        private NullLiteral root;
+
+        public NullLiteralClone()
+        {
+            root = new NullLiteral();
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (NullLiteral)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/NumericLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/NumericLiteralClone.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
 {
     public class NumericLiteralClone
     {
-        private NumericLiteral root;
+        private readonly NumericLiteral root;
 
         public NumericLiteralClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/NumericLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/NumericLiteralClone.cs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
+{
+    public class NumericLiteralClone
+    {
+        private NumericLiteral root;
+
+        public NumericLiteralClone()
+        {
+            root = new NumericLiteral()
+            {
+                Value = 42
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (NumericLiteral)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneValueIsIndependent()
+        {
+            var clone = (NumericLiteral)root.Clone();
+            clone.Value = 99;
+            Assert.NotEqual(root, clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/StringLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/StringLiteralClone.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
 {
     public class StringLiteralClone
     {
-        private StringLiteral root;
+        private readonly StringLiteral root;
 
         public StringLiteralClone()
         {

--- a/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/StringLiteralClone.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/CloneTests/LiteralClone/StringLiteralClone.cs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.CloneTests.LiteralClone
+{
+    public class StringLiteralClone
+    {
+        private StringLiteral root;
+
+        public StringLiteralClone()
+        {
+            root = new StringLiteral()
+            {
+                Value = "hello"
+            };
+        }
+
+        [Fact]
+        public void CloneIsEqualToOriginal()
+        {
+            var clone = (StringLiteral)root.Clone();
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void CloneIsNotSameReference()
+        {
+            var clone = root.Clone();
+            Assert.False(ReferenceEquals(root, clone));
+        }
+
+        [Fact]
+        public void CloneValueIsIndependent()
+        {
+            var clone = (StringLiteral)root.Clone();
+            clone.Value = "world";
+            Assert.NotEqual(root, clone);
+        }
+    }
+}


### PR DESCRIPTION
There is a point of allowing operators to modify column order inside of its computation, and it needs to update expression field references because of it. This allows a localized copy to be created before applying any mutation to the expression.