### PR TITLE
Join performance improvements, radix sort implementation

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/AlwaysNullColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/AlwaysNullColumn.cs
@@ -213,6 +213,21 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             // Nothing required
         }
+
+        public RadixCapability SupportsRadixSort(int bytesLeft, bool hasNullByte)
+        {
+            return RadixCapability.None();
+        }
+
+        public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition)
+        {
+            return 0;
+        }
+
+        public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, int nullBytePosition, Span<int> selectionVector)
+        {
+            return 0;
+        }
     }
 }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -27,6 +27,8 @@ using System.Collections;
 using System.Diagnostics;
 using System.IO.Hashing;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 
@@ -1582,6 +1584,116 @@ namespace FlowtideDotNet.Core.ColumnStore
             }
 
             return dataColumnCompare;
+        }
+
+        public RadixCapability SupportsRadixSort(int bytesLeft, bool hasNullByte)
+        {
+            if (_dataColumn == null)
+            {
+                return RadixCapability.None();
+            }
+            if (_nullCounter > 0)
+            {
+                if (hasNullByte)
+                {
+                    return _dataColumn.SupportsRadixSort(bytesLeft);
+                }
+                else
+                {
+                    if (bytesLeft < 1)
+                    {
+                        return RadixCapability.None();
+                    }
+                    var innerCapability = _dataColumn.SupportsRadixSort(bytesLeft - 1);
+                    if (innerCapability.Support == RadixSupport.None)
+                    {
+                        return RadixCapability.None();
+                    }
+                    else if (innerCapability.Support == RadixSupport.Partial)
+                    {
+                        return RadixCapability.Partial(innerCapability.BytesConsumed + 1);
+                    }
+                    else
+                    {
+                        return RadixCapability.Full(innerCapability.BytesConsumed + 1);
+                    }
+                }
+            }
+            return _dataColumn.SupportsRadixSort(bytesLeft);
+        }
+
+        public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition)
+        {
+            return SetRadixPrefix(items, insertBytePosition, -1, Span<int>.Empty);
+        }
+
+        public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, int nullBytePosition, Span<int> selectionVector)
+        {
+            if (_dataColumn == null)
+            {
+                return 0;
+            }
+
+            if (_nullCounter == 0)
+            {
+                return _dataColumn.SetRadixPrefix(items, insertBytePosition, selectionVector);
+            }
+
+            Debug.Assert(_validityList != null);
+            ref RadixItem itemsRef = ref MemoryMarshal.GetReference(items);
+            bool createdNullByte = false;
+
+            if (nullBytePosition == -1)
+            {
+                nullBytePosition = insertBytePosition;
+                insertBytePosition = insertBytePosition + 1;
+                createdNullByte = true;
+            }
+
+            if (selectionVector.IsEmpty)
+            {
+                for (int i = 0; i < items.Length; i++)
+                {
+                    ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                    bool isNotNull = _validityList.Get(item.Index);
+
+                    ref byte nullByte = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), nullBytePosition);
+
+                    if (createdNullByte)
+                    {
+                        nullByte = (byte)(isNotNull ? 0x01 : 0x00);
+                    }
+                    else if (!isNotNull)
+                    {
+                        nullByte = 0x00;
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < items.Length; i++)
+                {
+                    ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                    int physicalIndex = selectionVector[item.Index];
+
+                    ref byte nullByte = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), nullBytePosition);
+
+                    bool isNotNull = physicalIndex >= 0 && _validityList.Get(physicalIndex);
+
+                    if (createdNullByte)
+                    {
+                        nullByte = (byte)(isNotNull ? 0x01 : 0x00);
+                    }
+                    else if (!isNotNull)
+                    {
+                        nullByte = 0x00;
+                    }
+                }
+            }
+
+            int innerBytes = _dataColumn.SetRadixPrefix(items, insertBytePosition, selectionVector);
+
+            return (createdNullByte ? 1 : 0) + innerBytes;
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/ColumnWithOffset.cs
@@ -414,6 +414,59 @@ namespace FlowtideDotNet.Core.ColumnStore
                 throw new NotSupportedException();
             }
         }
+
+        public RadixCapability SupportsRadixSort(int bytesLeft, bool hasNullByte)
+        {
+            if (hasNullByte)
+            {
+                throw new InvalidOperationException("Column with offset should be the outer most layer, otherwise there is a risk for multiple selection vectors.");
+            }
+            if (bytesLeft < 1)
+            {
+                return RadixCapability.None();
+            }
+
+            var innerCapability = this.innerColumn.SupportsRadixSort(bytesLeft - 1, true);
+
+            if (innerCapability.Support == RadixSupport.None)
+            {
+                return RadixCapability.None();
+            }
+            else if (innerCapability.Support == RadixSupport.Partial)
+            {
+                // We can only support partial if we have at least 2 bytes left, since we need 1 byte for the null from offset
+                return RadixCapability.Partial(innerCapability.BytesConsumed + 1);
+            }
+            else
+            {
+                return RadixCapability.Full(innerCapability.BytesConsumed + 1);
+            }
+        }
+
+        public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition)
+        {
+            Span<int> offsetsSpan = this.offsets.Span;
+            ref RadixItem itemsRef = ref MemoryMarshal.GetReference(items);
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                int physicalOffset = offsetsSpan[item.Index];
+                ref byte nullIndicatorByte = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+                nullIndicatorByte = (byte)(physicalOffset >= 0 ? 0x01 : 0x00);
+            }
+
+            innerColumn.SetRadixPrefix(items, insertBytePosition + 1, insertBytePosition, offsetsSpan);
+            return 0;
+        }
+
+        public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, int nullBytePosition,  Span<int> selectionVector)
+        {
+            // Selection vector on selection vector is an anti-pattern, if you find yourself needing this,
+            // you should probably create a new column with offset on top of this column with the new selection vector,
+            // instead of trying to apply multiple selection vectors on top of each other.
+            throw new NotSupportedException("ColumnWithOffset does not support SetRadixPrefix with selection vector since it already has a selection vector.");
+        }
     }
 }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IDataColumn.cs
@@ -125,5 +125,21 @@ namespace FlowtideDotNet.Core.ColumnStore
         {
             throw new NotImplementedException();
         }
+
+        RadixCapability SupportsRadixSort(int bytesLeft) => RadixCapability.None();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="items"></param>
+        /// <param name="insertBytePosition"></param>
+        /// <param name="selectionVector">The indices of the items that should be inserted. This is used to only insert a subset of the items, for example when only a subset of the column is sorted.
+        /// If empty, all data should be copied, -1 is a special value meaning the row is null, so 0 should be set on bytes</param>
+        /// <returns>How many bytes where used up</returns>
+        int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, ReadOnlySpan<int> selectionVector)
+        {
+            throw new InvalidOperationException(
+                "This column does not support Radix packing. The Query Planner should have halted extraction.");
+        }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/DataColumns/IntegerColumn.cs
@@ -89,6 +89,8 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                 System.Linq.Expressions.Expression yExpression);
 
             CompareColumnState GetColumnState();
+
+            int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, ReadOnlySpan<int> selectionVector);
         }
 
         private sealed class Int8Data : IIntData
@@ -258,6 +260,46 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             {
                 return CompareColumnStateBuilder.Create(ArrowTypeId.Int8);
             }
+
+            public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, ReadOnlySpan<int> selectionVector)
+            {
+                ReadOnlySpan<sbyte> span = _list.Span;
+                ref RadixItem itemsRef = ref MemoryMarshal.GetReference(items);
+
+                if (selectionVector.IsEmpty)
+                {
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                        sbyte rawValue = span[item.Index];
+                        byte alignedValue = (byte)(rawValue ^ 0x80);
+                        ref byte byteOffset = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+                        byteOffset = alignedValue;
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                        int selectedIndex = selectionVector[item.Index];
+
+                        ref byte byteOffset = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+
+                        if (selectedIndex >= 0)
+                        {
+                            sbyte rawValue = span[selectedIndex];
+                            byteOffset = (byte)(rawValue ^ 0x80);
+                        }
+                        else
+                        {
+                            byteOffset = 0;
+                        }
+                    }
+                }
+
+                return 1;
+            }
         }
 
         private sealed class Int16Data : IIntData
@@ -426,6 +468,48 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             public CompareColumnState GetColumnState()
             {
                 return CompareColumnStateBuilder.Create(ArrowTypeId.Int16);
+            }
+
+            public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, ReadOnlySpan<int> selectionVector)
+            {
+                ReadOnlySpan<short> span = _list.Span;
+                ref RadixItem itemsRef = ref MemoryMarshal.GetReference(items);
+
+                if (selectionVector.IsEmpty)
+                {
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                        short rawValue = span[item.Index];
+                        ushort alignedValue = (ushort)(rawValue ^ 0x8000);
+
+                        ref byte byteOffset = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+                        Unsafe.As<byte, ushort>(ref byteOffset) = alignedValue;
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                        int selectedIndex = selectionVector[item.Index];
+
+                        ref byte byteOffset = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+
+                        if (selectedIndex >= 0)
+                        {
+                            short rawValue = span[selectedIndex];
+                            ushort alignedValue = (ushort)(rawValue ^ 0x8000);
+                            Unsafe.As<byte, ushort>(ref byteOffset) = alignedValue;
+                        }
+                        else
+                        {
+                            Unsafe.As<byte, ushort>(ref byteOffset) = 0;
+                        }
+                    }
+                }
+
+                return 2;
             }
         }
 
@@ -597,6 +681,49 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             {
                 return CompareColumnStateBuilder.Create(ArrowTypeId.Int32);
             }
+
+            public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, ReadOnlySpan<int> selectionVector)
+            {
+                ReadOnlySpan<int> span = _list.Span;
+                ref RadixItem itemsRef = ref MemoryMarshal.GetReference(items);
+
+                if (selectionVector.IsEmpty)
+                {
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                        int rawValue = span[item.Index];
+
+                        uint alignedValue = (uint)rawValue ^ 0x80000000u;
+
+                        ref byte byteOffset = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+                        Unsafe.As<byte, uint>(ref byteOffset) = alignedValue;
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                        int selectedIndex = selectionVector[item.Index];
+
+                        ref byte byteOffset = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+
+                        if (selectedIndex >= 0)
+                        {
+                            int rawValue = span[selectedIndex];
+                            uint alignedValue = (uint)rawValue ^ 0x80000000u;
+                            Unsafe.As<byte, uint>(ref byteOffset) = alignedValue;
+                        }
+                        else
+                        {
+                            Unsafe.As<byte, uint>(ref byteOffset) = 0u;
+                        }
+                    }
+                }
+
+                return 4;
+            }
         }
 
         private sealed class Int64Data : IIntData
@@ -765,6 +892,49 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
             public CompareColumnState GetColumnState()
             {
                 return CompareColumnStateBuilder.Create(ArrowTypeId.Int64);
+            }
+
+            public int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, ReadOnlySpan<int> selectionVector)
+            {
+                ReadOnlySpan<long> span = _list.Span;
+                ref RadixItem itemsRef = ref MemoryMarshal.GetReference(items);
+
+                if (selectionVector.IsEmpty)
+                {
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                        long rawValue = span[item.Index];
+
+                        ulong alignedValue = (ulong)rawValue ^ 0x8000000000000000ul;
+
+                        ref byte byteOffset = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+                        Unsafe.As<byte, ulong>(ref byteOffset) = alignedValue;
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        ref RadixItem item = ref Unsafe.Add(ref itemsRef, i);
+                        int selectedIndex = selectionVector[item.Index];
+
+                        ref byte byteOffset = ref Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), insertBytePosition);
+
+                        if (selectedIndex >= 0)
+                        {
+                            long rawValue = span[selectedIndex];
+                            ulong alignedValue = (ulong)rawValue ^ 0x8000000000000000ul;
+                            Unsafe.As<byte, ulong>(ref byteOffset) = alignedValue;
+                        }
+                        else
+                        {
+                            Unsafe.As<byte, ulong>(ref byteOffset) = 0ul;
+                        }
+                    }
+                }
+
+                return 8;
             }
         }
 
@@ -1273,6 +1443,36 @@ namespace FlowtideDotNet.Core.ColumnStore.DataColumns
                     cumulativeMass += elementSize;
                 }
             }
+        }
+
+        RadixCapability IDataColumn.SupportsRadixSort(int bytesLeft)
+        {
+            if (_data != null)
+            {
+                switch (_data.BitWidth)
+                {
+                    case 8:
+                        return bytesLeft >= 1 ? RadixCapability.Full(1) : RadixCapability.None();
+                    case 16:
+                        return bytesLeft >= 2 ? RadixCapability.Full(2) : RadixCapability.None();
+                    case 32:
+                        return bytesLeft >= 4 ? RadixCapability.Full(4) : RadixCapability.None();
+                    case 64:
+                        return bytesLeft >= 8 ? RadixCapability.Full(8) : RadixCapability.None();
+                    default:
+                        return RadixCapability.None();
+                }
+            }
+            return RadixCapability.None();
+        }
+
+        int IDataColumn.SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, ReadOnlySpan<int> selectionVector)
+        {
+            if (_data != null) 
+            { 
+                return _data.SetRadixPrefix(items, insertBytePosition, selectionVector);
+            }
+            return 0;
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/IColumn.cs
@@ -106,6 +106,20 @@ namespace FlowtideDotNet.Core.ColumnStore
             System.Linq.Expressions.Expression selfComparePointerExpression,
             System.Linq.Expressions.Expression xExpression,
             System.Linq.Expressions.Expression yExpression);
+
+        RadixCapability SupportsRadixSort(int bytesLeft, bool hasNullByte);
+
+        int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="items"></param>
+        /// <param name="insertBytePosition"></param>
+        /// <param name="nullBytePosition">-1 if null byte has not been assigned, otherwise the position of the null byte.</param>
+        /// <param name="selectionVector"></param>
+        /// <returns></returns>
+        int SetRadixPrefix(Span<RadixItem> items, int insertBytePosition, int nullBytePosition, Span<int> selectionVector);
     }
 }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSortCompiler.cs
@@ -152,7 +152,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             return lambda;
         }
 
-        public static BlockExpression Compile(IColumn[] columns, Expression contextParameter, Expression xParameter, Expression yParameter)
+        public static BlockExpression Compile(IColumn[] columns, Expression contextParameter, Expression xParameter, Expression yParameter, int startColumnIndex)
         {
             var pointersField = typeof(SortCompareContext).GetField(nameof(SortCompareContext.pointers))!;
             var columnsField = typeof(SortCompareContext).GetField(nameof(SortCompareContext.columns))!;
@@ -164,7 +164,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             var compareResultVar = Expression.Variable(typeof(int), "compareResult");
             var bodyExpressions = new List<Expression>();
 
-            for (int i = 0; i < columns.Length && i < 7; i++)
+            for (int i = startColumnIndex; i < columns.Length && i < 7; i++)
             {
                 var column = columns[i];
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSorter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSorter.cs
@@ -28,6 +28,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
     internal class BatchSorter
     {
         private readonly SelfComparePointers[] _pointers;
+        private RadixItem[] _radixItems = Array.Empty<RadixItem>();
         private UInt128 _lastKey = 0;
         private SortCompiler.SortDelegate? _lastSort;
         private SortCompiler.SortWithTagsDelegate? _lastSortWithTags;
@@ -55,7 +56,14 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
                 }
             }
 
-            _lastSort(new SortCompareContext(columns, _pointers), ref indirect);
+            if (_radixItems.Length < indirect.Length)
+            {
+                _radixItems = new RadixItem[indirect.Length];
+            }
+
+            var radixItemsSpan = _radixItems.AsSpan(0, indirect.Length);
+
+            _lastSort(new SortCompareContext(columns, _pointers), ref indirect, ref radixItemsSpan);
         }
 
         /// <summary>

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSorter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/BatchSorter.cs
@@ -90,7 +90,14 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
                     columns[i].SetSelfComparePointers(ref _pointers[i]);
                 }
             }
-            _lastSortWithTags(new SortCompareContext(columns, _pointers), ref indirect, ref tags);
+
+            if (_radixItems.Length < indirect.Length)
+            {
+                _radixItems = new RadixItem[indirect.Length];
+            }
+
+            var radixItemsSpan = _radixItems.AsSpan(0, indirect.Length);
+            _lastSortWithTags(new SortCompareContext(columns, _pointers), ref indirect, ref tags, ref radixItemsSpan);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/ComparerStructCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/ComparerStructCompiler.cs
@@ -48,7 +48,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             return builder;
         }
 
-        public static Type Compile(IColumn[] columns)
+        public static Type Compile(IColumn[] columns, int columnStartIndex)
         {
             lock (s_lock)
             {
@@ -94,7 +94,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
                 var x = Expression.Parameter(typeof(int), "x");
                 var y = Expression.Parameter(typeof(int), "y");
 
-                var block = BatchSortCompiler.Compile(columns, ctxParam, x, y);
+                var block = BatchSortCompiler.Compile(columns, ctxParam, x, y, columnStartIndex);
 
                 var success = Expression.Lambda(block, ctxParam, x, y).CompileFastToIL(staticGen);
                 if (!success) throw new InvalidOperationException("FEC failed to compile.");

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/ComparerStructCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/ComparerStructCompiler.cs
@@ -38,13 +38,20 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
                 s_assemblyName,
                 AssemblyBuilderAccess.Run
             );
-            var ignoresAccessChecksTo = new CustomAttributeBuilder
-            (
-                typeof(IgnoresAccessChecksToAttribute).GetConstructor(new Type[] { typeof(string) }),
-                new object[] { typeof(ComparerStructCompiler).Assembly.GetName().Name }
-            );
+            var ctor = typeof(IgnoresAccessChecksToAttribute).GetConstructor(new Type[] { typeof(string) });
+            var assemblyName = typeof(ComparerStructCompiler).Assembly.GetName().Name;
 
-            builder.SetCustomAttribute(ignoresAccessChecksTo);
+            if (ctor != null && assemblyName != null)
+            {
+                var ignoresAccessChecksTo = new CustomAttributeBuilder
+                (
+                    ctor,
+                    new object[] { assemblyName }
+                );
+
+                builder.SetCustomAttribute(ignoresAccessChecksTo);
+            }
+           
             return builder;
         }
 

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/HybridRadixSorter.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/HybridRadixSorter.cs
@@ -1,0 +1,95 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.ColumnStore.Sort
+{
+    public static class HybridRadixSorter
+    {
+        [SkipLocalsInit]
+        public static void SortBatch(Span<RadixItem> data, int bytePasses)
+        {
+            if (data.Length <= 1 || bytePasses == 0) return;
+
+            RadixItem[] destArray = ArrayPool<RadixItem>.Shared.Rent(data.Length);
+            Span<RadixItem> dest = destArray.AsSpan(0, data.Length);
+
+            Span<RadixItem> currentSource = data;
+            Span<RadixItem> currentDest = dest;
+
+            Span<int> histograms = stackalloc int[3072];
+            histograms.Clear();
+
+            ref RadixItem sourceRef = ref MemoryMarshal.GetReference(currentSource);
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                ref RadixItem item = ref Unsafe.Add(ref sourceRef, i);
+
+                for (int pass = 0; pass < bytePasses; pass++)
+                {
+                    int byteVal = Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), pass);
+                    histograms[(pass << 8) + byteVal]++;
+                }
+            }
+
+            ref RadixItem destRef = ref MemoryMarshal.GetReference(currentDest);
+
+            for (int pass = 0; pass < bytePasses; pass++)
+            {
+                int histogramOffset = pass << 8;
+                int offset = 0;
+                Span<int> passHistogram = histograms.Slice(histogramOffset, 256);
+
+                for (int i = 0; i < 256; i++)
+                {
+                    int count = passHistogram[i];
+                    passHistogram[i] = offset;
+                    offset += count;
+                }
+
+                for (int i = 0; i < currentSource.Length; i++)
+                {
+                    ref RadixItem item = ref Unsafe.Add(ref sourceRef, i);
+
+                    int byteVal = Unsafe.Add(ref Unsafe.As<RadixItem, byte>(ref item), pass);
+                    int destIndex = passHistogram[byteVal]++;
+
+                    Unsafe.Add(ref destRef, destIndex) = item;
+                }
+
+                Span<RadixItem> temp = currentSource;
+                currentSource = currentDest;
+                currentDest = temp;
+
+                ref RadixItem tempRef = ref sourceRef;
+                sourceRef = ref destRef;
+                destRef = ref tempRef;
+            }
+
+            if (bytePasses % 2 != 0)
+            {
+                currentSource.CopyTo(data);
+            }
+
+            ArrayPool<RadixItem>.Shared.Return(destArray);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/RadixCapability.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/RadixCapability.cs
@@ -1,0 +1,36 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.ColumnStore.Sort
+{
+    public readonly struct RadixCapability
+    {
+        public readonly RadixSupport Support;
+        public readonly int BytesConsumed;
+
+        public RadixCapability(RadixSupport support, int bytesConsumed)
+        {
+            Support = support;
+            BytesConsumed = bytesConsumed;
+        }
+
+        public static RadixCapability None() => new RadixCapability(RadixSupport.None, 0);
+        public static RadixCapability Full(int bytes) => new RadixCapability(RadixSupport.Full, bytes);
+        public static RadixCapability Partial(int bytes) => new RadixCapability(RadixSupport.Partial, bytes);
+    }
+}

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/RadixItem.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/RadixItem.cs
@@ -1,9 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Core.ColumnStore.Sort
 {

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/RadixItem.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/RadixItem.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.ColumnStore.Sort
+{
+    [StructLayout(LayoutKind.Explicit, Size = 16)]
+    public struct RadixItem
+    {
+        // Evaluated first (Passes 0-3). Least significant sort order.
+        [FieldOffset(0)] public uint SecondaryKey;
+
+        // Evaluated last (Passes 4-11). Dominant sort order.
+        [FieldOffset(4)] public ulong PrimaryKey;
+
+        // Ignored by Radix passes. Travels safely with the struct.
+        [FieldOffset(12)] public int Index;
+    }
+}

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/RadixSupport.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/RadixSupport.cs
@@ -1,0 +1,27 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Core.ColumnStore.Sort
+{
+    public enum RadixSupport
+    {
+        None,       // Cannot be radix packed at all (Lists, Maps)
+        Partial,    // Can pack a prefix, but ties REQUIRE a full re-evaluation (Strings)
+        Full        // Completely absorbed by the Radix pass. Ties are true ties.
+    }
+}

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -470,8 +470,10 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             }
 
             int availableBytes = AvailableBytesRadix;
-            int currentBytePosition = 0;
-
+            
+            // First pass: calculate total bytes used and list bytes used per column
+            int totalBytes = 0;
+            var listBytesUsed = new List<int>();
             for (int i = 0; i < columns.Length; i++)
             {
                 var column = columns[i];
@@ -479,24 +481,34 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
 
                 if (capability.Support == RadixSupport.Full || capability.Support == RadixSupport.Partial)
                 {
-                    var columnInstanceExpr = Expression.ArrayIndex(columnsExpression, Expression.Constant(i));
-                    var positionExpr = Expression.Constant(currentBytePosition, typeof(int));
-                    var callExpr = Expression.Call(
-                        columnInstanceExpr,
-                        setRadixMethod,
-                        workspaceExpression,
-                        positionExpr);
-
-                    methodCalls.Add(callExpr);
-
                     int bytesUsed = capability.BytesConsumed;
+                    listBytesUsed.Add(bytesUsed);
                     availableBytes -= bytesUsed;
-                    currentBytePosition += bytesUsed;
+                    totalBytes += bytesUsed;
                 }
                 else
                 {
                     break;
                 }
+            }
+
+            // Second pass: generate expressions with correct reverse byte positions
+            int cumulativeBytes = 0;
+            for (int i = 0; i < listBytesUsed.Count; i++)
+            {
+                int bytesUsed = listBytesUsed[i];
+                cumulativeBytes += bytesUsed;
+                int currentBytePosition = totalBytes - cumulativeBytes;
+
+                var columnInstanceExpr = Expression.ArrayIndex(columnsExpression, Expression.Constant(i));
+                var positionExpr = Expression.Constant(currentBytePosition, typeof(int));
+                var callExpr = Expression.Call(
+                    columnInstanceExpr,
+                    setRadixMethod,
+                    workspaceExpression,
+                    positionExpr);
+
+                methodCalls.Add(callExpr);
             }
 
             var block = Expression.Block(methodCalls);

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
@@ -474,7 +474,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             // First pass: calculate total bytes used and list bytes used per column
             int totalBytes = 0;
             var listBytesUsed = new List<int>();
-            for (int i = 0; i < columns.Length; i++)
+            for (int i = 0; i < columns.Length && i < 7; i++)
             {
                 var column = columns[i];
                 var capability = column.SupportsRadixSort(availableBytes, false);

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
@@ -25,7 +25,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
     {
         public delegate void SortDelegate(SortCompareContext context, ref Span<int> indices, ref Span<RadixItem> radixItems);
 
-        public delegate void SortWithTagsDelegate(SortCompareContext context, ref Span<int> indices, ref Span<int> tags);
+        public delegate void SortWithTagsDelegate(SortCompareContext context, ref Span<int> indices, ref Span<int> tags, ref Span<RadixItem> radixItems);
 
         private static readonly ConcurrentDictionary<UInt128, SortDelegate> _cache = new ConcurrentDictionary<UInt128, SortDelegate>();
 
@@ -215,11 +215,49 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
 
         private static SortWithTagsDelegate CompileWithTags(IColumn[] columns)
         {
+            int availableBytes = AvailableBytesRadix;
+            int quicksortStartIndex = 0;
+            bool usedRadix = false;
+
+            // --- STEP 1: CAPABILITY ROUTING ---
+            for (int i = 0; i < columns.Length; i++)
+            {
+                var capability = columns[i].SupportsRadixSort(availableBytes, false);
+                availableBytes -= capability.BytesConsumed;
+
+                if (capability.Support == RadixSupport.Full)
+                {
+                    quicksortStartIndex = i + 1;
+                    usedRadix = true;
+                }
+                else if (capability.Support == RadixSupport.Partial)
+                {
+                    // Radix grouped the prefix. Quicksort MUST start here to resolve string ties
+                    quicksortStartIndex = i;
+                    usedRadix = true;
+                    break;
+                }
+                else
+                {
+                    // RadixSupport.None. Quicksort starts here.
+                    quicksortStartIndex = i;
+                    break;
+                }
+            }
+
+            if (usedRadix)
+            {
+                int bytePasses = AvailableBytesRadix - availableBytes;
+                return CompileWithTagsRadix(columns, quicksortStartIndex, bytePasses);
+            }
+
             var comparerType = ComparerStructCompiler.Compile(columns, 0);
 
             var parameter = Expression.Parameter(typeof(SortCompareContext), "context");
             var indicesParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "indices");
             var tagsParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "tags");
+
+            var radixWorkspaceParam = Expression.Parameter(typeof(Span<RadixItem>).MakeByRefType(), "workspace");
 
             var ctor = comparerType.GetConstructor([typeof(SortCompareContext)]);
 
@@ -230,7 +268,9 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
 
             var newExpr = Expression.New(ctor, parameter);
 
-            var doSort = typeof(SortCompiler).GetMethod(nameof(DoSortWithTags), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+            var doSort = typeof(SortCompiler).GetMethod(
+                nameof(DoSortWithTags),
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
 
             if (doSort == null)
             {
@@ -239,7 +279,72 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
 
             var callSort = Expression.Call(doSort.MakeGenericMethod(comparerType), indicesParameter, tagsParameter, newExpr);
 
-            var lambda = Expression.Lambda<SortWithTagsDelegate>(callSort, parameter, indicesParameter, tagsParameter);
+            var lambda = Expression.Lambda<SortWithTagsDelegate>(
+                callSort,
+                parameter,
+                indicesParameter,
+                tagsParameter,
+                radixWorkspaceParam
+            );
+
+            return lambda.Compile();
+        }
+
+        private static SortWithTagsDelegate CompileWithTagsRadix(IColumn[] columns, int quicksortStartIndex, int bytePasses)
+        {
+            var comparerType = ComparerStructCompiler.Compile(columns, quicksortStartIndex);
+
+            var contextParam = Expression.Parameter(typeof(SortCompareContext), "context");
+            var indicesParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "indices");
+            var tagsParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "tags");
+
+            var radixWorkspaceParam = Expression.Parameter(typeof(Span<RadixItem>).MakeByRefType(), "workspace");
+
+            var columnsField = Expression.Field(contextParam, nameof(SortCompareContext.columns));
+            var executionSteps = new List<Expression>();
+
+            executionSteps.Add(CallResetRadixItems(radixWorkspaceParam, indicesParameter));
+
+            Expression invokeExtractor = CompileRadixExtractor(columns, radixWorkspaceParam, columnsField);
+            executionSteps.Add(invokeExtractor);
+
+            var ctor = comparerType.GetConstructor([typeof(SortCompareContext)]);
+            if (ctor == null)
+            {
+                throw new InvalidOperationException($"Comparer struct {comparerType.FullName} does not have the expected constructor.");
+            }
+            var newComparerExpr = Expression.New(ctor, contextParam);
+
+            var doSortRadixMethod = typeof(SortCompiler).GetMethod(
+                nameof(DoSortRadixWithTags),
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+
+            if (doSortRadixMethod == null)
+            {
+                throw new InvalidOperationException($"Could not find method {nameof(DoSortRadixWithTags)}.");
+            }
+
+            var callSortRadix = Expression.Call(
+                doSortRadixMethod.MakeGenericMethod(comparerType),
+                Expression.Constant(bytePasses),
+                Expression.Constant(quicksortStartIndex < columns.Length),
+                radixWorkspaceParam,
+                indicesParameter,
+                tagsParameter,
+                newComparerExpr
+            );
+
+            executionSteps.Add(callSortRadix);
+
+            var masterBlock = Expression.Block(executionSteps);
+
+            var lambda = Expression.Lambda<SortWithTagsDelegate>(
+                masterBlock,
+                contextParam,
+                indicesParameter,
+                tagsParameter,
+                radixWorkspaceParam
+            );
 
             return lambda.Compile();
         }

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
@@ -220,7 +220,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             bool usedRadix = false;
 
             // --- STEP 1: CAPABILITY ROUTING ---
-            for (int i = 0; i < columns.Length; i++)
+            for (int i = 0; i < columns.Length && i < 7; i++)
             {
                 var capability = columns[i].SupportsRadixSort(availableBytes, false);
                 availableBytes -= capability.BytesConsumed;

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
@@ -23,7 +23,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
 {
     internal static class SortCompiler
     {
-        public delegate void SortDelegate(SortCompareContext context, ref Span<int> indices);
+        public delegate void SortDelegate(SortCompareContext context, ref Span<int> indices, ref Span<RadixItem> radixItems);
 
         public delegate void SortWithTagsDelegate(SortCompareContext context, ref Span<int> indices, ref Span<int> tags);
 
@@ -57,11 +57,48 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             return _cache.GetOrAdd<IColumn[]>(key, static (key, args) => Compile(args), columns);
         }
 
+        public const int AvailableBytesRadix = 12;
+
         private static SortDelegate Compile(IColumn[] columns)
         {
-            var comparerType = ComparerStructCompiler.Compile(columns);
+            int availableBytes = AvailableBytesRadix;
+            int quicksortStartIndex = 0;
+            bool usedRadix = false;
+
+            for (int i = 0; i < columns.Length; i++)
+            {
+                var capability = columns[i].SupportsRadixSort(availableBytes, false);
+                availableBytes -= capability.BytesConsumed;
+                if (capability.Support == RadixSupport.Full)
+                {
+                    quicksortStartIndex = i + 1;
+                    usedRadix = true;
+                }
+                else if (capability.Support == RadixSupport.Partial)
+                {
+                    // Radix grouped the prefix. Quicksort MUST start here to resolve string ties
+                    quicksortStartIndex = i;
+                    usedRadix = true;
+                    break;
+                }
+                else
+                {
+                    // RadixSupport.None. Quicksort starts here.
+                    quicksortStartIndex = i;
+                    break;
+                }
+            }
+
+            if (usedRadix)
+            {
+                int bytePasses = AvailableBytesRadix - availableBytes;
+                return CompileWithRadix(columns, quicksortStartIndex, bytePasses);
+            }
+
+            var comparerType = ComparerStructCompiler.Compile(columns, 0);
             
             var parameter = Expression.Parameter(typeof(SortCompareContext), "context");
+            var radixWorkspaceParam = Expression.Parameter(typeof(Span<RadixItem>).MakeByRefType(), "workspace");
             var indicesParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "indices");
 
             var ctor = comparerType.GetConstructor([typeof(SortCompareContext)]);
@@ -80,7 +117,56 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
 
             var callSort = Expression.Call(doSort.MakeGenericMethod(comparerType), indicesParameter, newExpr);
 
-            var lambda = Expression.Lambda<SortDelegate>(callSort, parameter, indicesParameter);
+            var lambda = Expression.Lambda<SortDelegate>(callSort, parameter, indicesParameter, radixWorkspaceParam);
+
+            return lambda.Compile();
+        }
+
+        private static SortDelegate CompileWithRadix(IColumn[] columns, int quicksortStartIndex, int bytePasses)
+        {
+            var comparerType = ComparerStructCompiler.Compile(columns, quicksortStartIndex);
+
+            var contextParam = Expression.Parameter(typeof(SortCompareContext), "context");
+            var radixWorkspaceParam = Expression.Parameter(typeof(Span<RadixItem>).MakeByRefType(), "workspace");
+            var indicesParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "indices");
+
+            var columnsField = Expression.Field(contextParam, nameof(SortCompareContext.columns));
+            var executionSteps = new List<Expression>();
+
+            executionSteps.Add(CallResetRadixItems(radixWorkspaceParam, indicesParameter));
+
+            Expression invokeExtractor = CompileRadixExtractor(columns, radixWorkspaceParam, columnsField);
+            executionSteps.Add(invokeExtractor);
+
+            var ctor = comparerType.GetConstructor([typeof(SortCompareContext)]);
+            if (ctor == null) throw new InvalidOperationException($"Comparer struct {comparerType.FullName} is missing a constructor.");
+            var newComparerExpr = Expression.New(ctor, contextParam);
+
+            var doSortRadixMethod = typeof(SortCompiler).GetMethod(
+                nameof(DoSortWithRadix),
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+
+            if (doSortRadixMethod == null) throw new InvalidOperationException("Could not find DoSortWithRadix method.");
+
+            var callSortRadix = Expression.Call(
+                doSortRadixMethod.MakeGenericMethod(comparerType),
+                Expression.Constant(bytePasses),
+                Expression.Constant(quicksortStartIndex < columns.Length),
+                radixWorkspaceParam,
+                indicesParameter,
+                newComparerExpr
+            );
+
+            executionSteps.Add(callSortRadix);
+
+            var masterBlock = Expression.Block(executionSteps);
+
+            var lambda = Expression.Lambda<SortDelegate>(
+                masterBlock,
+                contextParam,
+                indicesParameter,
+                radixWorkspaceParam
+            );
 
             return lambda.Compile();
         }
@@ -90,6 +176,38 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             IntroSort.Sort(indices, ref comparer);
         }
 
+        public static void DoSortWithRadix<TComparer>(int bytePasses, bool tieNeeded, ref Span<RadixItem> radixItems, ref Span<int> indices, TComparer comparer) where TComparer : struct, IComparer<int>
+        {
+            HybridRadixSorter.SortBatch(radixItems, bytePasses);
+
+            for (int i = 0; i < indices.Length; i++)
+            {
+                indices[i] = radixItems[i].Index;
+            }
+
+            if (tieNeeded)
+            {
+                int length = indices.Length;
+                int start = 0;
+
+                for (int i = 1; i <= length; i++)
+                {
+                    if (i == length ||
+                        radixItems[i].PrimaryKey != radixItems[start].PrimaryKey ||
+                        radixItems[i].SecondaryKey != radixItems[start].SecondaryKey)
+                    {
+                        int tieLength = i - start;
+                        if (tieLength > 1)
+                        {
+                            Span<int> tiedIndices = indices.Slice(start, tieLength);
+                            IntroSort.Sort(tiedIndices, ref comparer);
+                        }
+                        start = i;
+                    }
+                }
+            }
+        }
+
         public static SortWithTagsDelegate GetOrCompileWithTags(UInt128 key, IColumn[] columns)
         {
             return _tagsCache.GetOrAdd(key, static (key, args) => CompileWithTags(args), columns);
@@ -97,7 +215,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
 
         private static SortWithTagsDelegate CompileWithTags(IColumn[] columns)
         {
-            var comparerType = ComparerStructCompiler.Compile(columns);
+            var comparerType = ComparerStructCompiler.Compile(columns, 0);
 
             var parameter = Expression.Parameter(typeof(SortCompareContext), "context");
             var indicesParameter = Expression.Parameter(typeof(Span<int>).MakeByRefType(), "indices");
@@ -144,6 +262,140 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
                 }
                 tags[i] = currentGroup;
             }
+        }
+
+        public static void DoSortRadixWithTags<TComparer>(int bytePasses, bool tieNeeded, ref Span<RadixItem> radixItems, ref Span<int> indices, ref Span<int> tags, TComparer comparer) where TComparer : struct, IComparer<int>
+        {
+            HybridRadixSorter.SortBatch(radixItems, bytePasses);
+
+            for (int i = 0; i < indices.Length; i++)
+            {
+                indices[i] = radixItems[i].Index;
+            }
+            int length = indices.Length;
+            if (length == 0) return;
+            
+            int start = 0;
+            int currentGroup = 0;
+
+            for (int i = 1; i <= length; i++)
+            {
+                bool isTieBreak = i == length ||
+                    Unsafe.As<RadixItem, ulong>(ref radixItems[i]) != Unsafe.As<RadixItem, ulong>(ref radixItems[start]) ||
+                    Unsafe.Add(ref Unsafe.As<RadixItem, uint>(ref radixItems[i]), 2) != Unsafe.Add(ref Unsafe.As<RadixItem, uint>(ref radixItems[start]), 2);
+
+                if (isTieBreak)
+                {
+                    int tieLength = i - start;
+
+                    if (start == 0)
+                    {
+                        tags[0] = currentGroup;
+                    }
+                    else
+                    {
+                        currentGroup++;
+                        tags[start] = currentGroup;
+                    }
+
+                    if (tieLength > 1)
+                    {
+                        if (tieNeeded)
+                        {
+                            Span<int> tiedIndices = indices.Slice(start, tieLength);
+                            IntroSort.Sort(tiedIndices, ref comparer);
+
+                            for (int j = start + 1; j < i; j++)
+                            {
+                                if (comparer.Compare(indices[j - 1], indices[j]) != 0)
+                                {
+                                    currentGroup++;
+                                }
+                                tags[j] = currentGroup;
+                            }
+                        }
+                        else
+                        {
+                            for (int j = start + 1; j < i; j++)
+                            {
+                                tags[j] = currentGroup;
+                            }
+                        }
+                    }
+
+                    start = i;
+                }
+            }
+        }
+
+        public delegate void ExtractRadixDelegate(ref Span<RadixItem> workspace, IColumn[] columns);
+
+        private static void ResetRadixItems(ref Span<RadixItem> items, ref Span<int> indices)
+        {
+            for (int i = 0; i < items.Length; i++)
+            {
+                items[i] = new RadixItem()
+                {
+                    SecondaryKey = 0,
+                    PrimaryKey = 0,
+                    Index = indices[i]
+                };
+            }
+        }
+
+        private static Expression CallResetRadixItems(Expression radixItems, Expression indices)
+        {
+            var method = typeof(SortCompiler).GetMethod(nameof(ResetRadixItems), System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            if (method == null)
+            {
+                throw new InvalidOperationException($"Could not find method {nameof(ResetRadixItems)} on {typeof(SortCompiler).FullName}.");
+            }
+            return Expression.Call(method, radixItems, indices);
+        }
+
+        public static Expression CompileRadixExtractor(IColumn[] columns, Expression workspaceExpression, Expression columnsExpression)
+        {
+            var methodCalls = new List<Expression>();
+
+            var setRadixMethod = typeof(IColumn).GetMethod(nameof(IColumn.SetRadixPrefix), [typeof(Span<RadixItem>), typeof(int)]);
+
+            if (setRadixMethod == null)
+            {
+                throw new InvalidOperationException($"Could not find method {nameof(IColumn.SetRadixPrefix)} on {typeof(IColumn).FullName}.");
+            }
+
+            int availableBytes = AvailableBytesRadix;
+            int currentBytePosition = 0;
+
+            for (int i = 0; i < columns.Length; i++)
+            {
+                var column = columns[i];
+                var capability = column.SupportsRadixSort(availableBytes, false);
+
+                if (capability.Support == RadixSupport.Full || capability.Support == RadixSupport.Partial)
+                {
+                    var columnInstanceExpr = Expression.ArrayIndex(columnsExpression, Expression.Constant(i));
+                    var positionExpr = Expression.Constant(currentBytePosition, typeof(int));
+                    var callExpr = Expression.Call(
+                        columnInstanceExpr,
+                        setRadixMethod,
+                        workspaceExpression,
+                        positionExpr);
+
+                    methodCalls.Add(callExpr);
+
+                    int bytesUsed = capability.BytesConsumed;
+                    availableBytes -= bytesUsed;
+                    currentBytePosition += bytesUsed;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            var block = Expression.Block(methodCalls);
+            return block;
         }
     }
 }

--- a/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Sort/SortCompiler.cs
@@ -65,7 +65,7 @@ namespace FlowtideDotNet.Core.ColumnStore.Sort
             int quicksortStartIndex = 0;
             bool usedRadix = false;
 
-            for (int i = 0; i < columns.Length; i++)
+            for (int i = 0; i < columns.Length && i < 7; i++)
             {
                 var capability = columns[i].SupportsRadixSort(availableBytes, false);
                 availableBytes -= capability.BytesConsumed;

--- a/src/FlowtideDotNet.Core/Operators/Filter/ColumnFilterOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Filter/ColumnFilterOperator.cs
@@ -57,6 +57,7 @@ namespace FlowtideDotNet.Core.Operators.Filter
             PrimitiveList<int> weights = new PrimitiveList<int>(MemoryAllocator);
             PrimitiveList<uint> iterations = new PrimitiveList<uint>(MemoryAllocator);
 
+            bool _notEmitted = false;
             var data = msg.Data;
             for (int i = 0; i < data.Count; i++)
             {
@@ -65,6 +66,10 @@ namespace FlowtideDotNet.Core.Operators.Filter
                     weights.Add(data.Weights[i]);
                     iterations.Add(data.Iterations[i]);
                     offsets.Add(i);
+                }
+                else
+                {
+                    _notEmitted = true;
                 }
             }
 
@@ -75,10 +80,19 @@ namespace FlowtideDotNet.Core.Operators.Filter
                 for (int i = 0; i < _filterRelation.Emit.Count; i++)
                 {
                     var emitIndex = _filterRelation.Emit[i];
-                    outputColumns[i] = ColumnWithOffset.CreateFlattened(data.EventBatchData.Columns[emitIndex], offsets, MemoryAllocator, out var offsetUsed);
-                    if (offsetUsed)
+                    if (!_notEmitted)
                     {
-                        shouldDisposeOffset = false;
+                        // if all rows are emitted, we can reuse the original column without flattening
+                        outputColumns[i] = data.EventBatchData.Columns[emitIndex];
+                        continue;
+                    }
+                    else
+                    {
+                        outputColumns[i] = ColumnWithOffset.CreateFlattened(data.EventBatchData.Columns[emitIndex], offsets, MemoryAllocator, out var offsetUsed);
+                        if (offsetUsed)
+                        {
+                            shouldDisposeOffset = false;
+                        }
                     }
                 }
                 if (shouldDisposeOffset)

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -266,6 +266,46 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             return targetId == 0 ? OnRecieveLeft(msg, time) : OnRecieveRight(msg, time);
         }
 
+        private void CopyCollectedIndices(
+            List<Column> columns,
+            List<int> outputColumns,
+            EventBatchData leafData,
+            PrimitiveList<int> leafIndicesToCopy,
+            PrimitiveList<int> targetPositions)
+        {
+            if (leafIndicesToCopy.Count == 0) return;
+
+            if (columns.Count == 0)
+            {
+                leafIndicesToCopy.Clear();
+                return;
+            }
+
+            int count = leafIndicesToCopy.Count;
+            int initialCount = columns[0].Count;
+
+            targetPositions.Clear();
+            targetPositions.EnsureCapacity(count);
+            for (int i = 0; i < count; i++)
+            {
+                targetPositions.Add(initialCount);
+            }
+
+            ReadOnlySpan<int> sortedLookupSpan = leafIndicesToCopy.Span;
+            ReadOnlySpan<int> targetPositionsSpan = targetPositions.Span;
+
+            for (int z = 0; z < columns.Count; z++)
+            {
+                columns[z].InsertFrom(
+                    leafData.Columns[outputColumns[z]],
+                    in sortedLookupSpan,
+                    in targetPositionsSpan,
+                    ColumnWithOffset.NullValueIndex);
+            }
+
+            leafIndicesToCopy.Clear();
+        }
+
         private async IAsyncEnumerable<StreamEventBatch> OnRecieveLeft(StreamEventBatch msg, long time)
         {
             Debug.Assert(_rightTree != null);
@@ -280,6 +320,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             PrimitiveList<int> foundOffsets = new PrimitiveList<int>(memoryManager, keyLength);
             PrimitiveList<int> weights = new PrimitiveList<int>(memoryManager, keyLength);
             PrimitiveList<uint> iterations = new PrimitiveList<uint>(memoryManager, keyLength);
+
+            PrimitiveList<int> leafIndicesToCopy = new PrimitiveList<int>(memoryManager, keyLength);
+            PrimitiveList<int> targetPositions = new PrimitiveList<int>(memoryManager, keyLength);
 
             for (int i = 0; i < _rightOutputColumns.Count; i++)
             {
@@ -340,11 +383,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                         int outWeight = joinStorageValue.weight * weight;
                         insertValues[keyIndex].joinWeight += outWeight;
 
-                        for (int z = 0; z < rightColumns.Count; z++)
-                        {
-                            pageKeyStorage._data.Columns[_rightOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
-                            rightColumns[z].Add(_dataValueContainer);
-                        }
+                        leafIndicesToCopy.Add(k);
                         foundOffsets.Add(keyIndex);
                         iterations.Add(msg.Data.Iterations[keyIndex]);
                         weights.Add(outWeight);
@@ -354,11 +393,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                             pageUpdated = true;
                             if (joinStorageValue.joinWeight == 0)
                             {
-                                for (int z = 0; z < rightColumns.Count; z++)
-                                {
-                                    pageKeyStorage._data.Columns[_rightOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
-                                    rightColumns[z].Add(_dataValueContainer);
-                                }
+                                leafIndicesToCopy.Add(k);
                                 foundOffsets.Add(ColumnWithOffset.NullValueIndex);
                                 weights.Add(-joinStorageValue.weight);
                                 iterations.Add(msg.Data.Iterations[keyIndex]);
@@ -368,11 +403,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                             if (joinStorageValue.joinWeight == 0)
                             {
-                                for (int z = 0; z < rightColumns.Count; z++)
-                                {
-                                    pageKeyStorage._data.Columns[_rightOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
-                                    rightColumns[z].Add(_dataValueContainer);
-                                }
+                                leafIndicesToCopy.Add(k);
                                 foundOffsets.Add(ColumnWithOffset.NullValueIndex);
                                 weights.Add(joinStorageValue.weight);
                                 iterations.Add(msg.Data.Iterations[keyIndex]);
@@ -380,18 +411,22 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                             
                             pageValues.Update(k, joinStorageValue);
                         }
-
-                        if (foundOffsets.Count >= MaxRowSize)
-                        {
-                            leafNode.ExitWriteLock();
-                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, null, rightColumns, true);
-                            _eventsCounter.Add(outputBatch.Data.Weights.Count);
-                            yield return outputBatch;
-                            ResetOutputLists(ref foundOffsets, ref weights, ref iterations, null, rightColumns);
-                            leafNode.EnterWriteLock();
-                        }
                     }
                 }
+
+                CopyCollectedIndices(rightColumns, _rightOutputColumns, pageKeyStorage._data, leafIndicesToCopy, targetPositions);
+
+                // We output when a leaf is done
+                if (foundOffsets.Count >= MaxRowSize)
+                {
+                    leafNode.ExitWriteLock();
+                    var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, null, rightColumns, true);
+                    _eventsCounter.Add(outputBatch.Data.Weights.Count);
+                    yield return outputBatch;
+                    ResetOutputLists(ref foundOffsets, ref weights, ref iterations, null, rightColumns);
+                    leafNode.EnterWriteLock();
+                }
+
                 leafNode.ExitWriteLock();
                 if (pageUpdated)
                 {
@@ -446,6 +481,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 iterations.Dispose();
             }
 
+            leafIndicesToCopy.Dispose();
+            targetPositions.Dispose();
 
             await _leftInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, _duplicatesTagBuffer, new JoinWeightsMutator(_leftInputColumnCount), batchSize);
         }
@@ -464,6 +501,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             PrimitiveList<int> foundOffsets = new PrimitiveList<int>(memoryManager, keyLength);
             PrimitiveList<int> weights = new PrimitiveList<int>(memoryManager, keyLength);
             PrimitiveList<uint> iterations = new PrimitiveList<uint>(memoryManager, keyLength);
+
+            PrimitiveList<int> leafIndicesToCopy = new PrimitiveList<int>(memoryManager, keyLength);
+            PrimitiveList<int> targetPositions = new PrimitiveList<int>(memoryManager, keyLength);
 
             for (int i = 0; i < _leftOutputColumns.Count; i++)
             {
@@ -522,11 +562,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                         int outWeight = joinStorageValue.weight * weight;
                         insertValues[keyIndex].joinWeight += outWeight;
 
-                        for (int z = 0; z < leftColumns.Count; z++)
-                        {
-                            pageKeyStorage._data.Columns[_leftOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
-                            leftColumns[z].Add(_dataValueContainer);
-                        }
+                        leafIndicesToCopy.Add(k);
                         foundOffsets.Add(keyIndex);
                         iterations.Add(msg.Data.Iterations[keyIndex]);
                         weights.Add(outWeight);
@@ -536,11 +572,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                             pageUpdated = true;
                             if (joinStorageValue.joinWeight == 0)
                             {
-                                for (int z = 0; z < leftColumns.Count; z++)
-                                {
-                                    pageKeyStorage._data.Columns[_leftOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
-                                    leftColumns[z].Add(_dataValueContainer);
-                                }
+                                leafIndicesToCopy.Add(k);
                                 foundOffsets.Add(ColumnWithOffset.NullValueIndex);
                                 weights.Add(-joinStorageValue.weight);
                                 iterations.Add(msg.Data.Iterations[keyIndex]);
@@ -550,11 +582,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
                             if (joinStorageValue.joinWeight == 0)
                             {
-                                for (int z = 0; z < leftColumns.Count; z++)
-                                {
-                                    pageKeyStorage._data.Columns[_leftOutputColumns[z]].GetValueAt(k, _dataValueContainer, default);
-                                    leftColumns[z].Add(_dataValueContainer);
-                                }
+                                leafIndicesToCopy.Add(k);
                                 foundOffsets.Add(ColumnWithOffset.NullValueIndex);
                                 weights.Add(joinStorageValue.weight);
                                 iterations.Add(msg.Data.Iterations[keyIndex]);
@@ -562,18 +590,22 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                             
                             pageValues.Update(k, joinStorageValue);
                         }
-
-                        if (foundOffsets.Count >= MaxRowSize)
-                        {
-                            leafNode.ExitWriteLock();
-                            var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, leftColumns, null, false);
-                            _eventsCounter.Add(outputBatch.Data.Weights.Count);
-                            yield return outputBatch;
-                            ResetOutputLists(ref foundOffsets, ref weights, ref iterations, leftColumns, null);
-                            leafNode.EnterWriteLock();
-                        }
                     }
                 }
+
+                CopyCollectedIndices(leftColumns, _leftOutputColumns, pageKeyStorage._data, leafIndicesToCopy, targetPositions);
+
+                // We output when a leaf is done, matching OnRecieveLeft
+                if (foundOffsets.Count >= MaxRowSize)
+                {
+                    leafNode.ExitWriteLock();
+                    var outputBatch = BuildOutputBatch(msg, foundOffsets, weights, iterations, leftColumns, null, false);
+                    _eventsCounter.Add(outputBatch.Data.Weights.Count);
+                    yield return outputBatch;
+                    ResetOutputLists(ref foundOffsets, ref weights, ref iterations, leftColumns, null);
+                    leafNode.EnterWriteLock();
+                }
+
                 leafNode.ExitWriteLock();
                 if (pageUpdated)
                 {
@@ -627,6 +659,9 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 weights.Dispose();
                 iterations.Dispose();
             }
+
+            leafIndicesToCopy.Dispose();
+            targetPositions.Dispose();
 
             await _rightInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, _duplicatesTagBuffer, new JoinWeightsMutator(_rightInputColumnCount), batchSize);
         }

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -27,7 +27,7 @@ namespace FlowtideDotNet.AcceptanceTests
         [Fact]
         public async Task InnerJoinMergeJoin()
         {
-            GenerateData();
+            GenerateData(5);
             await StartStream(@"
                 INSERT INTO output 
                 SELECT 

--- a/tests/FlowtideDotNet.Benchmarks/BatchSortBenchmark.cs
+++ b/tests/FlowtideDotNet.Benchmarks/BatchSortBenchmark.cs
@@ -145,21 +145,6 @@ namespace FlowtideDotNet.Benchmarks
         }
 
         [Benchmark]
-        public void SortMethod()
-        {
-            for (int i = 0; i < Count; i++)
-            {
-                indices[i] = i;
-            }
-            for (int i = 0; i < pointers.Length; i++)
-            {
-                columns[i].SetSelfComparePointers(ref pointers[i]);
-            }
-            var span = indices.AsSpan();
-            sortMethod(new SortCompareContext(columns, pointers), ref span);
-        }
-
-        [Benchmark]
         public void BatchSorter()
         {
             for (int i = 0; i < Count; i++)

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Sort/BatchSorterTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Sort/BatchSorterTests.cs
@@ -140,15 +140,15 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Sort
                 var col = new Column(GlobalMemoryManager.Instance);
                 if (i < numColumns - 1)
                 {
-                    col.Add(new DoubleValue(1));
-                    col.Add(new DoubleValue(1));
-                    col.Add(new DoubleValue(1));
+                    col.Add(new Int64Value(1));
+                    col.Add(new Int64Value(1));
+                    col.Add(new Int64Value(1));
                 }
                 else
                 {
-                    col.Add(new DoubleValue(2));
-                    col.Add(new DoubleValue(0));
-                    col.Add(new DoubleValue(1));
+                    col.Add(new Int64Value(2));
+                    col.Add(new Int64Value(0));
+                    col.Add(new Int64Value(1));
                 }
                 columns[i] = col;
             }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/Sort/BatchSorterTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/Sort/BatchSorterTests.cs
@@ -695,5 +695,41 @@ namespace FlowtideDotNet.Core.Tests.ColumnStore.Sort
             Assert.Equal(5000000000L, column.GetValueAt(indirect[2], default).AsLong);
             Assert.Equal(1000000000000L, column.GetValueAt(indirect[3], default).AsLong);
         }
+
+        [Fact]
+        public void TestSortIntegerTwoColumnsRadix()
+        {
+            // Column 1 is integers not sorted
+            var column1 = new Column(GlobalMemoryManager.Instance);
+            column1.Add(new Int64Value(50));
+            column1.Add(new Int64Value(10));
+            column1.Add(new Int64Value(50));
+            column1.Add(new Int64Value(10));
+
+            // Column 2 is integers sorted
+            var column2 = new Column(GlobalMemoryManager.Instance);
+            column2.Add(new Int64Value(10));
+            column2.Add(new Int64Value(20));
+            column2.Add(new Int64Value(30));
+            column2.Add(new Int64Value(40));
+
+            IColumn[] columns = new IColumn[] { column1, column2 };
+            var batchSorter = new BatchSorter(2);
+
+            int[] indirect = new int[] { 0, 1, 2, 3 };
+            var span = indirect.AsSpan();
+
+            batchSorter.SortData(columns, ref span);
+
+            // Sorting by Col 1, then Col 2:
+            // Col 1 has 10 (at index 1 and 3) -> Col 2: index 1 has 20, index 3 has 40. Since 20 < 40, index 1 comes first, then 3.
+            // Col 1 has 50 (at index 0 and 2) -> Col 2: index 0 has 10, index 2 has 30. Since 10 < 30, index 0 comes first, then 2.
+            // Expected sorted indices: 1, 3, 0, 2
+            Assert.Equal(1, indirect[0]);
+            Assert.Equal(3, indirect[1]);
+            Assert.Equal(0, indirect[2]);
+            Assert.Equal(2, indirect[3]);
+        }
     }
 }
+


### PR DESCRIPTION
Add radix sort to improve sorting performance when joining on integer columns.

Also fix so output is written in bulk from leafs and not one row at the time.