### PR TITLE
Add so sorting can generate duplicate tags

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSorter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSorter.cs
@@ -30,6 +30,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
         private readonly SelfComparePointers[] _pointers;
         private UInt128 _lastKey = 0;
         private SortCompiler.SortDelegate? _lastSort;
+        private SortCompiler.SortWithTagsDelegate? _lastSortWithTags;
         public BatchSorter(int columnCount)
         {
             _pointers = new SelfComparePointers[columnCount];
@@ -55,6 +56,33 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             }
 
             _lastSort(new SortCompareContext(columns, _pointers), ref indirect);
+        }
+
+        /// <summary>
+        /// Does a sort and an extra pass to find duplicate rows.
+        /// These are created as tags, 0 0 1 1 1 1 etc, where if they share the same value in the sort columns, they get the same tag.
+        /// This is helpful to to create at this step since columns are already in cache.
+        /// </summary>
+        /// <param name="columns"></param>
+        /// <param name="indirect"></param>
+        /// <param name="tags"></param>
+        public void SortDataWithTags(IColumn[] columns, ref Span<int> indirect, ref Span<int> tags)
+        {
+            Debug.Assert(columns.Length == _pointers.Length);
+            var key = SortCompiler.CreateKey(columns);
+            if (key != _lastKey || _lastSortWithTags == null)
+            {
+                _lastSortWithTags = SortCompiler.GetOrCompileWithTags(key, columns);
+                _lastKey = key;
+            }
+            for (int i = 0; i < columns.Length; i++)
+            {
+                if (columns[i].SupportSelfCompareExpression)
+                {
+                    columns[i].SetSelfComparePointers(ref _pointers[i]);
+                }
+            }
+            _lastSortWithTags(new SortCompareContext(columns, _pointers), ref indirect, ref tags);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSorter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSorter.cs
@@ -61,7 +61,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
         /// <summary>
         /// Does a sort and an extra pass to find duplicate rows.
         /// These are created as tags, 0 0 1 1 1 1 etc, where if they share the same value in the sort columns, they get the same tag.
-        /// This is helpful to to create at this step since columns are already in cache.
+        /// This is helpful to create at this step since columns are already in cache.
         /// </summary>
         /// <param name="columns"></param>
         /// <param name="indirect"></param>

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
@@ -64,9 +64,19 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             var parameter = Expression.Parameter(typeof(SortCompareContext), "context");
             var indicesParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "indices");
 
-            var newExpr = Expression.New(comparerType.GetConstructor([typeof(SortCompareContext)]), parameter);
+            var ctor = comparerType.GetConstructor([typeof(SortCompareContext)]);
+            if (ctor == null)
+            {
+                throw new InvalidOperationException($"Comparer struct {comparerType.FullName} does not have the expected constructor.");
+            }
+            var newExpr = Expression.New(ctor, parameter);
 
             var doSort = typeof(SortCompiler).GetMethod(nameof(DoSort), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+
+            if (doSort == null)
+            {
+                throw new InvalidOperationException($"Could not find method {nameof(DoSort)} on {typeof(SortCompiler).FullName}.");
+            }
 
             var callSort = Expression.Call(doSort.MakeGenericMethod(comparerType), indicesParameter, newExpr);
 
@@ -93,9 +103,21 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             var indicesParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "indices");
             var tagsParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "tags");
 
-            var newExpr = Expression.New(comparerType.GetConstructor([typeof(SortCompareContext)]), parameter);
+            var ctor = comparerType.GetConstructor([typeof(SortCompareContext)]);
+
+            if (ctor == null)
+            {
+                throw new InvalidOperationException($"Comparer struct {comparerType.FullName} does not have the expected constructor.");
+            }
+
+            var newExpr = Expression.New(ctor, parameter);
 
             var doSort = typeof(SortCompiler).GetMethod(nameof(DoSortWithTags), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+
+            if (doSort == null)
+            {
+                throw new InvalidOperationException($"Could not find method {nameof(DoSortWithTags)} on {typeof(SortCompiler).FullName}.");
+            }
 
             var callSort = Expression.Call(doSort.MakeGenericMethod(comparerType), indicesParameter, tagsParameter, newExpr);
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
@@ -25,7 +25,11 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
     {
         public delegate void SortDelegate(SortCompareContext context, ref Span<int> indices);
 
+        public delegate void SortWithTagsDelegate(SortCompareContext context, ref Span<int> indices, ref Span<int> tags);
+
         private static readonly ConcurrentDictionary<UInt128, SortDelegate> _cache = new ConcurrentDictionary<UInt128, SortDelegate>();
+
+        private static readonly ConcurrentDictionary<UInt128, SortWithTagsDelegate> _tagsCache = new ConcurrentDictionary<UInt128, SortWithTagsDelegate>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static UInt128 CreateKey(IColumn[] columns)
@@ -76,5 +80,48 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             IntroSort.Sort(indices, ref comparer);
         }
 
+        public static SortWithTagsDelegate GetOrCompileWithTags(UInt128 key, IColumn[] columns)
+        {
+            return _tagsCache.GetOrAdd(key, static (key, args) => CompileWithTags(args), columns);
+        }
+
+        private static SortWithTagsDelegate CompileWithTags(IColumn[] columns)
+        {
+            var comparerType = ComparerStructCompiler.Compile(columns);
+
+            var parameter = Expression.Parameter(typeof(SortCompareContext), "context");
+            var indicesParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "indices");
+            var tagsParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "tags");
+
+            var newExpr = Expression.New(comparerType.GetConstructor([typeof(SortCompareContext)]), parameter);
+
+            var doSort = typeof(SortCompiler).GetMethod(nameof(DoSortWithTags), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+
+            var callSort = Expression.Call(doSort.MakeGenericMethod(comparerType), indicesParameter, tagsParameter, newExpr);
+
+            var lambda = Expression.Lambda<SortWithTagsDelegate>(callSort, parameter, indicesParameter, tagsParameter);
+
+            return lambda.Compile();
+        }
+
+        public static void DoSortWithTags<TComparer>(ref Span<int> indices, ref Span<int> tags, TComparer comparer) where TComparer : struct, IComparer<int>
+        {
+            IntroSort.Sort(indices, ref comparer);
+
+            if (indices.Length == 0) return;
+
+            // After sorting indices, we need to find tags
+            int currentGroup = 0;
+            tags[0] = 0;
+
+            for (int i = 1; i < indices.Length; i++)
+            {
+                if (comparer.Compare(indices[i - 1], indices[i]) != 0)
+                {
+                    currentGroup++;
+                }
+                tags[i] = currentGroup;
+            }
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -85,6 +85,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         private readonly IColumn[] _leftSortColumns;
         private readonly IColumn[] _rightSortColumns;
         private int[] _sortedIndicesBuffer = Array.Empty<int>();
+        private int[] _duplicatesTagBuffer = Array.Empty<int>();
 
         private readonly MergeJoinRelation _mergeJoinRelation;
         private readonly MergeJoinInsertComparer _leftInsertComparer;
@@ -446,7 +447,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             }
 
 
-            await _leftInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator(_leftInputColumnCount), batchSize);
+            await _leftInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, _duplicatesTagBuffer, new JoinWeightsMutator(_leftInputColumnCount), batchSize);
         }
 
         private async IAsyncEnumerable<StreamEventBatch> OnRecieveRight(StreamEventBatch msg, long time)
@@ -627,9 +628,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 iterations.Dispose();
             }
 
-
-
-            await _rightInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, new JoinWeightsMutator(_rightInputColumnCount), batchSize);
+            await _rightInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, _duplicatesTagBuffer, new JoinWeightsMutator(_rightInputColumnCount), batchSize);
         }
 
         private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)
@@ -778,6 +777,10 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             {
                 _sortedIndicesBuffer = new int[keyLength];
             }
+            if (keyLength > _duplicatesTagBuffer.Length)
+            {
+                _duplicatesTagBuffer = new int[keyLength];
+            }
             for (int i = 0; i < comparer.ColumnOrder.Count; i++)
             {
                 sortColumns[i] = batchData.Columns[comparer.ColumnOrder[i]];
@@ -787,7 +790,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 _sortedIndicesBuffer[i] = i;
             }
             var indirectSpan = _sortedIndicesBuffer.AsSpan(0, keyLength);
-            batchSorter.SortData(sortColumns, ref indirectSpan);
+            var tagsSpan = _duplicatesTagBuffer.AsSpan(0, keyLength);
+            batchSorter.SortDataWithTags(sortColumns, ref indirectSpan, ref tagsSpan);
             return _sortedIndicesBuffer;
         }
     }

--- a/src/FlowtideDotNet.Storage/Tree/IBPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/IBPlusTreeBulkInserter.cs
@@ -27,7 +27,7 @@ namespace FlowtideDotNet.Storage.Tree
         ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, TMutator mutator, int totalBatchByteSize)
             where TMutator : IRowMutator<K, V>;
 
-        ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, int[] sortedIndices, TMutator mutator, int totalBatchByteSize)
+        ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, int[] sortedIndices, int[] duplicateTags, TMutator mutator, int totalBatchByteSize)
             where TMutator : IRowMutator<K, V>;
 
         int LeafHitCount { get; }

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -49,6 +49,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
     {
         private readonly BPlusTree<K, V, TKeyContainer, TValueContainer> _tree;
         private int[] _sortedIndices = Array.Empty<int>();
+        private int[] _duplicateTags = Array.Empty<int>();
         private int[] _insertSortedIndices = Array.Empty<int>();
         private int[] _insertTargetPositions = Array.Empty<int>();
         private int[] _deletePositions = Array.Empty<int>();
@@ -84,11 +85,11 @@ namespace FlowtideDotNet.Storage.Tree.Internal
         }
 
 
-        public async ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, int[] sortedIndices, TMutator mutator, int totalBatchByteSize)
+        public async ValueTask ApplyBatch<TMutator>(K[] keys, V[] values, int keyLength, int[] sortedIndices, int[] duplicateTags, TMutator mutator, int totalBatchByteSize)
             where TMutator : IRowMutator<K, V>
         {
             _totalBatchByteSize = totalBatchByteSize;
-            await StartBatch(keys, values, keyLength, sortedIndices);
+            await StartBatch(keys, values, keyLength, sortedIndices, duplicateTags);
             await MutateBatch(mutator);
             await ApplySplitsAndMerges();
         }
@@ -109,11 +110,12 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             return _sortedIndices;
         }
 
-        private ValueTask StartBatch(K[] keys, V[] values, int keyLength, int[] sortedIndices)
+        private ValueTask StartBatch(K[] keys, V[] values, int keyLength, int[] sortedIndices, int[] duplicateTags)
         {
             _keys = keys;
             _values = values;
             _sortedIndices = sortedIndices;
+            _duplicateTags = duplicateTags;
             _mappings.Clear();
             if (keyLength > _insertSortedIndices.Length)
             {
@@ -232,7 +234,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             leaf.EnterWriteLock();
             // Track the previous key's state for duplicate detection.
             // Since keys are sorted, duplicates are always adjacent.
-            int prevSortedKeyIndex = -1;
+            int prevSortedIndex = -1;
             bool prevWasPendingInsert = false;
             bool prevWasPendingDelete = false;
             // Whether the key physically exists in the original leaf (before
@@ -253,12 +255,13 @@ namespace FlowtideDotNet.Storage.Tree.Internal
             bool updated = false;
             for (int i = 0; i < mapping.Length; i++)
             {
-                var keyIndex = _sortedIndices[mapping.Offset + i];
+                var sortedIndex = mapping.Offset + i;
+                var keyIndex = _sortedIndices[sortedIndex];
                 var key = _keys[keyIndex];
                 
                 // Detect duplicate: current key equals previous key in sorted order.
-                if (prevSortedKeyIndex >= 0
-                    && searchComparer.CompareTo(key, _keys[prevSortedKeyIndex]) == 0)
+                if (prevSortedIndex >= 0
+                    && _duplicateTags[sortedIndex] == _duplicateTags[sortedIndex - 1])
                 {
                     //throw new InvalidOperationException("Duplicate");
                     if (prevWasPendingInsert)
@@ -342,7 +345,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                         }
                     }
 
-                    prevSortedKeyIndex = keyIndex;
+                    prevSortedIndex = sortedIndex;
                     continue;
                 }
 
@@ -367,7 +370,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     }
                     prevWasPendingDelete = false;
                     prevKeyExistsInLeaf = false;
-                    prevSortedKeyIndex = keyIndex;
+                    prevSortedIndex = sortedIndex;
                     continue;
                 }
 
@@ -424,7 +427,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                     }
                     prevKeyExistsInLeaf = true;
                 }
-                prevSortedKeyIndex = keyIndex;
+                prevSortedIndex = sortedIndex;
             }
 
             if (deleteCounter > 0)

--- a/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
+++ b/src/FlowtideDotNet.Storage/Tree/Internal/BPlusTreeBulkInserter.cs
@@ -10,7 +10,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
@@ -143,6 +142,7 @@ namespace FlowtideDotNet.Storage.Tree.Internal
                 _lookupBuffer = new int[keyLength];
                 _lowerBounds = new int[keyLength];
                 _upperBounds = new int[keyLength];
+                _duplicateTags = new int[keyLength];
             }
 
             // Sort the keys and values by keys
@@ -155,6 +155,21 @@ namespace FlowtideDotNet.Storage.Tree.Internal
 
             var indicesSpan = _sortedIndices.AsSpan().Slice(0, keyLength);
             indicesSpan.Sort(new ExternalKeyComparer<K, TKeyContainer, IBplusTreeComparer<K, TKeyContainer>>(keys,keyComparer));
+
+            if (indicesSpan.Length > 0)
+            {
+                int currentGroup = 0;
+                _duplicateTags[0] = 0;
+
+                for (int i = 1; i < keyLength; i++)
+                {
+                    if (keyComparer.CompareTo(_keys[_sortedIndices[i - 1]], _keys[_sortedIndices[i]]) != 0)
+                    {
+                        currentGroup++;
+                    }
+                    _duplicateTags[i] = currentGroup;
+                }
+            }
 
             return _tree.RouteBatchRootAsync(keys, keyLength, _sortedIndices, _tree.m_keyComparer, _mappings, _lowerBounds, _upperBounds, _lookupBuffer);
         }


### PR DESCRIPTION
This allows usage of JIT optimized comparisons and bulk insert just checks integers for duplicates.