### PR TITLE
Fix watermark handling in multiple input vertex regarding initial data done event

### DIFF
--- a/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -348,7 +348,7 @@ namespace FlowtideDotNet.Base.Vertices
             return new SingleAsyncEnumerable<IStreamEvent>(lockingEventPrepare);
         }
 
-        private IAsyncEnumerable<IStreamEvent> HandleInitialDataDoneEvent(int targetId, InitialDataDoneEvent initialDataDoneEvent)
+        private async IAsyncEnumerable<IStreamEvent> HandleInitialDataDoneEvent(int targetId, InitialDataDoneEvent initialDataDoneEvent)
         {
             Debug.Assert(_targetWatermarkNames != null, nameof(_targetWatermarkNames));
             Debug.Assert(_targetWatermarks != null, nameof(_targetWatermarks));
@@ -357,7 +357,7 @@ namespace FlowtideDotNet.Base.Vertices
 
             if (_initialWatermarkSent || _isInIteration)
             {
-                return EmptyAsyncEnumerable<IStreamEvent>.Instance;
+                yield break;
             }
 
             _targetSentWatermark[targetId] = true;
@@ -366,7 +366,7 @@ namespace FlowtideDotNet.Base.Vertices
             {
                 if (_targetSentDataSinceLastWatermark[i] && !_targetSentWatermark[i])
                 {
-                    return EmptyAsyncEnumerable<IStreamEvent>.Instance;
+                    yield break;
                 }
             }
             for (int i = 0; i < _targetSentDataSinceLastWatermark.Length; i++)
@@ -390,10 +390,24 @@ namespace FlowtideDotNet.Base.Vertices
             if (!hasRecievedWatermark || (_currentWatermark == null))
             {
                 // If no watermark was sent, send an empty one
-                return new SingleAsyncEnumerable<IStreamEvent>(initialDataDoneEvent);
+                yield return initialDataDoneEvent;
+                yield break;
             }
 
-            return new SingleAsyncEnumerable<IStreamEvent>(_currentWatermark);
+            if (!_currentWatermark.Equals(_previousWatermark))
+            {
+                await foreach (var e in OnWatermark(_currentWatermark))
+                {
+                    if (e is IRentable rentable)
+                    {
+                        rentable.Rent(_links.Count);
+                    }
+                    yield return new StreamMessage<T>(e, _currentTime);
+                }
+                _previousWatermark = _currentWatermark;
+            }
+
+            yield return _currentWatermark;
         }
 
         private async IAsyncEnumerable<IStreamEvent> HandleWatermark(int targetId, Watermark watermark)

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSourceOperator.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSourceOperator.cs
@@ -230,12 +230,10 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         protected override async Task SendInitial(IngressOutput<StreamEventBatch> output)
         {
             var tableName = readRelation.NamedTable.DotSeperated;
-            if (TableWaitSignals.TryGetValue(tableName, out var waitTableName))
+            if (TableWaitSignals.TryGetValue(tableName, out var waitTableName) &&
+                TableInitialSignals.TryGetValue(waitTableName, out var waitTcs))
             {
-                if (TableInitialSignals.TryGetValue(waitTableName, out var waitTcs))
-                {
-                    await waitTcs.Task;
-                }
+                await waitTcs.Task;
             }
 
             Debug.Assert(_state?.Value != null);

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSourceOperator.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSourceOperator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -40,6 +40,8 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         private MockTable _table;
         private IObjectState<MockDataSourceState>? _state;
         private BatchConverter _batchConverter;
+
+        public static Dictionary<string, TimeSpan> TableInitialDelay { get; } = new Dictionary<string, TimeSpan>();
 
         public MockDataSourceOperator(ReadRelation readRelation, MockDatabase mockDatabase, DataflowBlockOptions options) : base(options)
         {
@@ -226,6 +228,12 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
 
         protected override async Task SendInitial(IngressOutput<StreamEventBatch> output)
         {
+            var tableName = readRelation.NamedTable.DotSeperated;
+            if (TableInitialDelay.TryGetValue(tableName, out var delay))
+            {
+                await Task.Delay(delay);
+            }
+
             Debug.Assert(_state?.Value != null);
             await output.EnterCheckpointLock();
             var (operations, fetchedOffset) = _table.GetOperations(_state.Value.LatestOffset);

--- a/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSourceOperator.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Internal/MockDataSourceOperator.cs
@@ -41,7 +41,8 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         private IObjectState<MockDataSourceState>? _state;
         private BatchConverter _batchConverter;
 
-        public static Dictionary<string, TimeSpan> TableInitialDelay { get; } = new Dictionary<string, TimeSpan>();
+        public static Dictionary<string, System.Threading.Tasks.TaskCompletionSource> TableInitialSignals { get; } = new Dictionary<string, System.Threading.Tasks.TaskCompletionSource>();
+        public static Dictionary<string, string> TableWaitSignals { get; } = new Dictionary<string, string>();
 
         public MockDataSourceOperator(ReadRelation readRelation, MockDatabase mockDatabase, DataflowBlockOptions options) : base(options)
         {
@@ -229,9 +230,12 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
         protected override async Task SendInitial(IngressOutput<StreamEventBatch> output)
         {
             var tableName = readRelation.NamedTable.DotSeperated;
-            if (TableInitialDelay.TryGetValue(tableName, out var delay))
+            if (TableWaitSignals.TryGetValue(tableName, out var waitTableName))
             {
-                await Task.Delay(delay);
+                if (TableInitialSignals.TryGetValue(waitTableName, out var waitTcs))
+                {
+                    await waitTcs.Task;
+                }
             }
 
             Debug.Assert(_state?.Value != null);
@@ -315,6 +319,10 @@ namespace FlowtideDotNet.AcceptanceTests.Internal
             await allOutput!.FlushAsync();
 #endif
 
+            if (TableInitialSignals.TryGetValue(tableName, out var myTcs))
+            {
+                myTcs.TrySetResult();
+            }
         }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -480,6 +480,52 @@ namespace FlowtideDotNet.AcceptanceTests
             }
 
             AssertCurrentDataEqual(expected);
+        }
+
+        [Fact]
+        public async Task LeftJoinBlockLoopModulusUsersFirstDeterministicFail()
+        {
+            Internal.MockDataSourceOperator.TableInitialDelay.Clear();
+            Internal.MockDataSourceOperator.TableInitialDelay["orders"] = TimeSpan.FromMilliseconds(500);
+
+            try
+            {
+                GenerateCompanies(10);
+                GenerateUsers(100);
+                await StartStream(@"
+                    INSERT INTO output 
+                    SELECT 
+                        o.orderkey, u.firstName, u.LastName
+                    FROM users u
+                    LEFT JOIN orders o
+                    ON o.userkey % u.userkey = 0 AND u.userkey % 2 = 0");
+                await WaitForUpdate();
+
+                List<LeftJoinBlockLoopModulusResult> expected = new List<LeftJoinBlockLoopModulusResult>();
+
+                foreach (var user in Users)
+                {
+                    bool joinFound = false;
+                    foreach (var order in Orders)
+                    {
+                        if (order.UserKey % user.UserKey == 0 && user.UserKey % 2 == 0)
+                        {
+                            joinFound = true;
+                            expected.Add(new LeftJoinBlockLoopModulusResult(order.OrderKey, user.FirstName, user.LastName));
+                        }
+                    }
+                    if (!joinFound)
+                    {
+                        expected.Add(new LeftJoinBlockLoopModulusResult(null, user.FirstName, user.LastName));
+                    }
+                }
+
+                AssertCurrentDataEqual(expected);
+            }
+            finally
+            {
+                Internal.MockDataSourceOperator.TableInitialDelay.Clear();
+            }
         }
 
         [Fact]

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -13,6 +13,7 @@
 using Bogus;
 using FlowtideDotNet.AcceptanceTests.Entities;
 using FlowtideDotNet.Base;
+using System.Linq;
 using Xunit.Abstractions;
 
 namespace FlowtideDotNet.AcceptanceTests
@@ -508,13 +509,10 @@ namespace FlowtideDotNet.AcceptanceTests
                 foreach (var user in Users)
                 {
                     bool joinFound = false;
-                    foreach (var order in Orders)
+                    foreach (var order in Orders.Where(order => order.UserKey % user.UserKey == 0 && user.UserKey % 2 == 0))
                     {
-                        if (order.UserKey % user.UserKey == 0 && user.UserKey % 2 == 0)
-                        {
-                            joinFound = true;
-                            expected.Add(new LeftJoinBlockLoopModulusResult(order.OrderKey, user.FirstName, user.LastName));
-                        }
+                        joinFound = true;
+                        expected.Add(new LeftJoinBlockLoopModulusResult(order.OrderKey, user.FirstName, user.LastName));
                     }
                     if (!joinFound)
                     {

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -483,7 +483,7 @@ namespace FlowtideDotNet.AcceptanceTests
         }
 
         [Fact]
-        public async Task LeftJoinBlockLoopModulusUsersFirstDeterministicFail()
+        public async Task LeftJoinBlockLoopModulusUsersFirstOrdersWaitForUsers()
         {
             Internal.MockDataSourceOperator.TableInitialSignals.Clear();
             Internal.MockDataSourceOperator.TableWaitSignals.Clear();

--- a/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/JoinTests.cs
@@ -485,8 +485,10 @@ namespace FlowtideDotNet.AcceptanceTests
         [Fact]
         public async Task LeftJoinBlockLoopModulusUsersFirstDeterministicFail()
         {
-            Internal.MockDataSourceOperator.TableInitialDelay.Clear();
-            Internal.MockDataSourceOperator.TableInitialDelay["orders"] = TimeSpan.FromMilliseconds(500);
+            Internal.MockDataSourceOperator.TableInitialSignals.Clear();
+            Internal.MockDataSourceOperator.TableWaitSignals.Clear();
+            Internal.MockDataSourceOperator.TableInitialSignals["users"] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Internal.MockDataSourceOperator.TableWaitSignals["orders"] = "users";
 
             try
             {
@@ -524,7 +526,8 @@ namespace FlowtideDotNet.AcceptanceTests
             }
             finally
             {
-                Internal.MockDataSourceOperator.TableInitialDelay.Clear();
+                Internal.MockDataSourceOperator.TableInitialSignals.Clear();
+                Internal.MockDataSourceOperator.TableWaitSignals.Clear();
             }
         }
 


### PR DESCRIPTION
This fixes that watermark was not always emitted correctly at the start