### PR TITLE
Table function redesign to reduce allocations

### DIFF
--- a/src/FlowtideDotNet.Core/Compute/Columnar/ColumnTableFunctionCompiler.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ColumnTableFunctionCompiler.cs
@@ -19,7 +19,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar
 {
     /// <summary>
     /// A compiled table function. For input row <c>index</c> in <c>batch</c> it appends the
-    /// produced rows directly into <c>output</c> instead of allocating a batch per row.
+    /// produced rows directly into <c>output</c>.
     /// </summary>
     public delegate void TableFunctionEmit(EventBatchData batch, int index, ITableFunctionOutput output);
 

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ColumnTableFunctionCompiler.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ColumnTableFunctionCompiler.cs
@@ -17,7 +17,13 @@ using System.Linq.Expressions;
 
 namespace FlowtideDotNet.Core.Compute.Columnar
 {
-    public record TableFunctionCompileResult(Func<EventBatchData, int, IEnumerable<EventBatchWeighted>> Function);
+    /// <summary>
+    /// A compiled table function. For input row <c>index</c> in <c>batch</c> it appends the
+    /// produced rows directly into <c>output</c> instead of allocating a batch per row.
+    /// </summary>
+    public delegate void TableFunctionEmit(EventBatchData batch, int index, ITableFunctionOutput output);
+
+    public record TableFunctionCompileResult(TableFunctionEmit Emit);
     internal static class ColumnTableFunctionCompiler
     {
         public static TableFunctionCompileResult CompileWithArg(
@@ -31,12 +37,13 @@ namespace FlowtideDotNet.Core.Compute.Columnar
             }
             var param = System.Linq.Expressions.Expression.Parameter(typeof(EventBatchData));
             var indexParam = System.Linq.Expressions.Expression.Parameter(typeof(int));
+            var outputParam = System.Linq.Expressions.Expression.Parameter(typeof(ITableFunctionOutput));
             var resultContainer = System.Linq.Expressions.Expression.Constant(new DataValueContainer());
             var parameterInfo = new ColumnParameterInfo(new List<ParameterExpression>() { param }, new List<ParameterExpression>() { indexParam }, new List<int> { 0 }, resultContainer);
             var visitor = new ColumnarExpressionVisitor(functionsRegister);
 
-            var tableFunctionResult = tableFunctionFactory.MapFunc(tableFunction, parameterInfo, visitor, memoryAllocator);
-            var lambda = System.Linq.Expressions.Expression.Lambda<Func<EventBatchData, int, IEnumerable<EventBatchWeighted>>>(tableFunctionResult.Expression, param, indexParam);
+            var tableFunctionResult = tableFunctionFactory.MapFunc(tableFunction, parameterInfo, visitor, memoryAllocator, outputParam);
+            var lambda = System.Linq.Expressions.Expression.Lambda<TableFunctionEmit>(tableFunctionResult.Expression, param, indexParam, outputParam);
             return new TableFunctionCompileResult(lambda.Compile());
         }
     }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ColumnTableFunctionDefinition.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ColumnTableFunctionDefinition.cs
@@ -12,11 +12,16 @@
 
 using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.Expressions;
+using System.Linq.Expressions;
 
 namespace FlowtideDotNet.Core.Compute.Columnar
 {
     public class TableFunctionResult
     {
+        /// <summary>
+        /// A void-returning expression that appends the produced rows for a single input
+        /// row into the <see cref="ITableFunctionOutput"/> passed to the compiled function.
+        /// </summary>
         public System.Linq.Expressions.Expression Expression { get; }
         public TableFunctionResult(System.Linq.Expressions.Expression expression)
         {
@@ -30,7 +35,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar
         public ColumnTableFunctionDefinition(
             string uri,
             string name,
-            Func<TableFunction, ColumnParameterInfo, ColumnarExpressionVisitor, IMemoryAllocator, TableFunctionResult> mapFunc)
+            Func<TableFunction, ColumnParameterInfo, ColumnarExpressionVisitor, IMemoryAllocator, ParameterExpression, TableFunctionResult> mapFunc)
         {
             Uri = uri;
             Name = name;
@@ -41,6 +46,11 @@ namespace FlowtideDotNet.Core.Compute.Columnar
 
         public string Name { get; }
 
-        public Func<TableFunction, ColumnParameterInfo, ColumnarExpressionVisitor, IMemoryAllocator, TableFunctionResult> MapFunc { get; }
+        /// <summary>
+        /// Builds the append expression for the function. The last parameter is the
+        /// <see cref="ITableFunctionOutput"/> parameter expression that the produced rows
+        /// should be written into.
+        /// </summary>
+        public Func<TableFunction, ColumnParameterInfo, ColumnarExpressionVisitor, IMemoryAllocator, ParameterExpression, TableFunctionResult> MapFunc { get; }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/TableFunctions/UnnestFunction.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/TableFunctions/UnnestFunction.cs
@@ -11,8 +11,6 @@
 // limitations under the License.
 
 using FlowtideDotNet.Core.ColumnStore;
-using FlowtideDotNet.Storage.DataStructures;
-using FlowtideDotNet.Storage.Memory;
 using FlowtideDotNet.Substrait.FunctionExtensions;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -38,7 +36,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.TableFunctions
         public static void AddBuiltInUnnestFunction(FunctionsRegister functionsRegister)
         {
             functionsRegister.RegisterColumnTableFunction(FunctionsTableGeneric.Uri, FunctionsTableGeneric.Unnest,
-                (tableFunc, parameterInfo, visitor, memoryAllocator) =>
+                (tableFunc, parameterInfo, visitor, memoryAllocator, outputParam) =>
                 {
                     if (tableFunc.Arguments.Count != 1)
                     {
@@ -57,25 +55,22 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.TableFunctions
                     }
 
                     var genericMethod = _unnestMethod.MakeGenericMethod(expr.Type);
-                    return new TableFunctionResult(Expression.Call(genericMethod, expr, Expression.Constant(memoryAllocator)));
+                    return new TableFunctionResult(Expression.Call(genericMethod, expr, outputParam));
                 });
         }
 
-        public static IEnumerable<EventBatchWeighted> DoUnnest<T>(T value, IMemoryAllocator memoryAllocator)
+        public static void DoUnnest<T>(T value, ITableFunctionOutput output)
             where T : IDataValue
         {
-            PrimitiveList<int> weights = new PrimitiveList<int>(memoryAllocator);
-            PrimitiveList<uint> iterations = new PrimitiveList<uint>(memoryAllocator);
-            IColumn[] outputColumns = [Column.Create(memoryAllocator)];
+            var column = output.Columns[0];
             if (value.Type == ArrowTypeId.List)
             {
                 var list = value.AsList;
 
                 for (int i = 0; i < list.Count; i++)
                 {
-                    weights.Add(1);
-                    iterations.Add(0);
-                    outputColumns[0].Add(list.GetAt(i));
+                    column.Add(list.GetAt(i));
+                    output.CommitRow(1, 0);
                 }
             }
             else if (value.Type == ArrowTypeId.Map)
@@ -86,17 +81,13 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.TableFunctions
 
                 for (int i = 0; i < mapLength; i++)
                 {
-                    weights.Add(1);
-                    iterations.Add(0);
-                    outputColumns[0].Add(new MapValue(
+                    column.Add(new MapValue(
                         new KeyValuePair<IDataValue, IDataValue>(_keyValue, map.GetKeyAt(i)),
                         new KeyValuePair<IDataValue, IDataValue>(_valueValue, map.GetValueAt(i))
                     ));
+                    output.CommitRow(1, 0);
                 }
             }
-
-            EventBatchWeighted[] result = [new EventBatchWeighted(weights, iterations, new EventBatchData(outputColumns))];
-            return result;
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/TableFunctions/UnnestFunction.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/TableFunctions/UnnestFunction.cs
@@ -66,18 +66,36 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.TableFunctions
             if (value.Type == ArrowTypeId.List)
             {
                 var list = value.AsList;
-
-                for (int i = 0; i < list.Count; i++)
+                var count = list.Count;
+                if (count == 0)
                 {
-                    column.Add(list.GetAt(i));
-                    output.CommitRow(1, 0);
+                    return;
                 }
+
+                if (list is ReferenceListValue refList)
+                {
+                    // The list is a contiguous slice of a backing column, so copy the whole
+                    // run in one range copy instead of value-by-value.
+                    column.InsertRangeFrom(column.Count, refList.column, refList.start, count);
+                }
+                else
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        column.Add(list.GetAt(i));
+                    }
+                }
+                output.CommitRows(count, 1, 0);
             }
             else if (value.Type == ArrowTypeId.Map)
             {
                 var map = value.AsMap;
 
                 var mapLength = map.GetLength();
+                if (mapLength == 0)
+                {
+                    return;
+                }
 
                 for (int i = 0; i < mapLength; i++)
                 {
@@ -85,8 +103,8 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.TableFunctions
                         new KeyValuePair<IDataValue, IDataValue>(_keyValue, map.GetKeyAt(i)),
                         new KeyValuePair<IDataValue, IDataValue>(_valueValue, map.GetValueAt(i))
                     ));
-                    output.CommitRow(1, 0);
                 }
+                output.CommitRows(mapLength, 1, 0);
             }
         }
     }

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ITableFunctionOutput.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ITableFunctionOutput.cs
@@ -17,13 +17,6 @@ namespace FlowtideDotNet.Core.Compute.Columnar
     /// <summary>
     /// Sink that a compiled table function appends its generated rows into.
     /// <para>
-    /// This replaces the previous contract where a table function returned a fresh
-    /// <see cref="EventBatchWeighted"/> for every single input row, which allocated a
-    /// column set, weight/iteration lists and batch wrappers per row. Here the columns
-    /// and lists are owned by the operator and reused for the whole incoming batch, in
-    /// the same spirit as the bulk aggregate operator and the window output builder.
-    /// </para>
-    /// </summary>
     public interface ITableFunctionOutput
     {
         /// <summary>

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ITableFunctionOutput.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ITableFunctionOutput.cs
@@ -16,7 +16,7 @@ namespace FlowtideDotNet.Core.Compute.Columnar
 {
     /// <summary>
     /// Sink that a compiled table function appends its generated rows into.
-    /// <para>
+    /// </summary>
     public interface ITableFunctionOutput
     {
         /// <summary>

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ITableFunctionOutput.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ITableFunctionOutput.cs
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+
+namespace FlowtideDotNet.Core.Compute.Columnar
+{
+    /// <summary>
+    /// Sink that a compiled table function appends its generated rows into.
+    /// <para>
+    /// This replaces the previous contract where a table function returned a fresh
+    /// <see cref="EventBatchWeighted"/> for every single input row, which allocated a
+    /// column set, weight/iteration lists and batch wrappers per row. Here the columns
+    /// and lists are owned by the operator and reused for the whole incoming batch, in
+    /// the same spirit as the bulk aggregate operator and the window output builder.
+    /// </para>
+    /// </summary>
+    public interface ITableFunctionOutput
+    {
+        /// <summary>
+        /// The function's output columns, one per column in the table function schema.
+        /// For each produced row the function writes one value to every column and then
+        /// calls <see cref="CommitRow"/>.
+        /// </summary>
+        IReadOnlyList<IColumn> Columns { get; }
+
+        /// <summary>
+        /// Number of rows committed so far.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Commits a produced row with the given weight and iteration. Must be called
+        /// once, after the row's values have been written to <see cref="Columns"/>.
+        /// </summary>
+        void CommitRow(int weight, uint iteration);
+    }
+}

--- a/src/FlowtideDotNet.Core/Compute/Columnar/ITableFunctionOutput.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/ITableFunctionOutput.cs
@@ -43,5 +43,13 @@ namespace FlowtideDotNet.Core.Compute.Columnar
         /// once, after the row's values have been written to <see cref="Columns"/>.
         /// </summary>
         void CommitRow(int weight, uint iteration);
+
+        /// <summary>
+        /// Commits <paramref name="count"/> produced rows that all share the same weight and
+        /// iteration, after their values have been written to <see cref="Columns"/>. This lets
+        /// a function that emits a run of uniform rows (e.g. unnesting a list) fill the
+        /// bookkeeping in bulk instead of one <see cref="CommitRow"/> call per row.
+        /// </summary>
+        void CommitRows(int count, int weight, uint iteration);
     }
 }

--- a/src/FlowtideDotNet.Core/Compute/FunctionsRegister.cs
+++ b/src/FlowtideDotNet.Core/Compute/FunctionsRegister.cs
@@ -196,7 +196,7 @@ namespace FlowtideDotNet.Core.Compute
         public void RegisterColumnTableFunction(
             string uri,
             string name,
-            Func<TableFunction, ColumnParameterInfo, ColumnarExpressionVisitor, IMemoryAllocator, TableFunctionResult> mapFunc)
+            Func<TableFunction, ColumnParameterInfo, ColumnarExpressionVisitor, IMemoryAllocator, ParameterExpression, TableFunctionResult> mapFunc)
         {
             _columnTableFunctions.Add($"{uri}:{name}", new ColumnTableFunctionDefinition(uri, name, mapFunc));
         }

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOperator.cs
@@ -263,12 +263,27 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
             (_, _rightOutputIndices) = GetOutputColumns(_tableFunctionRelation, _tableFunctionRelation.Input.OutputLength, _functionOutputLength);
             if (_tableFunctionRelation.JoinCondition != null)
             {
+                if (_scratch != null)
+                {
+                    _scratch.Dispose();
+                    _scratch = null;
+                }
                 // Create a boolean filter function that takes both the left and right side of the join
                 _joinCondition = ColumnBooleanCompiler.CompileTwoInputs(_tableFunctionRelation.JoinCondition, _functionsRegister, _tableFunctionRelation.Input.OutputLength);
                 // Reusable scratch for the filtered path.
                 _scratch = new TableFunctionRowBuffer(_functionOutputLength, MemoryAllocator);
             }
             return Task.CompletedTask;
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            if (_scratch != null)
+            {
+                _scratch.Dispose();
+            }
+            
+            return base.DisposeAsync();
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOperator.cs
@@ -14,10 +14,8 @@ using FlowtideDotNet.Base.Metrics;
 using FlowtideDotNet.Base.Utils;
 using FlowtideDotNet.Base.Vertices;
 using FlowtideDotNet.Core.ColumnStore;
-using FlowtideDotNet.Core.ColumnStore.DataValues;
 using FlowtideDotNet.Core.Compute;
 using FlowtideDotNet.Core.Compute.Columnar;
-using FlowtideDotNet.Storage.DataStructures;
 using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Substrait.Relations;
 using System.Diagnostics;
@@ -29,9 +27,14 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
     {
         private readonly TableFunctionRelation _tableFunctionRelation;
         private readonly IFunctionsRegister _functionsRegister;
-        private Func<EventBatchData, int, IEnumerable<EventBatchWeighted>>? _func;
+        private TableFunctionEmit? _func;
         private Func<EventBatchData, int, EventBatchData, int, bool>? _joinCondition;
         private int _functionOutputLength;
+
+        // Reusable scratch used only when a join condition is present. The function appends
+        // its produced rows here, the condition filters them, and the passing rows are copied
+        // into the output. Cleared (not reallocated) per input row.
+        private TableFunctionRowBuffer? _scratch;
 
         private readonly List<int> _leftOutputColumns;
         private readonly List<int> _leftOutputIndices;
@@ -119,87 +122,95 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
             var inputWeights = msg.Data.Weights;
             var iterations = msg.Data.Iterations;
 
-            PrimitiveList<int> foundOffsets = new PrimitiveList<int>(MemoryAllocator);
-            PrimitiveList<int> outputWeights = new PrimitiveList<int>(MemoryAllocator);
-            PrimitiveList<uint> outputIterations = new PrimitiveList<uint>(MemoryAllocator);
-            IColumn[] outputColumns = new IColumn[_functionOutputLength];
-            for (int i = 0; i < outputColumns.Length; i++)
-            {
-                outputColumns[i] = Column.Create(MemoryAllocator);
-            }
+            // The function appends its rows straight into this output; the columns and weight
+            // lists are reused for the whole incoming batch instead of one batch per row.
+            var output = new TableFunctionJoinOutput(_functionOutputLength, MemoryAllocator);
 
             _eventsProcessed.Add(inputWeights.Count);
             for (int inputIndex = 0; inputIndex < inputWeights.Count; inputIndex++)
             {
                 var inputWeight = inputWeights[inputIndex];
                 var inputIteration = iterations[inputIndex];
-                var newRows = _func(data, inputIndex);
 
-                bool emittedAny = false;
-                foreach (var batch in newRows)
+                if (_joinCondition == null)
                 {
+                    // Fast path: every produced row is emitted, so the function writes directly
+                    // into the output columns/weights with no intermediate copy.
+                    output.InputIndex = inputIndex;
+                    output.InputWeight = inputWeight;
+                    output.InputIteration = inputIteration;
+
+                    int before = output.Count;
+                    _func(data, inputIndex, output);
+
+                    if (_tableFunctionRelation.Type == JoinType.Left && output.Count == before)
+                    {
+                        output.AddNullRow(inputIndex, inputWeight);
+                    }
+                }
+                else
+                {
+                    // Filtered path: generate into the reusable scratch, then copy only the rows
+                    // that pass the join condition into the output, coalescing them into ranges.
+                    var scratch = _scratch!;
+                    scratch.Clear();
+                    _func(data, inputIndex, scratch);
+
+                    var scratchBatch = scratch.Batch;
+                    var scratchWeights = scratch.Weights;
+                    var outputColumns = output.FunctionColumns;
+
+                    bool emittedAny = false;
                     int matchStart = -1;
                     int matchEnd = -1;
-                    for (int newIndex = 0; newIndex < batch.Weights.Count; newIndex++)
+                    for (int newIndex = 0; newIndex < scratch.Count; newIndex++)
                     {
-                        if (_joinCondition == null || _joinCondition(data, inputIndex, batch.EventBatchData, newIndex))
+                        if (_joinCondition(data, inputIndex, scratchBatch, newIndex))
                         {
                             emittedAny = true;
-                            foundOffsets.Add(inputIndex);
-                            outputWeights.Add(inputWeight * batch.Weights[newIndex]);
-                            outputIterations.Add(inputIteration);
+                            output.FoundOffsets.Add(inputIndex);
+                            output.Weights.Add(inputWeight * scratchWeights[newIndex]);
+                            output.Iterations.Add(inputIteration);
                             if (matchStart == -1)
                             {
                                 matchStart = newIndex;
                             }
                             matchEnd = newIndex;
                         }
-                        else
+                        else if (matchStart != -1)
                         {
-                            if (matchStart != -1)
+                            for (int i = 0; i < outputColumns.Length; i++)
                             {
-                                // Copy data over in batch from matchStart to matchEnd
-                                for (int i = 0; i < outputColumns.Length; i++)
-                                {
-                                    outputColumns[i].InsertRangeFrom(outputColumns[i].Count, batch.EventBatchData.Columns[i], matchStart, matchEnd - matchStart + 1);
-                                }
-                                matchStart = -1;
-                                matchEnd = -1;
+                                outputColumns[i].InsertRangeFrom(outputColumns[i].Count, scratchBatch.Columns[i], matchStart, matchEnd - matchStart + 1);
                             }
+                            matchStart = -1;
+                            matchEnd = -1;
                         }
                     }
                     if (matchStart != -1)
                     {
                         for (int i = 0; i < outputColumns.Length; i++)
                         {
-                            outputColumns[i].InsertRangeFrom(outputColumns[i].Count, batch.EventBatchData.Columns[i], matchStart, matchEnd - matchStart + 1);
+                            outputColumns[i].InsertRangeFrom(outputColumns[i].Count, scratchBatch.Columns[i], matchStart, matchEnd - matchStart + 1);
                         }
                     }
-                    batch.Return();
-                }
 
-                if (_tableFunctionRelation.Type == JoinType.Left && !emittedAny)
-                {
-                    foundOffsets.Add(inputIndex);
-                    outputWeights.Add(inputWeight);
-                    outputIterations.Add(0);
-                    for (int i = 0; i < outputColumns.Length; i++)
+                    if (_tableFunctionRelation.Type == JoinType.Left && !emittedAny)
                     {
-                        outputColumns[i].Add(NullValue.Instance);
+                        output.AddNullRow(inputIndex, inputWeight);
                     }
                 }
             }
 
-            if (foundOffsets.Count > 0)
+            if (output.Count > 0)
             {
-                
                 IColumn[] emitColumns = new IColumn[_leftOutputColumns.Count + _rightOutputIndices.Count];
                 if (_leftOutputColumns.Count > 0)
                 {
                     bool shouldDisposeOffsets = true;
                     for (int i = 0; i < _leftOutputColumns.Count; i++)
                     {
-                        emitColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], foundOffsets, MemoryAllocator, out var offsetUsed);
+                        emitColumns[_leftOutputIndices[i]] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_leftOutputColumns[i]], output.FoundOffsets, MemoryAllocator, out var offsetUsed);
                         if (offsetUsed)
                         {
                             shouldDisposeOffsets = false;
@@ -207,32 +218,26 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
                     }
                     if (shouldDisposeOffsets)
                     {
-                        foundOffsets.Dispose();
+                        output.FoundOffsets.Dispose();
                     }
                 }
                 else
                 {
-                    foundOffsets.Dispose();
+                    output.FoundOffsets.Dispose();
                 }
 
-                for (int i = 0; i < outputColumns.Length; i++)
+                for (int i = 0; i < output.FunctionColumns.Length; i++)
                 {
-                    emitColumns[_rightOutputIndices[i]] = outputColumns[i];
+                    emitColumns[_rightOutputIndices[i]] = output.FunctionColumns[i];
                 }
 
-                _eventsCounter.Add(outputWeights.Count);
-                var outputBatch = new StreamEventBatch(new EventBatchWeighted(outputWeights, outputIterations, new EventBatchData(emitColumns)));
+                _eventsCounter.Add(output.Weights.Count);
+                var outputBatch = new StreamEventBatch(new EventBatchWeighted(output.Weights, output.Iterations, new EventBatchData(emitColumns)));
                 return new SingleAsyncEnumerable<StreamEventBatch>(outputBatch);
             }
             else
             {
-                foundOffsets.Dispose();
-                outputWeights.Dispose();
-                outputIterations.Dispose();
-                for (int i = 0; i < outputColumns.Length; i++)
-                {
-                    outputColumns[i].Dispose();
-                }
+                output.Dispose();
             }
 
             return EmptyAsyncEnumerable<StreamEventBatch>.Instance;
@@ -253,13 +258,15 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
 
             // Must be compiled in initialize to have access to memory allocator
             var compileResult = ColumnTableFunctionCompiler.CompileWithArg(_tableFunctionRelation.TableFunction, _functionsRegister, MemoryAllocator);
-            _func = compileResult.Function;
+            _func = compileResult.Emit;
             _functionOutputLength = _tableFunctionRelation.TableFunction.TableSchema.Names.Count;
             (_, _rightOutputIndices) = GetOutputColumns(_tableFunctionRelation, _tableFunctionRelation.Input.OutputLength, _functionOutputLength);
             if (_tableFunctionRelation.JoinCondition != null)
             {
                 // Create a boolean filter function that takes both the left and right side of the join
                 _joinCondition = ColumnBooleanCompiler.CompileTwoInputs(_tableFunctionRelation.JoinCondition, _functionsRegister, _tableFunctionRelation.Input.OutputLength);
+                // Reusable scratch for the filtered path.
+                _scratch = new TableFunctionRowBuffer(_functionOutputLength, MemoryAllocator);
             }
             return Task.CompletedTask;
         }

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOutput.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOutput.cs
@@ -1,0 +1,95 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.Compute.Columnar;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+
+namespace FlowtideDotNet.Core.Operators.TableFunction
+{
+    /// <summary>
+    /// Accumulator the table function appends the right (generated) side of a join into.
+    /// The columns and weight lists live for the whole incoming batch, so no per-row
+    /// batch is allocated. The operator sets the per-input-row context
+    /// (<see cref="InputIndex"/>, <see cref="InputWeight"/>, <see cref="InputIteration"/>)
+    /// before invoking the function, and <see cref="CommitRow"/> folds that context in as
+    /// the function produces rows.
+    /// </summary>
+    internal sealed class TableFunctionJoinOutput : ITableFunctionOutput
+    {
+        /// <summary>The generated (right side) columns, one per table function schema column.</summary>
+        public IColumn[] FunctionColumns { get; }
+
+        /// <summary>For each output row, the index of the input row it was generated from.</summary>
+        public PrimitiveList<int> FoundOffsets { get; }
+
+        public PrimitiveList<int> Weights { get; }
+
+        public PrimitiveList<uint> Iterations { get; }
+
+        // Per input-row context, set by the operator before each function invocation.
+        public int InputIndex;
+        public int InputWeight;
+        public uint InputIteration;
+
+        public TableFunctionJoinOutput(int functionOutputLength, IMemoryAllocator memoryAllocator)
+        {
+            FunctionColumns = new IColumn[functionOutputLength];
+            for (int i = 0; i < functionOutputLength; i++)
+            {
+                FunctionColumns[i] = Column.Create(memoryAllocator);
+            }
+            FoundOffsets = new PrimitiveList<int>(memoryAllocator);
+            Weights = new PrimitiveList<int>(memoryAllocator);
+            Iterations = new PrimitiveList<uint>(memoryAllocator);
+        }
+
+        public IReadOnlyList<IColumn> Columns => FunctionColumns;
+
+        public int Count => Weights.Count;
+
+        public void CommitRow(int weight, uint iteration)
+        {
+            FoundOffsets.Add(InputIndex);
+            Weights.Add(InputWeight * weight);
+            Iterations.Add(InputIteration);
+        }
+
+        /// <summary>
+        /// Emits the all-null right side used by a LEFT join when an input row produced no
+        /// matching rows.
+        /// </summary>
+        public void AddNullRow(int inputIndex, int inputWeight)
+        {
+            FoundOffsets.Add(inputIndex);
+            Weights.Add(inputWeight);
+            Iterations.Add(0);
+            for (int i = 0; i < FunctionColumns.Length; i++)
+            {
+                FunctionColumns[i].Add(NullValue.Instance);
+            }
+        }
+
+        public void Dispose()
+        {
+            FoundOffsets.Dispose();
+            Weights.Dispose();
+            Iterations.Dispose();
+            for (int i = 0; i < FunctionColumns.Length; i++)
+            {
+                FunctionColumns[i].Dispose();
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOutput.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOutput.cs
@@ -19,7 +19,7 @@ using FlowtideDotNet.Storage.Memory;
 namespace FlowtideDotNet.Core.Operators.TableFunction
 {
     /// <summary>
-    /// Accumulator the table function appends the right (generated) side of a join into.
+    /// Accumulator that the table function appends the right (generated) side of a join into.
     /// The columns and weight lists live for the whole incoming batch, so no per-row
     /// batch is allocated. The operator sets the per-input-row context
     /// (<see cref="InputIndex"/>, <see cref="InputWeight"/>, <see cref="InputIteration"/>)

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOutput.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionJoinOutput.cs
@@ -66,6 +66,15 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
             Iterations.Add(InputIteration);
         }
 
+        public void CommitRows(int count, int weight, uint iteration)
+        {
+            // All rows produced for one input row share its offset/weight/iteration, so fill
+            // the bookkeeping as uniform ranges instead of one Add per row.
+            FoundOffsets.InsertStaticRange(FoundOffsets.Count, InputIndex, count);
+            Weights.InsertStaticRange(Weights.Count, InputWeight * weight, count);
+            Iterations.InsertStaticRange(Iterations.Count, InputIteration, count);
+        }
+
         /// <summary>
         /// Emits the all-null right side used by a LEFT join when an input row produced no
         /// matching rows.

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionReadOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionReadOperator.cs
@@ -28,7 +28,8 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
         private IReadOnlySet<string>? _watermarkNames;
         private readonly TableFunctionRelation _tableFunctionRelation;
         private readonly IFunctionsRegister _functionsRegister;
-        private Func<EventBatchData, int, IEnumerable<EventBatchWeighted>>? _func;
+        private TableFunctionEmit? _func;
+        private int _functionOutputLength;
         private IObjectState<TableFunctionReadState>? _state;
 
         private ICounter<long>? _eventsCounter;
@@ -88,7 +89,8 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
             _watermarkNames = new HashSet<string>() { Name };
 
             var compileResult = ColumnTableFunctionCompiler.CompileWithArg(_tableFunctionRelation.TableFunction, _functionsRegister, MemoryAllocator);
-            _func = compileResult.Function;
+            _func = compileResult.Emit;
+            _functionOutputLength = _tableFunctionRelation.TableFunction.TableSchema.Names.Count;
         }
 
         protected override async Task OnCheckpoint(long checkpointTime)
@@ -106,14 +108,18 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
 
             if (!_state.Value.HasSentInitial)
             {
-                var batches = _func(new EventBatchData(Array.Empty<IColumn>()), 0);
+                var buffer = new TableFunctionRowBuffer(_functionOutputLength, MemoryAllocator);
+                _func(new EventBatchData(Array.Empty<IColumn>()), 0, buffer);
 
-
-                foreach (var batch in batches)
+                if (buffer.Count > 0)
                 {
-                    _eventsCounter.Add(batch.Count);
-                    _eventsProcessed.Add(batch.Count);
-                    await output.SendAsync(new StreamEventBatch(batch));
+                    _eventsCounter.Add(buffer.Count);
+                    _eventsProcessed.Add(buffer.Count);
+                    await output.SendAsync(new StreamEventBatch(buffer.ToBatch()));
+                }
+                else
+                {
+                    buffer.Dispose();
                 }
 
                 await output.SendWatermark(new Base.Watermark(Name, new LongWatermarkValue(1)));

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionRowBuffer.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionRowBuffer.cs
@@ -67,6 +67,12 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
             _iterations.Add(iteration);
         }
 
+        public void CommitRows(int count, int weight, uint iteration)
+        {
+            _weights.InsertStaticRange(_weights.Count, weight, count);
+            _iterations.InsertStaticRange(_iterations.Count, iteration, count);
+        }
+
         /// <summary>Clears the buffer so it can be reused for the next input row.</summary>
         public void Clear()
         {

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionRowBuffer.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionRowBuffer.cs
@@ -1,0 +1,100 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.Compute.Columnar;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+
+namespace FlowtideDotNet.Core.Operators.TableFunction
+{
+    /// <summary>
+    /// A plain reusable buffer of produced rows (columns + weights + iterations) that a
+    /// table function appends into.
+    /// <para>
+    /// Used in two places:
+    /// <list type="bullet">
+    /// <item>as the scratch buffer for the join-condition path, where it is cleared per
+    /// input row and its <see cref="Batch"/> is fed to the join condition before the
+    /// passing rows are copied out; and</item>
+    /// <item>as the output of the table function read (<c>FROM unnest(...)</c>) operator,
+    /// whose buffers are handed off with <see cref="ToBatch"/>.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    internal sealed class TableFunctionRowBuffer : ITableFunctionOutput
+    {
+        private readonly Column[] _columns;
+        private readonly PrimitiveList<int> _weights;
+        private readonly PrimitiveList<uint> _iterations;
+        private readonly EventBatchData _batch;
+
+        public TableFunctionRowBuffer(int columnCount, IMemoryAllocator memoryAllocator)
+        {
+            _columns = new Column[columnCount];
+            for (int i = 0; i < columnCount; i++)
+            {
+                _columns[i] = Column.Create(memoryAllocator);
+            }
+            _weights = new PrimitiveList<int>(memoryAllocator);
+            _iterations = new PrimitiveList<uint>(memoryAllocator);
+            _batch = new EventBatchData(_columns);
+        }
+
+        public IReadOnlyList<IColumn> Columns => _columns;
+
+        public int Count => _weights.Count;
+
+        /// <summary>The produced rows as an <see cref="EventBatchData"/>, for use as the right side of a join condition.</summary>
+        public EventBatchData Batch => _batch;
+
+        public PrimitiveList<int> Weights => _weights;
+
+        public PrimitiveList<uint> Iterations => _iterations;
+
+        public void CommitRow(int weight, uint iteration)
+        {
+            _weights.Add(weight);
+            _iterations.Add(iteration);
+        }
+
+        /// <summary>Clears the buffer so it can be reused for the next input row.</summary>
+        public void Clear()
+        {
+            for (int i = 0; i < _columns.Length; i++)
+            {
+                _columns[i].Clear();
+            }
+            _weights.Clear();
+            _iterations.Clear();
+        }
+
+        /// <summary>
+        /// Wraps the current buffers as a batch and hands off ownership. The buffer must not
+        /// be used afterwards.
+        /// </summary>
+        public EventBatchWeighted ToBatch()
+        {
+            return new EventBatchWeighted(_weights, _iterations, _batch);
+        }
+
+        public void Dispose()
+        {
+            for (int i = 0; i < _columns.Length; i++)
+            {
+                _columns[i].Dispose();
+            }
+            _weights.Dispose();
+            _iterations.Dispose();
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionRowBuffer.cs
+++ b/src/FlowtideDotNet.Core/Operators/TableFunction/TableFunctionRowBuffer.cs
@@ -17,20 +17,6 @@ using FlowtideDotNet.Storage.Memory;
 
 namespace FlowtideDotNet.Core.Operators.TableFunction
 {
-    /// <summary>
-    /// A plain reusable buffer of produced rows (columns + weights + iterations) that a
-    /// table function appends into.
-    /// <para>
-    /// Used in two places:
-    /// <list type="bullet">
-    /// <item>as the scratch buffer for the join-condition path, where it is cleared per
-    /// input row and its <see cref="Batch"/> is fed to the join condition before the
-    /// passing rows are copied out; and</item>
-    /// <item>as the output of the table function read (<c>FROM unnest(...)</c>) operator,
-    /// whose buffers are handed off with <see cref="ToBatch"/>.</item>
-    /// </list>
-    /// </para>
-    /// </summary>
     internal sealed class TableFunctionRowBuffer : ITableFunctionOutput
     {
         private readonly Column[] _columns;
@@ -54,7 +40,6 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
 
         public int Count => _weights.Count;
 
-        /// <summary>The produced rows as an <see cref="EventBatchData"/>, for use as the right side of a join condition.</summary>
         public EventBatchData Batch => _batch;
 
         public PrimitiveList<int> Weights => _weights;
@@ -73,7 +58,6 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
             _iterations.InsertStaticRange(_iterations.Count, iteration, count);
         }
 
-        /// <summary>Clears the buffer so it can be reused for the next input row.</summary>
         public void Clear()
         {
             for (int i = 0; i < _columns.Length; i++)
@@ -84,10 +68,6 @@ namespace FlowtideDotNet.Core.Operators.TableFunction
             _iterations.Clear();
         }
 
-        /// <summary>
-        /// Wraps the current buffers as a batch and hands off ownership. The buffer must not
-        /// be used afterwards.
-        /// </summary>
         public EventBatchWeighted ToBatch()
         {
             return new EventBatchWeighted(_weights, _iterations, _batch);

--- a/tests/FlowtideDotNet.AcceptanceTests/TableFunctionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/TableFunctionTests.cs
@@ -161,6 +161,60 @@ namespace FlowtideDotNet.AcceptanceTests
         }
 
         [Fact]
+        public async Task UnnestLeftJoinRetractsOnDeleteAndInsert()
+        {
+            GenerateData(100);
+            await StartStream(@"
+                CREATE VIEW test AS
+                SELECT
+                    userkey, list_agg(orderkey) as orders
+                FROM orders
+                GROUP BY userkey;
+
+                INSERT INTO output
+                SELECT
+                    userkey, order_item
+                FROM test
+                LEFT JOIN unnest(orders) order_item;");
+            await WaitForUpdate();
+            this.AssertCurrentDataEqual(Orders.Select(x => new { x.UserKey, x.OrderKey }));
+
+            // Deleting an order must retract exactly that unnested row.
+            DeleteOrder(Orders[0]);
+            await WaitForUpdate();
+            this.AssertCurrentDataEqual(Orders.Select(x => new { x.UserKey, x.OrderKey }));
+
+            // Adding a new order for an existing user must produce a new unnested row.
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 100000, UserKey = Orders[0].UserKey });
+            await WaitForUpdate();
+            this.AssertCurrentDataEqual(Orders.Select(x => new { x.UserKey, x.OrderKey }));
+        }
+
+        [Fact]
+        public async Task UnnestLeftJoinEmptyListProducesNull()
+        {
+            // A LEFT join with no condition where the unnested value yields no rows must emit
+            // a single all-null right side per input row (the direct-path null fallback that
+            // list_agg never triggers, since its lists are always non-empty).
+            GenerateData(100);
+            await StartStream(@"
+                CREATE VIEW test AS
+                SELECT
+                    userkey, list_agg(orderkey) as orders
+                FROM orders
+                GROUP BY userkey;
+
+                INSERT INTO output
+                SELECT
+                    userkey, order_item
+                FROM test
+                LEFT JOIN unnest(null) order_item;");
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(Orders.GroupBy(x => x.UserKey).Select(x => new { UserKey = x.Key, OrderKey = (int?)null }));
+        }
+
+        [Fact]
         public async Task UnnestInFrom()
         {
             await StartStream(@"


### PR DESCRIPTION
Redesign table functions to share event batch across rows to not have allocations per incoming row.