### PR TITLE
Change merge join to not depend on column order inside hot paths

### DIFF
--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -18,6 +18,7 @@ using FlowtideDotNet.Core.ColumnStore.Sort;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Core.Compute.Columnar;
+using FlowtideDotNet.Core.Optimizer.EmitPushdown;
 using FlowtideDotNet.Core.Utils;
 using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.StateManager;
@@ -107,6 +108,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             _leftSortColumns = new IColumn[_leftInsertComparer.ColumnOrder.Count];
             _rightSortColumns = new IColumn[_rightInsertComparer.ColumnOrder.Count];
 
+            var leftColumnOrder = BuildColumnOrder(leftColumns, mergeJoinRelation.Left.OutputLength);
+            var rightColumnOrder = BuildColumnOrder(rightColumns, mergeJoinRelation.Right.OutputLength);
+
             (_leftOutputColumns, _leftOutputIndices) = GetOutputColumns(mergeJoinRelation, 0, mergeJoinRelation.Left.OutputLength);
             (_rightOutputColumns, _rightOutputIndices) = GetOutputColumns(mergeJoinRelation, mergeJoinRelation.Left.OutputLength, mergeJoinRelation.Right.OutputLength);
 
@@ -114,6 +118,61 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             {
                 _postCondition = ColumnBooleanCompiler.CompileTwoInputs(mergeJoinRelation.PostJoinFilter, functionsRegister, mergeJoinRelation.Left.OutputLength);
             }
+        }
+
+        /// <summary>
+        /// Remaps the field references in the specified filter expression according to the provided left and right
+        /// column order mappings.
+        /// </summary>
+        /// <remarks>Use this method when the column order of the underlying data has changed and filter
+        /// expressions need to be updated to match the new schema. The method does not modify the original filter
+        /// expression.</remarks>
+        /// <param name="filter">The filter expression whose field references are to be remapped.</param>
+        /// <param name="leftColumnOrder">A list of column identifiers representing the original order of the left-side columns. Used to map old field
+        /// references to their new positions.</param>
+        /// <param name="rightColumnOrder">A list of column identifiers representing the original order of the right-side columns. Used to map old
+        /// field references to their new positions, offset by the count of left-side columns.</param>
+        /// <returns>A new expression with field references remapped to reflect the specified column orderings.</returns>
+        private Expression RemapFilter(Expression filter, List<int> leftColumnOrder, List<int> rightColumnOrder)
+        {
+            Dictionary<int, int> oldToNew = new Dictionary<int, int>();
+
+            for (int i = 0; i < leftColumnOrder.Count; i++)
+            {
+                var oldId = leftColumnOrder[i];
+                oldToNew[oldId] = i;
+            }
+
+            for (int i = 0; i < rightColumnOrder.Count; i++)
+            {
+                var oldId = rightColumnOrder[i] + leftColumnOrder.Count;
+                oldToNew[oldId] = i + leftColumnOrder.Count;
+            }
+
+            var clone = filter.Clone();
+            var visitor = new ExpressionFieldReplaceVisitor(oldToNew);
+            visitor.Visit(clone, default);
+            return clone;
+        }
+
+        private List<int> BuildColumnOrder(List<int> comparisonColumns, int columnCount)
+        {
+            var output = new List<int>();
+            // Add the comparison columns first
+            for (int i = 0; i < comparisonColumns.Count; i++)
+            {
+                output.Add(comparisonColumns[i]);
+            }
+
+            // Add the missing columns in the order they appear in the data
+            for (int i = 0; i < columnCount; i++)
+            {
+                if (!output.Contains(i))
+                {
+                    output.Add(i);
+                }
+            }
+            return output;
         }
 
         private static (List<int> incomingIndices, List<int> outgoingIndex) GetOutputColumns(MergeJoinRelation mergeJoinRelation, int relative, int maxSize)

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -76,6 +76,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         private readonly List<int> _leftOutputIndices;
         private readonly List<int> _rightOutputIndices;
 
+        private readonly List<int> _leftColumnOrder;
+        private readonly List<int> _rightColumnOrder;
+
         // Metrics
         private ICounter<long>? _eventsCounter;
         private ICounter<long>? _eventsProcessed;
@@ -97,26 +100,36 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             _dataValueContainer = new DataValueContainer();
             var leftColumns = GetCompareColumns(mergeJoinRelation.LeftKeys, 0);
             var rightColumns = GetCompareColumns(mergeJoinRelation.RightKeys, mergeJoinRelation.Left.OutputLength);
-            _leftInsertComparer = new MergeJoinInsertComparer(leftColumns, mergeJoinRelation.Left.OutputLength);
-            _rightInsertComparer = new MergeJoinInsertComparer(rightColumns, mergeJoinRelation.Right.OutputLength);
+            _leftColumnOrder = BuildColumnOrder(leftColumns, mergeJoinRelation.Left.OutputLength);
+            _rightColumnOrder = BuildColumnOrder(rightColumns, mergeJoinRelation.Right.OutputLength);
 
-            _searchLeftComparer = new MergeJoinSearchComparer(leftColumns, rightColumns);
-            _searchRightComparer = new MergeJoinSearchComparer(rightColumns, leftColumns);
+            _leftInsertComparer = new MergeJoinInsertComparer(mergeJoinRelation.Left.OutputLength);
+            _rightInsertComparer = new MergeJoinInsertComparer(mergeJoinRelation.Right.OutputLength);
 
-            _leftBatchSorter = new BatchSorter(_leftInsertComparer.ColumnOrder.Count);
-            _rightBatchSorter = new BatchSorter(_rightInsertComparer.ColumnOrder.Count);
-            _leftSortColumns = new IColumn[_leftInsertComparer.ColumnOrder.Count];
-            _rightSortColumns = new IColumn[_rightInsertComparer.ColumnOrder.Count];
+            _searchLeftComparer = new MergeJoinSearchComparer(leftColumns.Count);
+            _searchRightComparer = new MergeJoinSearchComparer(rightColumns.Count);
 
-            var leftColumnOrder = BuildColumnOrder(leftColumns, mergeJoinRelation.Left.OutputLength);
-            var rightColumnOrder = BuildColumnOrder(rightColumns, mergeJoinRelation.Right.OutputLength);
+            _leftBatchSorter = new BatchSorter(_leftColumnOrder.Count);
+            _rightBatchSorter = new BatchSorter(_rightColumnOrder.Count);
+            _leftSortColumns = new IColumn[_leftColumnOrder.Count];
+            _rightSortColumns = new IColumn[_rightColumnOrder.Count];
 
             (_leftOutputColumns, _leftOutputIndices) = GetOutputColumns(mergeJoinRelation, 0, mergeJoinRelation.Left.OutputLength);
             (_rightOutputColumns, _rightOutputIndices) = GetOutputColumns(mergeJoinRelation, mergeJoinRelation.Left.OutputLength, mergeJoinRelation.Right.OutputLength);
 
+            for (int i = 0; i < _leftOutputColumns.Count; i++)
+            {
+                _leftOutputColumns[i] = _leftColumnOrder.IndexOf(_leftOutputColumns[i]);
+            }
+            for (int i = 0; i < _rightOutputColumns.Count; i++)
+            {
+                _rightOutputColumns[i] = _rightColumnOrder.IndexOf(_rightOutputColumns[i]);
+            }
+
             if (mergeJoinRelation.PostJoinFilter != null)
             {
-                _postCondition = ColumnBooleanCompiler.CompileTwoInputs(mergeJoinRelation.PostJoinFilter, functionsRegister, mergeJoinRelation.Left.OutputLength);
+                var remappedFilter = RemapFilter(mergeJoinRelation.PostJoinFilter, _leftColumnOrder, _rightColumnOrder);
+                _postCondition = ColumnBooleanCompiler.CompileTwoInputs(remappedFilter, functionsRegister, mergeJoinRelation.Left.OutputLength);
             }
         }
 
@@ -308,6 +321,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             }
 
             
+            var sortedIndices = SortBatch(msg.Data.EventBatchData, keyLength, _leftColumnOrder, _leftBatchSorter, _leftSortColumns, out var reorderedBatch);
+
             ColumnRowReference[] keys = new ColumnRowReference[keyLength];
             JoinWeights[] insertValues = new JoinWeights[keyLength];
 
@@ -315,7 +330,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             {
                 keys[i] = new ColumnRowReference()
                 {
-                    referenceBatch = msg.Data.EventBatchData,
+                    referenceBatch = reorderedBatch,
                     RowIndex = i
                 };
                 insertValues[i] = new JoinWeights()
@@ -324,8 +339,6 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     joinWeight = 0 
                 };
             }
-
-            var sortedIndices = SortBatch(msg.Data.EventBatchData, keyLength, _leftInsertComparer, _leftBatchSorter, _leftSortColumns);
 
             await _rightSearcher.Start(keys, keyLength, sortedIndices);
 
@@ -403,7 +416,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                         if (foundOffsets.Count >= MaxRowSize)
                         {
-                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, null, rightColumns, true);
+                            var outputBatch = BuildOutputBatch(msg, reorderedBatch, foundOffsets, weights, iterations, null, rightColumns, true);
                             _eventsCounter.Add(outputBatch.Data.Weights.Count);
                             yield return outputBatch;
                             ResetOutputLists(ref foundOffsets, ref weights, ref iterations, null, rightColumns);
@@ -438,7 +451,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                         if (foundOffsets.Count >= MaxRowSize)
                         {
-                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, null, rightColumns, true);
+                            var outputBatch = BuildOutputBatch(msg, reorderedBatch, foundOffsets, weights, iterations, null, rightColumns, true);
                             _eventsCounter.Add(outputBatch.Data.Weights.Count);
                             yield return outputBatch;
                             ResetOutputLists(ref foundOffsets, ref weights, ref iterations, null, rightColumns);
@@ -449,7 +462,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
             if (foundOffsets.Count > 0)
             {
-                var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, null, rightColumns, true);
+                var outputBatch = BuildOutputBatch(msg, reorderedBatch, foundOffsets, weights, iterations, null, rightColumns, true);
                 _eventsCounter.Add(outputBatch.Data.Weights.Count);
                 yield return outputBatch;
             }
@@ -489,6 +502,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             }
 
             
+            var sortedIndices = SortBatch(msg.Data.EventBatchData, keyLength, _rightColumnOrder, _rightBatchSorter, _rightSortColumns, out var reorderedBatch);
+
             ColumnRowReference[] keys = new ColumnRowReference[keyLength];
             JoinWeights[] insertValues = new JoinWeights[keyLength];
 
@@ -496,7 +511,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             {
                 keys[i] = new ColumnRowReference()
                 {
-                    referenceBatch = msg.Data.EventBatchData,
+                    referenceBatch = reorderedBatch,
                     RowIndex = i
                 };
                 insertValues[i] = new JoinWeights()
@@ -505,8 +520,6 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     joinWeight = 0 
                 };
             }
-
-            var sortedIndices = SortBatch(msg.Data.EventBatchData, keyLength, _rightInsertComparer, _rightBatchSorter, _rightSortColumns);
 
             await _leftSearcher.Start(keys, keyLength, sortedIndices);
 
@@ -583,7 +596,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                         if (foundOffsets.Count >= MaxRowSize)
                         {
-                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, leftColumns, null, false);
+                            var outputBatch = BuildOutputBatch(msg, reorderedBatch, foundOffsets, weights, iterations, leftColumns, null, false);
                             _eventsCounter.Add(outputBatch.Data.Weights.Count);
                             yield return outputBatch;
                             ResetOutputLists(ref foundOffsets, ref weights, ref iterations, leftColumns, null);
@@ -618,7 +631,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                         if (foundOffsets.Count >= MaxRowSize)
                         {
-                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, leftColumns, null, false);
+                            var outputBatch = BuildOutputBatch(msg, reorderedBatch, foundOffsets, weights, iterations, leftColumns, null, false);
                             _eventsCounter.Add(outputBatch.Data.Weights.Count);
                             yield return outputBatch;
                             ResetOutputLists(ref foundOffsets, ref weights, ref iterations, leftColumns, null);
@@ -629,7 +642,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
             if (foundOffsets.Count > 0)
             {
-                var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, leftColumns, null, false);
+                var outputBatch = BuildOutputBatch(msg, reorderedBatch, foundOffsets, weights, iterations, leftColumns, null, false);
                 _eventsCounter.Add(outputBatch.Data.Weights.Count);
                 yield return outputBatch;
             }
@@ -649,7 +662,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             await _rightInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator());
         }
 
-        private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)
+        private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, EventBatchData reorderedBatch, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)
         {
             IColumn[] outputColumns = new IColumn[_leftOutputColumns.Count + _rightOutputColumns.Count];
             bool shouldDisposeOffsets = true;
@@ -659,7 +672,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 {
                     for (int i = 0; i < _leftOutputColumns.Count; i++)
                     {
-                        outputColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, MemoryAllocator, out var usedOffset);
+                        outputColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(reorderedBatch.Columns[_leftOutputColumns[i]], foundOffsets, MemoryAllocator, out var usedOffset);
                         if (usedOffset)
                         {
                             shouldDisposeOffsets = false;
@@ -683,7 +696,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 {
                     for (int i = 0; i < _rightOutputColumns.Count; i++)
                     {
-                        outputColumns[_rightOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_rightOutputColumns[i]], foundOffsets, MemoryAllocator, out var usedOffset);
+                        outputColumns[_rightOutputIndices[i]] = ColumnWithOffset.CreateFlattened(reorderedBatch.Columns[_rightOutputColumns[i]], foundOffsets, MemoryAllocator, out var usedOffset);
                         if (usedOffset)
                         {
                             shouldDisposeOffsets = false;
@@ -775,16 +788,20 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             _rightSearcher = _rightTree.CreateBulkSearcher(_searchRightComparer);
         }
 
-        private int[] SortBatch(EventBatchData batchData, int keyLength, MergeJoinInsertComparer comparer, BatchSorter batchSorter, IColumn[] sortColumns)
+        private int[] SortBatch(EventBatchData batchData, int keyLength, List<int> columnOrder, BatchSorter batchSorter, IColumn[] sortColumns, out EventBatchData reorderedBatch)
         {
             if (keyLength > _sortedIndicesBuffer.Length)
             {
                 _sortedIndicesBuffer = new int[keyLength];
             }
-            for (int i = 0; i < comparer.ColumnOrder.Count; i++)
+            IColumn[] newColumns = new IColumn[columnOrder.Count];
+            for (int i = 0; i < columnOrder.Count; i++)
             {
-                sortColumns[i] = batchData.Columns[comparer.ColumnOrder[i]];
+                var col = batchData.Columns[columnOrder[i]];
+                sortColumns[i] = col;
+                newColumns[i] = col;
             }
+            reorderedBatch = new EventBatchData(newColumns);
             for (int i = 0; i < keyLength; i++)
             {
                 _sortedIndicesBuffer[i] = i;

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnStoreMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnStoreMergeJoin.cs
@@ -23,6 +23,7 @@ using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
 using FlowtideDotNet.Substrait.Expressions;
 using FlowtideDotNet.Substrait.Relations;
+using FlowtideDotNet.Core.Optimizer.EmitPushdown;
 using System.Diagnostics;
 using System.Threading.Tasks.Dataflow;
 
@@ -44,6 +45,51 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         private readonly List<int> _leftOutputIndices;
         private readonly List<int> _rightOutputIndices;
+
+        private readonly List<int> _leftColumnOrder;
+        private readonly List<int> _rightColumnOrder;
+
+        private List<int> BuildColumnOrder(List<int> comparisonColumns, int columnCount)
+        {
+            var output = new List<int>();
+            // Add the comparison columns first
+            for (int i = 0; i < comparisonColumns.Count; i++)
+            {
+                output.Add(comparisonColumns[i]);
+            }
+
+            // Add the missing columns in the order they appear in the data
+            for (int i = 0; i < columnCount; i++)
+            {
+                if (!output.Contains(i))
+                {
+                    output.Add(i);
+                }
+            }
+            return output;
+        }
+
+        private Expression RemapFilter(Expression filter, List<int> leftColumnOrder, List<int> rightColumnOrder)
+        {
+            Dictionary<int, int> oldToNew = new Dictionary<int, int>();
+
+            for (int i = 0; i < leftColumnOrder.Count; i++)
+            {
+                var oldId = leftColumnOrder[i];
+                oldToNew[oldId] = i;
+            }
+
+            for (int i = 0; i < rightColumnOrder.Count; i++)
+            {
+                var oldId = rightColumnOrder[i] + leftColumnOrder.Count;
+                oldToNew[oldId] = i + leftColumnOrder.Count;
+            }
+
+            var clone = filter.Clone();
+            var visitor = new ExpressionFieldReplaceVisitor(oldToNew);
+            visitor.Visit(clone, default);
+            return clone;
+        }
 
         // Metrics
         private ICounter<long>? _eventsCounter;
@@ -73,18 +119,31 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             _dataValueContainer = new DataValueContainer();
             var leftColumns = GetCompareColumns(mergeJoinRelation.LeftKeys, 0);
             var rightColumns = GetCompareColumns(mergeJoinRelation.RightKeys, mergeJoinRelation.Left.OutputLength);
-            _leftInsertComparer = new MergeJoinInsertComparer(leftColumns, mergeJoinRelation.Left.OutputLength);
-            _rightInsertComparer = new MergeJoinInsertComparer(rightColumns, mergeJoinRelation.Right.OutputLength);
+            _leftColumnOrder = BuildColumnOrder(leftColumns, mergeJoinRelation.Left.OutputLength);
+            _rightColumnOrder = BuildColumnOrder(rightColumns, mergeJoinRelation.Right.OutputLength);
 
-            _searchLeftComparer = new MergeJoinSearchComparer(leftColumns, rightColumns);
-            _searchRightComparer = new MergeJoinSearchComparer(rightColumns, leftColumns);
+            _leftInsertComparer = new MergeJoinInsertComparer(mergeJoinRelation.Left.OutputLength);
+            _rightInsertComparer = new MergeJoinInsertComparer(mergeJoinRelation.Right.OutputLength);
+
+            _searchLeftComparer = new MergeJoinSearchComparer(leftColumns.Count);
+            _searchRightComparer = new MergeJoinSearchComparer(rightColumns.Count);
 
             (_leftOutputColumns, _leftOutputIndices) = GetOutputColumns(mergeJoinRelation, 0, mergeJoinRelation.Left.OutputLength);
             (_rightOutputColumns, _rightOutputIndices) = GetOutputColumns(mergeJoinRelation, mergeJoinRelation.Left.OutputLength, mergeJoinRelation.Right.OutputLength);
 
+            for (int i = 0; i < _leftOutputColumns.Count; i++)
+            {
+                _leftOutputColumns[i] = _leftColumnOrder.IndexOf(_leftOutputColumns[i]);
+            }
+            for (int i = 0; i < _rightOutputColumns.Count; i++)
+            {
+                _rightOutputColumns[i] = _rightColumnOrder.IndexOf(_rightOutputColumns[i]);
+            }
+
             if (mergeJoinRelation.PostJoinFilter != null)
             {
-                _postCondition = ColumnBooleanCompiler.CompileTwoInputs(mergeJoinRelation.PostJoinFilter, functionsRegister, mergeJoinRelation.Left.OutputLength);
+                var remappedFilter = RemapFilter(mergeJoinRelation.PostJoinFilter, _leftColumnOrder, _rightColumnOrder);
+                _postCondition = ColumnBooleanCompiler.CompileTwoInputs(remappedFilter, functionsRegister, mergeJoinRelation.Left.OutputLength);
             }
         }
 
@@ -187,11 +246,19 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             {
                 rightColumns.Add(Column.Create(memoryManager));
             }
+            
+            IColumn[] newColumns = new IColumn[_leftColumnOrder.Count];
+            for (int j = 0; j < _leftColumnOrder.Count; j++)
+            {
+                newColumns[j] = msg.Data.EventBatchData.Columns[_leftColumnOrder[j]];
+            }
+            var reorderedBatch = new EventBatchData(newColumns);
+            
             for (int i = 0; i < msg.Data.Weights.Count; i++)
             {
                 var columnReference = new ColumnRowReference()
                 {
-                    referenceBatch = msg.Data.EventBatchData,
+                    referenceBatch = reorderedBatch,
                     RowIndex = i
                 };
 
@@ -252,7 +319,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                     bool shouldDisposeOffsets = true;
                                     for (int l = 0; l < _leftOutputColumns.Count; l++)
                                     {
-                                        outputColumns[_leftOutputIndices[l]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[l]], foundOffsets, MemoryAllocator, out var offsetUsed);
+                                        outputColumns[_leftOutputIndices[l]] = ColumnWithOffset.CreateFlattened(reorderedBatch.Columns[_leftOutputColumns[l]], foundOffsets, MemoryAllocator, out var offsetUsed);
                                         if (offsetUsed)
                                         {
                                             shouldDisposeOffsets = false;
@@ -342,7 +409,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     bool shouldDisposeOffsets = true;
                     for (int i = 0; i < _leftOutputColumns.Count; i++)
                     {
-                        outputColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, MemoryAllocator, out var offsetUsed);
+                        outputColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(reorderedBatch.Columns[_leftOutputColumns[i]], foundOffsets, MemoryAllocator, out var offsetUsed);
                         if (offsetUsed)
                         {
                             shouldDisposeOffsets = false;
@@ -409,11 +476,19 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             {
                 leftColumns.Add(Column.Create(memoryManager));
             }
+            
+            IColumn[] newColumns = new IColumn[_rightColumnOrder.Count];
+            for (int j = 0; j < _rightColumnOrder.Count; j++)
+            {
+                newColumns[j] = msg.Data.EventBatchData.Columns[_rightColumnOrder[j]];
+            }
+            var reorderedBatch = new EventBatchData(newColumns);
+            
             for (int i = 0; i < msg.Data.Weights.Count; i++)
             {
                 var columnReference = new ColumnRowReference()
                 {
-                    referenceBatch = msg.Data.EventBatchData,
+                    referenceBatch = reorderedBatch,
                     RowIndex = i
                 };
 
@@ -480,7 +555,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                     bool shouldDisposeOffsets = true;
                                     for (int l = 0; l < _rightOutputColumns.Count; l++)
                                     {
-                                        outputColumns[_rightOutputIndices[l]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_rightOutputColumns[l]], foundOffsets, MemoryAllocator, out var offsetUsed);
+                                        outputColumns[_rightOutputIndices[l]] = ColumnWithOffset.CreateFlattened(reorderedBatch.Columns[_rightOutputColumns[l]], foundOffsets, MemoryAllocator, out var offsetUsed);
                                         if (offsetUsed)
                                         {
                                             shouldDisposeOffsets = false;
@@ -570,7 +645,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     bool shouldDisposeOffsets = true;
                     for (int i = 0; i < _rightOutputColumns.Count; i++)
                     {
-                        outputColumns[_rightOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_rightOutputColumns[i]], foundOffsets, MemoryAllocator, out var offsetUsed);
+                        outputColumns[_rightOutputIndices[i]] = ColumnWithOffset.CreateFlattened(reorderedBatch.Columns[_rightOutputColumns[i]], foundOffsets, MemoryAllocator, out var offsetUsed);
                         if (offsetUsed)
                         {
                             shouldDisposeOffsets = false;

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinInsertComparer.cs
@@ -19,25 +19,12 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
     internal class MergeJoinInsertComparer : IBplusTreeComparer<ColumnRowReference, ColumnKeyStorageContainer>
     {
         private DataValueContainer dataValueContainer;
-        public List<int> ColumnOrder { get; }
-        public MergeJoinInsertComparer(List<int> comparisonColumns, int columnCount)
+        private readonly int _columnCount;
+
+        public MergeJoinInsertComparer(int columnCount)
         {
             dataValueContainer = new DataValueContainer();
-            ColumnOrder = new List<int>();
-            // Add the comparison columns first
-            for (int i = 0; i < comparisonColumns.Count; i++)
-            {
-                ColumnOrder.Add(comparisonColumns[i]);
-            }
-
-            // Add the missing columns in the order they appear in the data
-            for (int i = 0; i < columnCount; i++)
-            {
-                if (!ColumnOrder.Contains(i))
-                {
-                    ColumnOrder.Add(i);
-                }
-            }
+            _columnCount = columnCount;
         }
 
         public bool SeekNextPageForValue => false;
@@ -46,11 +33,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
         {
-            for (int i = 0; i < ColumnOrder.Count; i++)
+            for (int i = 0; i < _columnCount; i++)
             {
-                var col = ColumnOrder[i];
-                x.referenceBatch.Columns[col].GetValueAt(x.RowIndex, dataValueContainer, default);
-                y.referenceBatch.Columns[col].GetValueAt(y.RowIndex, _yDataValueContainer, default);
+                x.referenceBatch.Columns[i].GetValueAt(x.RowIndex, dataValueContainer, default);
+                y.referenceBatch.Columns[i].GetValueAt(y.RowIndex, _yDataValueContainer, default);
                 int cmp = FlowtideDotNet.Core.ColumnStore.Comparers.DataValueComparer.CompareTo(dataValueContainer, _yDataValueContainer);
                 if (cmp != 0)
                 {
@@ -62,11 +48,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         public int CompareTo(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, in int index)
         {
-            for (int i = 0; i < ColumnOrder.Count; i++)
+            for (int i = 0; i < _columnCount; i++)
             {
-                var col = ColumnOrder[i];
-                key.referenceBatch.Columns[col].GetValueAt(key.RowIndex, dataValueContainer, default);
-                keyContainer._data.Columns[col].GetValueAt(index, _yDataValueContainer, default);
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
+                keyContainer._data.Columns[i].GetValueAt(index, _yDataValueContainer, default);
                 int cmp = FlowtideDotNet.Core.ColumnStore.Comparers.DataValueComparer.CompareTo(dataValueContainer, _yDataValueContainer);
                 if (cmp != 0)
                 {
@@ -80,11 +65,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         {
             int start = startIndex;
             int end = endIndex;
-            for (int i = 0; i < ColumnOrder.Count; i++)
+            for (int i = 0; i < _columnCount; i++)
             {
-                var column = ColumnOrder[i];
-                key.referenceBatch.Columns[column].GetValueAt(key.RowIndex, dataValueContainer, default);
-                var (low, high) = keyContainer._data.Columns[column].SearchBoundries(dataValueContainer, start, end, default);
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
 
                 if (low < 0)
                 {
@@ -104,12 +88,11 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             int index = -1;
             int start = 0;
             int end = keyContainer.Count - 1;
-            for (int i = 0; i < ColumnOrder.Count; i++)
+            for (int i = 0; i < _columnCount; i++)
             {
-                var column = ColumnOrder[i];
                 // Get value by container to skip boxing for each value
-                key.referenceBatch.Columns[column].GetValueAt(key.RowIndex, dataValueContainer, default);
-                var (low, high) = keyContainer._data.Columns[column].SearchBoundries(dataValueContainer, start, end, default);
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
 
                 if (low < 0)
                 {

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/MergeJoinSearchComparer.cs
@@ -19,8 +19,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
     internal class MergeJoinSearchComparer : IBplusTreeComparer<ColumnRowReference, ColumnKeyStorageContainer>
     {
         private DataValueContainer dataValueContainer;
-        private readonly List<int> selfColumns;
-        private readonly List<int> referenceColumns;
+        private readonly int _comparisonColumnsCount;
 
         public int start;
         public int end;
@@ -28,22 +27,20 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         public bool SeekNextPageForValue => true;
 
-        public MergeJoinSearchComparer(List<int> selfColumns, List<int> referenceColumns)
+        public MergeJoinSearchComparer(int comparisonColumnsCount)
         {
             dataValueContainer = new DataValueContainer();
-            this.selfColumns = selfColumns;
-            this.referenceColumns = referenceColumns;
+            _comparisonColumnsCount = comparisonColumnsCount;
         }
         private readonly DataValueContainer _yDataValueContainer = new DataValueContainer();
 
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
         {
             // Usually not called for SearchComparer, but implementing similarly if needed
-            for (int i = 0; i < selfColumns.Count; i++)
+            for (int i = 0; i < _comparisonColumnsCount; i++)
             {
-                var col = selfColumns[i];
-                x.referenceBatch.Columns[col].GetValueAt(x.RowIndex, dataValueContainer, default);
-                y.referenceBatch.Columns[col].GetValueAt(y.RowIndex, _yDataValueContainer, default);
+                x.referenceBatch.Columns[i].GetValueAt(x.RowIndex, dataValueContainer, default);
+                y.referenceBatch.Columns[i].GetValueAt(y.RowIndex, _yDataValueContainer, default);
                 int cmp = FlowtideDotNet.Core.ColumnStore.Comparers.DataValueComparer.CompareTo(dataValueContainer, _yDataValueContainer);
                 if (cmp != 0)
                 {
@@ -55,11 +52,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
         public int CompareTo(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, in int index)
         {
-            for (int i = 0; i < selfColumns.Count; i++)
+            for (int i = 0; i < _comparisonColumnsCount; i++)
             {
-                var col = selfColumns[i];
-                key.referenceBatch.Columns[referenceColumns[i]].GetValueAt(key.RowIndex, dataValueContainer, default);
-                keyContainer._data.Columns[col].GetValueAt(index, _yDataValueContainer, default);
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
+                keyContainer._data.Columns[i].GetValueAt(index, _yDataValueContainer, default);
                 int cmp = FlowtideDotNet.Core.ColumnStore.Comparers.DataValueComparer.CompareTo(dataValueContainer, _yDataValueContainer);
                 if (cmp != 0)
                 {
@@ -75,17 +71,17 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             start = 0;
             end = keyContainer.Count - 1;
             noMatch = false;
-            for (int i = 0; i < selfColumns.Count; i++)
+            for (int i = 0; i < _comparisonColumnsCount; i++)
             {
                 // Get value by container to skip boxing for each value
-                key.referenceBatch.Columns[referenceColumns[i]].GetValueAt(key.RowIndex, dataValueContainer, default);
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
 
                 if (dataValueContainer._type == ArrowTypeId.Null)
                 {
                     noMatch = true;
                     return start;
                 }
-                var (low, high) = keyContainer._data.Columns[selfColumns[i]].SearchBoundries(dataValueContainer, start, end, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
 
                 if (low < 0)
                 {
@@ -107,16 +103,16 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         {
             int currentStart = startIndex;
             int currentEnd = endIndex;
-            for (int i = 0; i < selfColumns.Count; i++)
+            for (int i = 0; i < _comparisonColumnsCount; i++)
             {
                 // Get value by container to skip boxing for each value
-                key.referenceBatch.Columns[referenceColumns[i]].GetValueAt(key.RowIndex, dataValueContainer, default);
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
 
                 if (dataValueContainer._type == ArrowTypeId.Null)
                 {
                     return new FindBoundriesResult(~currentStart, ~currentStart);
                 }
-                var (low, high) = keyContainer._data.Columns[selfColumns[i]].SearchBoundries(dataValueContainer, currentStart, currentEnd, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, currentStart, currentEnd, default);
 
                 if (low < 0)
                 {


### PR DESCRIPTION
Change so column order is not looked up in the hot path, this saves a lookup in places such as boundary searching and insertion of elements.