### PR TITLE
Change between to use >= and <= to allow optimizers to work better

### DIFF
--- a/src/FlowtideDotNet.Core/Optimizer/EmitPushdown/ExpressionFieldReplaceVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/EmitPushdown/ExpressionFieldReplaceVisitor.cs
@@ -17,6 +17,7 @@ namespace FlowtideDotNet.Core.Optimizer.EmitPushdown
     internal class ExpressionFieldReplaceVisitor : ExpressionVisitor<object, object?>
     {
         private readonly Dictionary<int, int> oldToNew;
+        private HashSet<DirectFieldReference> visitedReferences = new HashSet<DirectFieldReference>(ReferenceEqualityComparer.Instance);
 
         public ExpressionFieldReplaceVisitor(Dictionary<int, int> oldToNew)
         {
@@ -25,6 +26,10 @@ namespace FlowtideDotNet.Core.Optimizer.EmitPushdown
 
         public override object? VisitDirectFieldReference(DirectFieldReference directFieldReference, object? state)
         {
+            if (visitedReferences.Contains(directFieldReference))
+            {
+                return default;
+            }
             if (directFieldReference.ReferenceSegment is StructReferenceSegment structReferenceSegment)
             {
                 if (oldToNew.TryGetValue(structReferenceSegment.Field, out var newField))
@@ -35,6 +40,7 @@ namespace FlowtideDotNet.Core.Optimizer.EmitPushdown
                 {
                     throw new NotImplementedException("Only struct reference segments is supported at this time for emit optimizer");
                 }
+                visitedReferences.Add(directFieldReference);
             }
             return base.VisitDirectFieldReference(directFieldReference, state);
         }

--- a/src/FlowtideDotNet.Core/Optimizer/EmitPushdown/ExpressionFieldReplaceVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/EmitPushdown/ExpressionFieldReplaceVisitor.cs
@@ -17,7 +17,7 @@ namespace FlowtideDotNet.Core.Optimizer.EmitPushdown
     internal class ExpressionFieldReplaceVisitor : ExpressionVisitor<object, object?>
     {
         private readonly Dictionary<int, int> oldToNew;
-        private HashSet<DirectFieldReference> visitedReferences = new HashSet<DirectFieldReference>(ReferenceEqualityComparer.Instance);
+        private readonly HashSet<DirectFieldReference> visitedReferences = new HashSet<DirectFieldReference>(ReferenceEqualityComparer.Instance);
 
         public ExpressionFieldReplaceVisitor(Dictionary<int, int> oldToNew)
         {

--- a/src/FlowtideDotNet.Substrait/Sql/SqlExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/SqlExpressionVisitor.cs
@@ -671,17 +671,34 @@ namespace FlowtideDotNet.Substrait.Sql
             var expr = Visit(between.Expression, state);
             var low = Visit(between.Low, state);
             var high = Visit(between.High, state);
-
+            
             return new ExpressionData(
                 new ScalarFunction()
                 {
-                    ExtensionUri = FunctionsComparison.Uri,
-                    ExtensionName = FunctionsComparison.Between,
+                    ExtensionUri = FunctionsBoolean.Uri,
+                    ExtensionName = FunctionsBoolean.And,
                     Arguments = new List<Expressions.Expression>()
                     {
-                        expr.Expr,
-                        low.Expr,
-                        high.Expr
+                        new ScalarFunction()
+                        {
+                            ExtensionUri = FunctionsComparison.Uri,
+                            ExtensionName = FunctionsComparison.GreaterThanOrEqual,
+                            Arguments = new List<Expressions.Expression>()
+                            {
+                                expr.Expr,
+                                low.Expr
+                            }
+                        },
+                        new ScalarFunction()
+                        {
+                            ExtensionUri = FunctionsComparison.Uri,
+                            ExtensionName = FunctionsComparison.LessThanOrEqual,
+                            Arguments = new List<Expressions.Expression>()
+                            {
+                                expr.Expr,
+                                high.Expr
+                            }
+                        }
                     }
                 }, "$between",
                 new BoolType() { Nullable = true }

--- a/tests/FlowtideDotNet.Nexmark/Internal/Builders/AuctionBatchBuilder.cs
+++ b/tests/FlowtideDotNet.Nexmark/Internal/Builders/AuctionBatchBuilder.cs
@@ -38,8 +38,8 @@ internal sealed class AuctionBatchBuilder
         _currentColumns[2].Add(new StringValue(auction.Description));
         _currentColumns[3].Add(new Int64Value(auction.InitialBid));
         _currentColumns[4].Add(new Int64Value(auction.Reserve));
-        _currentColumns[5].Add(new StringValue(auction.DateTime));
-        _currentColumns[6].Add(new StringValue(auction.Expires));
+        _currentColumns[5].Add(new TimestampTzValue(auction.DateTime));
+        _currentColumns[6].Add(new TimestampTzValue(auction.Expires));
         _currentColumns[7].Add(new Int64Value(auction.Seller));
         _currentColumns[8].Add(new Int64Value(auction.Category));
         _currentColumns[9].Add(new StringValue(auction.Extra));

--- a/tests/FlowtideDotNet.Nexmark/Internal/Builders/BidBatchBuilder.cs
+++ b/tests/FlowtideDotNet.Nexmark/Internal/Builders/BidBatchBuilder.cs
@@ -38,7 +38,7 @@ internal sealed class BidBatchBuilder
         _currentColumns[2].Add(new Int64Value(bid.Price));
         _currentColumns[3].Add(new StringValue(bid.Channel));
         _currentColumns[4].Add(new StringValue(bid.Url));
-        _currentColumns[5].Add(new StringValue(bid.DateTime));
+        _currentColumns[5].Add(new TimestampTzValue(bid.DateTime));
         _currentColumns[6].Add(new StringValue(bid.Extra));
 
         _currentRowCount++;

--- a/tests/FlowtideDotNet.Nexmark/Internal/Builders/PersonBatchBuilder.cs
+++ b/tests/FlowtideDotNet.Nexmark/Internal/Builders/PersonBatchBuilder.cs
@@ -39,7 +39,7 @@ internal sealed class PersonBatchBuilder
         _currentColumns[3].Add(new StringValue(person.CreditCard));
         _currentColumns[4].Add(new StringValue(person.City));
         _currentColumns[5].Add(new StringValue(person.State));
-        _currentColumns[6].Add(new StringValue(person.DateTime));
+        _currentColumns[6].Add(new TimestampTzValue(person.DateTime));
         _currentColumns[7].Add(new StringValue(person.Extra));
 
         _currentRowCount++;

--- a/tests/FlowtideDotNet.Nexmark/Internal/Models/Auction.cs
+++ b/tests/FlowtideDotNet.Nexmark/Internal/Models/Auction.cs
@@ -10,8 +10,8 @@ public struct Auction
     public string Description { get; set; }
     public long InitialBid { get; set; }
     public long Reserve { get; set; }
-    public string DateTime { get; set; }
-    public string Expires { get; set; }
+    public DateTime DateTime { get; set; }
+    public DateTime Expires { get; set; }
     public long Seller { get; set; }
     public long Category { get; set; }
     public string Extra { get; set; }
@@ -24,8 +24,8 @@ public struct Auction
         string description = rng.GenString(100);
         long initialBid = rng.GenPrice();
         long reserve = initialBid + rng.GenPrice();
-        string dateTime = NexmarkUtils.MilliTsToTimestampString(time);
-        string expires = NexmarkUtils.MilliTsToTimestampString(time + NextLength(eventsSoFar, rng, time, nex));
+        DateTime dateTime = DateTimeOffset.FromUnixTimeMilliseconds(time).UtcDateTime;
+        DateTime expires = DateTimeOffset.FromUnixTimeMilliseconds(time + NextLength(eventsSoFar, rng, time, nex)).UtcDateTime;
         
         long seller = rng.Next(0, nex.HotSellerRatio) > 0
             ? (Person.LastId(eventId, nex) / nex.HotSellerRatio2) * nex.HotSellerRatio2

--- a/tests/FlowtideDotNet.Nexmark/Internal/Models/Bid.cs
+++ b/tests/FlowtideDotNet.Nexmark/Internal/Models/Bid.cs
@@ -10,7 +10,7 @@ public struct Bid
     public long Price { get; set; }
     public string Channel { get; set; }
     public string Url { get; set; }
-    public string DateTime { get; set; }
+    public DateTime DateTime { get; set; }
     public string Extra { get; set; }
 
     public static Bid Generate(long eventId, long time, NexmarkConfig nex)
@@ -49,7 +49,7 @@ public struct Bid
             AuctionId = auction + nex.FirstAuctionId,
             BidderId = bidder + nex.FirstPersonId,
             Price = price,
-            DateTime = NexmarkUtils.MilliTsToTimestampString(time),
+            DateTime = DateTimeOffset.FromUnixTimeMilliseconds(time).UtcDateTime,
             Channel = channel,
             Url = url,
             Extra = extra

--- a/tests/FlowtideDotNet.Nexmark/Internal/Models/Person.cs
+++ b/tests/FlowtideDotNet.Nexmark/Internal/Models/Person.cs
@@ -11,7 +11,7 @@ public struct Person
     public string CreditCard { get; set; }
     public string City { get; set; }
     public string State { get; set; }
-    public string DateTime { get; set; }
+    public DateTime DateTime { get; set; }
     public string Extra { get; set; }
 
     public static Person Generate(long eventId, long time, NexmarkConfig nex)
@@ -35,7 +35,7 @@ public struct Person
             CreditCard = creditCard,
             City = city,
             State = state,
-            DateTime = NexmarkUtils.MilliTsToTimestampString(time),
+            DateTime = DateTimeOffset.FromUnixTimeMilliseconds(time).UtcDateTime,
             Extra = extra
         };
     }

--- a/tests/FlowtideDotNet.Nexmark/Internal/NexmarkSchema.cs
+++ b/tests/FlowtideDotNet.Nexmark/Internal/NexmarkSchema.cs
@@ -18,7 +18,7 @@ public static class NexmarkSchema
                 new StringType(), // creditCard
                 new StringType(), // city
                 new StringType(), // state
-                new StringType(), // dateTime
+                new TimestampType(), // dateTime
                 new StringType()  // extra
             }
         }
@@ -36,8 +36,8 @@ public static class NexmarkSchema
                 new StringType(), // description
                 new Int64Type(), // initialBid
                 new Int64Type(), // reserve
-                new StringType(), // dateTime
-                new StringType(), // expires
+                new TimestampType(), // dateTime
+                new TimestampType(), // expires
                 new Int64Type(), // seller
                 new Int64Type(), // category
                 new StringType()  // extra
@@ -57,7 +57,7 @@ public static class NexmarkSchema
                 new Int64Type(), // price
                 new StringType(), // channel
                 new StringType(), // url
-                new StringType(), // dateTime
+                new TimestampType(), // dateTime
                 new StringType()  // extra
             }
         }

--- a/tests/FlowtideDotNet.Nexmark/Query4.cs
+++ b/tests/FlowtideDotNet.Nexmark/Query4.cs
@@ -34,13 +34,13 @@ namespace FlowtideDotNet.Nexmark
             FROM (
             SELECT MAX(B.price) AS final, A.category
                 FROM auction A, bid B
-                WHERE A.id = B.auction AND B.date_time >= A.dateTime AND B.date_time <= A.expires
+                WHERE A.id = B.auction AND B.date_time BETWEEN A.dateTime AND A.expires
                 GROUP BY A.id, A.category
             ) Q
             GROUP BY Q.category
             ", planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings()
             {
-                Parallelization = 4                               
+                Parallelization = 1                              
             });
             await Stream.WaitForUpdate();
         }

--- a/tests/FlowtideDotNet.Nexmark/Query4.cs
+++ b/tests/FlowtideDotNet.Nexmark/Query4.cs
@@ -34,7 +34,7 @@ namespace FlowtideDotNet.Nexmark
             FROM (
             SELECT MAX(B.price) AS final, A.category
                 FROM auction A, bid B
-                WHERE A.id = B.auction AND B.date_time BETWEEN A.dateTime AND A.expires
+                WHERE A.id = B.auction AND B.date_time >= A.dateTime AND B.date_time <= A.expires
                 GROUP BY A.id, A.category
             ) Q
             GROUP BY Q.category


### PR DESCRIPTION
Optimizers look more at >= and <= so switching BETWEEN to output those operators helps better for performance.

Also updated nexmark benchmark to use timestamp instead of string.