### PR TITLE
Serialize distributed stream starts to prevent state-manager corruption

### DIFF
--- a/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
+++ b/src/FlowtideDotNet.Base/Engine/DataflowStream.cs
@@ -72,6 +72,9 @@ namespace FlowtideDotNet.Base.Engine
             return streamContext.OnFailure(exception);
         }
 
+        // Test seam: current block-created flag.
+        internal int BlocksCreatedForTests => streamContext._blocksCreated;
+
         /// <summary>
         /// Test seam: delivers an egress checkpoint done into the current state as if an egress
         /// vertex fired it, so tests can reproduce a spurious or stale acknowledgement arriving

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StartStreamState.cs
@@ -211,174 +211,221 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         {
             Debug.Assert(_context != null, nameof(_context));
 
-            // Clear all triggers, they have to be readded by the stream
-            await _context.ClearTriggers();
-            // Enable trigger registration
-            _context.EnableTriggerRegistration();
-
-
-            long? restoreVersion;
-            lock (_context._checkpointLock)
+            var beforeGateHook = StreamContext.StartupBeforeGateRegistrationHookForTests;
+            if (beforeGateHook != null)
             {
-                restoreVersion = _context._restoreCheckpointVersion;
+                await beforeGateHook(_context.streamName);
             }
 
-            // This start creates the blocks below; a failure before that must not run the
-            // block teardown.
+            // Serialize the state manager region across starts.
+            var initGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Task? predecessorInitGate;
             lock (_context._blockClaimLock)
             {
-                _context._blocksCreated = 0;
+                predecessorInitGate = _context._inFlightStartInitGate;
+                _context._inFlightStartInitGate = initGate.Task;
             }
-
-            if (StartAborted())
-            {
-                return;
-            }
-
-            // Initialize state
-            await _context._stateManager.InitializeAsync(_context._streamVersionInformation, restoreVersion);
-
-            if (StartAborted())
-            {
-                return;
-            }
-            _context._lastState = _context._stateManager.Metadata;
-            _context._startCheckpointVersion = _context._stateManager.CurrentVersion;
-            if (_context._lastState == null)
-            {
-                _context._lastState = await _context.stateHandler.LoadLatestState(_context.streamName);
-                if (_context._lastState == null)
-                {
-                    _context._lastState = StreamState.NullState;
-                }
-            }
-            else
-            {
-                if (_context._streamVersionInformation != null)
-                {
-                    _context._logger.CheckingStreamHashConsistency(_context.streamName);
-                    if (_context._streamVersionInformation.Hash != _context._lastState.StreamHash)
-                    {
-                        throw new InvalidOperationException("Stream plan hash stored in storage is different than the hash used.");
-                    }
-                }
-            }
-
-            // Seed the producing time with the wall clock so checkpoint times stay unique
-            // across a rollback. The restored time comes from the state manager metadata,
-            // which rolls back together with the state, so seeding with restored time + 1
-            // alone would mint the same times as the aborted epoch, whose barriers can still
-            // be in flight in exchange queues and messages between substreams. The pairing of
-            // checkpoint barriers between substreams relies on the times being unique. The
-            // max guards against a wall clock that moved backwards.
-            _context.producingTime = Math.Max(_context._lastState.Time + 1, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
-
-            if (StartAborted())
-            {
-                return;
-            }
-
-            // Create the blocks
-            _context._logger.SettingUpBlocks(_context.streamName);
-            _context.ForEachBlock((key, block) =>
-            {
-                block.Setup(_context.streamName, key);
-                block.CreateBlock();
-            });
-            lock (_context._blockClaimLock)
-            {
-                _context._blockGeneration++;
-                _myBlockGeneration = _context._blockGeneration;
-                _context._blocksCreated = 1;
-            }
-            // Link the blocks
-            _context._logger.LinkingBlocks(_context.streamName);
-            _context.ForEachBlock((key, block) =>
-            {
-                block.Link();
-            });
 
             try
             {
-                _context._logger.InitializingPropagatorBLocks(_context.streamName);
-                foreach (var block in _context.propagatorBlocks)
+                if (predecessorInitGate != null)
                 {
-                    TagList tags = new TagList()
-                    {
-                        { "stream", _context.streamName },
-                        { "operator", block.Key }
-                    };
-                    var blockStateClient = _context._stateManager.GetOrCreateClient(block.Key, tags);
-                    VertexHandler vertexHandler = new VertexHandler(
-                        _context.streamName,
-                        block.Key,
-                        _context.TryScheduleCheckpointIn,
-                        _context.AddTrigger,
-                        _context._streamMetrics.GetOrCreateVertexMeter(block.Key, () => block.Value.DisplayName),
-                        blockStateClient,
-                        _context.loggerFactory,
-                        _context._streamMemoryManager.CreateOperatorMemoryManager(block.Key),
-                        _context.FailAndRollback);
-                    await block.Value.Initialize(block.Key, _context._stateManager.LastCompletedCheckpointVersion, _context._stateManager.CurrentVersion, vertexHandler, _context._streamVersionInformation);
-                }
-                
-                _context._logger.InitializingEgressBlocks(_context.streamName);
-                foreach (var block in _context.egressBlocks)
-                {
-                    TagList tags = new TagList()
-                    {
-                        { "stream", _context.streamName },
-                        { "operator", block.Key }
-                    };
-                    var blockStateClient = _context._stateManager.GetOrCreateClient(block.Key, tags);
-                    VertexHandler vertexHandler = new VertexHandler(
-                        _context.streamName,
-                        block.Key,
-                        _context.TryScheduleCheckpointIn,
-                        _context.AddTrigger,
-                        _context._streamMetrics.GetOrCreateVertexMeter(block.Key, () => block.Value.DisplayName),
-                        blockStateClient,
-                        _context.loggerFactory,
-                        _context._streamMemoryManager.CreateOperatorMemoryManager(block.Key),
-                        _context.FailAndRollback);
-                    await block.Value.Initialize(block.Key, _context._stateManager.LastCompletedCheckpointVersion, _context._stateManager.CurrentVersion, vertexHandler, _context._streamVersionInformation);
-                    block.Value.SetCheckpointDoneFunction(_context.EgressCheckpointDone, _context.EgressDependenciesDone);
+                    await predecessorInitGate;
                 }
 
-                _context._logger.InitializingIngressBlocks(_context.streamName);
-                foreach (var block in _context.ingressBlocks)
+                // A superseded start must skip the shared setup.
+                if (StartAborted())
                 {
-                    TagList tags = new TagList()
+                    return;
+                }
+
+                // Clear all triggers, they have to be readded by the stream
+                await _context.ClearTriggers();
+                // Enable trigger registration
+                _context.EnableTriggerRegistration();
+
+
+                long? restoreVersion;
+                lock (_context._checkpointLock)
+                {
+                    restoreVersion = _context._restoreCheckpointVersion;
+                }
+
+                // This start creates the blocks below; a failure before that must not run the
+                // block teardown.
+                lock (_context._blockClaimLock)
+                {
+                    _context._blocksCreated = 0;
+                }
+
+                if (StartAborted())
+                {
+                    return;
+                }
+
+                // Initialize state
+                await _context._stateManager.InitializeAsync(_context._streamVersionInformation, restoreVersion);
+
+                if (StartAborted())
+                {
+                    return;
+                }
+                _context._lastState = _context._stateManager.Metadata;
+                _context._startCheckpointVersion = _context._stateManager.CurrentVersion;
+                if (_context._lastState == null)
+                {
+                    _context._lastState = await _context.stateHandler.LoadLatestState(_context.streamName);
+                    if (_context._lastState == null)
                     {
-                        { "stream", _context.streamName },
-                        { "operator", block.Key }
-                    };
-                    var blockStateClient = _context._stateManager.GetOrCreateClient(block.Key, tags);
-                    VertexHandler vertexHandler = new VertexHandler(
-                        _context.streamName,
-                        block.Key,
-                        _context.TryScheduleCheckpointIn,
-                        _context.AddTrigger,
-                        _context._streamMetrics.GetOrCreateVertexMeter(block.Key, () => block.Value.DisplayName),
-                        blockStateClient,
-                        _context.loggerFactory,
-                        _context._streamMemoryManager.CreateOperatorMemoryManager(block.Key),
-                        _context.FailAndRollback);
-                    await block.Value.Initialize(block.Key, _context._stateManager.LastCompletedCheckpointVersion, _context._stateManager.CurrentVersion, vertexHandler, _context._streamVersionInformation);
-                    block.Value.SetDependenciesDoneFunction(_context.EgressDependenciesDone);
+                        _context._lastState = StreamState.NullState;
+                    }
+                }
+                else
+                {
+                    if (_context._streamVersionInformation != null)
+                    {
+                        _context._logger.CheckingStreamHashConsistency(_context.streamName);
+                        if (_context._streamVersionInformation.Hash != _context._lastState.StreamHash)
+                        {
+                            throw new InvalidOperationException("Stream plan hash stored in storage is different than the hash used.");
+                        }
+                    }
+                }
+
+                // Seed the producing time with the wall clock so checkpoint times stay unique
+                // across a rollback. The restored time comes from the state manager metadata,
+                // which rolls back together with the state, so seeding with restored time + 1
+                // alone would mint the same times as the aborted epoch, whose barriers can still
+                // be in flight in exchange queues and messages between substreams. The pairing of
+                // checkpoint barriers between substreams relies on the times being unique. The
+                // max guards against a wall clock that moved backwards.
+                _context.producingTime = Math.Max(_context._lastState.Time + 1, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+                if (StartAborted())
+                {
+                    return;
+                }
+
+                // Create the blocks
+                _context._logger.SettingUpBlocks(_context.streamName);
+                _context.ForEachBlock((key, block) =>
+                {
+                    block.Setup(_context.streamName, key);
+                    block.CreateBlock();
+                });
+                lock (_context._blockClaimLock)
+                {
+                    _context._blockGeneration++;
+                    _myBlockGeneration = _context._blockGeneration;
+                    _context._blocksCreated = 1;
+                }
+                // Link the blocks
+                _context._logger.LinkingBlocks(_context.streamName);
+                _context.ForEachBlock((key, block) =>
+                {
+                    block.Link();
+                });
+
+                var blockInitHook = StreamContext.StartupDuringBlockInitHookForTests;
+                if (blockInitHook != null)
+                {
+                    await blockInitHook(_context.streamName);
+                }
+
+                if (StartAborted())
+                {
+                    // Abandon before initializing the blocks.
+                    await AbandonStartedBlocks();
+                    return;
+                }
+
+                try
+                {
+                    _context._logger.InitializingPropagatorBLocks(_context.streamName);
+                    foreach (var block in _context.propagatorBlocks)
+                    {
+                        TagList tags = new TagList()
+                        {
+                            { "stream", _context.streamName },
+                            { "operator", block.Key }
+                        };
+                        var blockStateClient = _context._stateManager.GetOrCreateClient(block.Key, tags);
+                        VertexHandler vertexHandler = new VertexHandler(
+                            _context.streamName,
+                            block.Key,
+                            _context.TryScheduleCheckpointIn,
+                            _context.AddTrigger,
+                            _context._streamMetrics.GetOrCreateVertexMeter(block.Key, () => block.Value.DisplayName),
+                            blockStateClient,
+                            _context.loggerFactory,
+                            _context._streamMemoryManager.CreateOperatorMemoryManager(block.Key),
+                            _context.FailAndRollback);
+                        await block.Value.Initialize(block.Key, _context._stateManager.LastCompletedCheckpointVersion, _context._stateManager.CurrentVersion, vertexHandler, _context._streamVersionInformation);
+                    }
+
+                    _context._logger.InitializingEgressBlocks(_context.streamName);
+                    foreach (var block in _context.egressBlocks)
+                    {
+                        TagList tags = new TagList()
+                        {
+                            { "stream", _context.streamName },
+                            { "operator", block.Key }
+                        };
+                        var blockStateClient = _context._stateManager.GetOrCreateClient(block.Key, tags);
+                        VertexHandler vertexHandler = new VertexHandler(
+                            _context.streamName,
+                            block.Key,
+                            _context.TryScheduleCheckpointIn,
+                            _context.AddTrigger,
+                            _context._streamMetrics.GetOrCreateVertexMeter(block.Key, () => block.Value.DisplayName),
+                            blockStateClient,
+                            _context.loggerFactory,
+                            _context._streamMemoryManager.CreateOperatorMemoryManager(block.Key),
+                            _context.FailAndRollback);
+                        await block.Value.Initialize(block.Key, _context._stateManager.LastCompletedCheckpointVersion, _context._stateManager.CurrentVersion, vertexHandler, _context._streamVersionInformation);
+                        block.Value.SetCheckpointDoneFunction(_context.EgressCheckpointDone, _context.EgressDependenciesDone);
+                    }
+
+                    _context._logger.InitializingIngressBlocks(_context.streamName);
+                    foreach (var block in _context.ingressBlocks)
+                    {
+                        TagList tags = new TagList()
+                        {
+                            { "stream", _context.streamName },
+                            { "operator", block.Key }
+                        };
+                        var blockStateClient = _context._stateManager.GetOrCreateClient(block.Key, tags);
+                        VertexHandler vertexHandler = new VertexHandler(
+                            _context.streamName,
+                            block.Key,
+                            _context.TryScheduleCheckpointIn,
+                            _context.AddTrigger,
+                            _context._streamMetrics.GetOrCreateVertexMeter(block.Key, () => block.Value.DisplayName),
+                            blockStateClient,
+                            _context.loggerFactory,
+                            _context._streamMemoryManager.CreateOperatorMemoryManager(block.Key),
+                            _context.FailAndRollback);
+                        await block.Value.Initialize(block.Key, _context._stateManager.LastCompletedCheckpointVersion, _context._stateManager.CurrentVersion, vertexHandler, _context._streamVersionInformation);
+                        block.Value.SetDependenciesDoneFunction(_context.EgressDependenciesDone);
+                    }
+                }
+                catch (Exception e)
+                {
+
+                    await _context.OnFailure(e);
+                    return;
+                }
+
+                if (StartAborted())
+                {
+                    await AbandonStartedBlocks();
+                    return;
                 }
             }
-            catch (Exception e)
+            finally
             {
-
-                await _context.OnFailure(e);
-                return;
-            }
-
-            if (StartAborted())
-            {
-                await AbandonStartedBlocks();
-                return;
+                // A successor may now run its own setup.
+                initGate.TrySetResult();
             }
 
             var completionTasks = _context.GetCompletionTasks();

--- a/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
+++ b/src/FlowtideDotNet.Base/Engine/Internal/StateMachine/StreamContext.cs
@@ -104,6 +104,9 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         internal int _blockGeneration;
         internal readonly object _blockClaimLock = new object();
 
+        // Serializes the state manager region across starts. Guarded by _blockClaimLock.
+        internal Task? _inFlightStartInitGate;
+
         // Test hooks, null in production. Each gets the stream name so a test can filter to its own
         // stream: CheckpointCommitHookForTests awaits inside the commit (so a test can hold a write in
         // flight), CompactionScheduledHookForTests awaits at the entry of a scheduled compaction task
@@ -125,6 +128,10 @@ namespace FlowtideDotNet.Base.Engine.Internal.StateMachine
         // stream in the Starting phase and deliver a spurious egress checkpoint done into that
         // window.
         internal static Func<string, Task>? StartupBeforeInitTrackingHookForTests;
+        // Test hook: park during block setup.
+        internal static Func<string, Task>? StartupDuringBlockInitHookForTests;
+        // Test hook: park before gate registration.
+        internal static Func<string, Task>? StartupBeforeGateRegistrationHookForTests;
 
         private StreamStatus _streamStatus;
 

--- a/src/FlowtideDotNet.Core/Operators/Exchange/SubstreamReadOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Exchange/SubstreamReadOperator.cs
@@ -49,6 +49,9 @@ namespace FlowtideDotNet.Core.Operators.Exchange
         // otherwise take minutes.
         internal static TimeSpan PairingAttemptDelay = TimeSpan.FromSeconds(5);
 
+        // Handoff drain patience; raised in tests.
+        internal static TimeSpan HandoffDrainTimeout = TimeSpan.FromSeconds(10);
+
         private readonly SubstreamCommunicationPoint _communicationPoint;
         private readonly SubstreamExchangeReferenceRelation _exchangeReferenceRelation;
         private readonly object _lock = new object();
@@ -568,17 +571,17 @@ namespace FlowtideDotNet.Core.Operators.Exchange
         /// </summary>
         public override async Task CompleteHandoffDrainAsync()
         {
-            await _communicationPoint.WaitForFetchLoopIdleAsync(TimeSpan.FromSeconds(10));
+            await _communicationPoint.WaitForFetchLoopIdleAsync(HandoffDrainTimeout);
 
             var channel = _channel;
             if (channel != null)
             {
-                var deadline = Environment.TickCount64 + (long)TimeSpan.FromSeconds(10).TotalMilliseconds;
+                var deadline = Environment.TickCount64 + (long)HandoffDrainTimeout.TotalMilliseconds;
                 while (channel.Reader.Count > 0)
                 {
                     if (Environment.TickCount64 >= deadline)
                     {
-                        throw new TimeoutException($"The read channel of {Name} did not drain within 10 seconds during the handoff drain.");
+                        throw new TimeoutException($"The read channel of {Name} did not drain within {HandoffDrainTimeout} during the handoff drain.");
                     }
                     await Task.Delay(10);
                 }

--- a/tests/FlowtideDotNet.AcceptanceTests/Distributed/OrphanedStartRecoveryTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Distributed/OrphanedStartRecoveryTests.cs
@@ -566,7 +566,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
                 return false;
             }
 
-            var batchCount = batch?.Count;
+            var batchCount = batch.Count;
             if (!batchCount.HasValue)
             {
                 return false;

--- a/tests/FlowtideDotNet.AcceptanceTests/Distributed/OrphanedStartRecoveryTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Distributed/OrphanedStartRecoveryTests.cs
@@ -561,19 +561,19 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
         private static bool TryReadCount(ConcurrentDictionary<string, EventBatchData> latestData, string key, out int count)
         {
             count = 0;
-            if (!latestData.TryGetValue(key, out var batch))
+            if (!latestData.TryGetValue(key, out var batch) || batch is null)
             {
                 return false;
             }
-            try
-            {
-                count = batch.Count;
-                return true;
-            }
-            catch (NullReferenceException)
+
+            var batchCount = batch?.Count;
+            if (!batchCount.HasValue)
             {
                 return false;
             }
+
+            count = batchCount.Value;
+            return true;
         }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/Distributed/OrphanedStartRecoveryTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Distributed/OrphanedStartRecoveryTests.cs
@@ -71,6 +71,8 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
             private readonly IPersistentStorage _inner;
             private readonly int _holdOnCall;
             private int _calls;
+            private int _concurrent;
+            private int _maxConcurrent;
 
             public readonly TaskCompletionSource Held = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             public readonly TaskCompletionSource Release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -83,14 +85,33 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
 
             public long CurrentVersion => _inner.CurrentVersion;
 
+            // High-water mark of overlapping inits.
+            public int MaxConcurrent => Volatile.Read(ref _maxConcurrent);
+
+            // Number of inits started.
+            public int Calls => Volatile.Read(ref _calls);
+
             public async Task InitializeAsync(StorageInitializationMetadata metadata)
             {
-                if (Interlocked.Increment(ref _calls) == _holdOnCall)
+                var now = Interlocked.Increment(ref _concurrent);
+                int observed;
+                while (now > (observed = Volatile.Read(ref _maxConcurrent)))
                 {
-                    Held.TrySetResult();
-                    await Release.Task;
+                    Interlocked.CompareExchange(ref _maxConcurrent, now, observed);
                 }
-                await _inner.InitializeAsync(metadata);
+                try
+                {
+                    if (Interlocked.Increment(ref _calls) == _holdOnCall)
+                    {
+                        Held.TrySetResult();
+                        await Release.Task;
+                    }
+                    await _inner.InitializeAsync(metadata);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _concurrent);
+                }
             }
 
             public IPersistentStorageSession CreateSession() => _inner.CreateSession();
@@ -164,6 +185,210 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
             // "Initialize while there are running tasks" and the data never returns.
             generator.Generate(100);
             await WaitForCount(latestData, "substream_0", ExpectedCount(generator), failures);
+        }
+
+        // Superseded start's init must not overlap the successor's.
+        [Fact]
+        public async Task SupersededStartDoesNotInitializeConcurrentlyWithTheSuccessor()
+        {
+            var generator = new DatasetGenerator(_db);
+            generator.Generate(200);
+            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
+
+            var holdingStorage = new HoldingStorage(
+                new ReservoirPersistentStorage(new Storage.Persistence.Reservoir.ReservoirStorageOptions()
+                {
+                    FileProvider = new MemoryFileProvider()
+                }),
+                holdOnCall: 2);
+
+            _stream = new DistributedStreamBuilder(TestName)
+                .AddPlan(BuildPlan)
+                .WithStateOptionsFactory((_, substreamName) => CreateStateOptions(substreamName, substreamName == "substream_0" ? holdingStorage : null))
+                .ConfigureSubstream((substreamName, substreamBuilder) =>
+                {
+                    var connectorManager = new ConnectorManager();
+                    connectorManager.AddSource(new MockSourceFactory("*", _db, true));
+                    connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, _ => { }));
+                    substreamBuilder.AddConnectorManager(connectorManager);
+                    substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
+                })
+                .DistributeAutomatically(2)
+                .Build();
+            await _stream.StartAsync();
+            await WaitForCount(latestData, "substream_0", ExpectedCount(generator), failures);
+
+            var substream0 = _stream.Substreams["substream_0"];
+
+            // Park the restart inside the state manager restore.
+            await substream0.InjectFailureForTests(new Exception("Forces the recovery restart"));
+            var held = await Task.WhenAny(holdingStorage.Held.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+            Assert.True(held == holdingStorage.Held.Task, "The recovery restart never reached the storage initialization");
+
+            // Supersede the parked start, then wait for the successor.
+            await substream0.InjectFailureForTests(new Exception("Late failure during the restart"));
+            await Task.Delay(TimeSpan.FromSeconds(2));
+            Assert.Equal(1, holdingStorage.MaxConcurrent);
+
+            // Release; only then may the successor init.
+            holdingStorage.Release.TrySetResult();
+            generator.Generate(100);
+            await WaitForCount(latestData, "substream_0", ExpectedCount(generator), failures);
+            Assert.Equal(1, holdingStorage.MaxConcurrent);
+        }
+
+        // Serialization must cover block setup, not just init.
+        [Fact]
+        public async Task SupersededStartInBlockSetupDoesNotLetTheSuccessorInitialize()
+        {
+            var generator = new DatasetGenerator(_db);
+            generator.Generate(200);
+            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
+
+            // Storage only counts inits; parking is via the hook.
+            var holdingStorage = new HoldingStorage(
+                new ReservoirPersistentStorage(new Storage.Persistence.Reservoir.ReservoirStorageOptions()
+                {
+                    FileProvider = new MemoryFileProvider()
+                }),
+                holdOnCall: int.MaxValue);
+
+            int substream0BlockInits = 0;
+            var restartInBlockSetup = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseRestart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            StreamContext.StartupDuringBlockInitHookForTests = async (streamName) =>
+            {
+                if (!streamName.Contains(TestName) || !streamName.Contains("substream_0"))
+                {
+                    return;
+                }
+                // Second block setup is the recovery restart.
+                if (Interlocked.Increment(ref substream0BlockInits) == 2)
+                {
+                    restartInBlockSetup.TrySetResult();
+                    await releaseRestart.Task;
+                }
+            };
+
+            try
+            {
+                _stream = new DistributedStreamBuilder(TestName)
+                    .AddPlan(BuildPlan)
+                    .WithStateOptionsFactory((_, substreamName) => CreateStateOptions(substreamName, substreamName == "substream_0" ? holdingStorage : null))
+                    .ConfigureSubstream((substreamName, substreamBuilder) =>
+                    {
+                        var connectorManager = new ConnectorManager();
+                        connectorManager.AddSource(new MockSourceFactory("*", _db, true));
+                        connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, _ => { }));
+                        substreamBuilder.AddConnectorManager(connectorManager);
+                        substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
+                    })
+                    .DistributeAutomatically(2)
+                    .Build();
+                await _stream.StartAsync();
+                await WaitForCount(latestData, "substream_0", ExpectedCount(generator), failures);
+
+                var substream0 = _stream.Substreams["substream_0"];
+
+                // Park the restart in block setup.
+                await substream0.InjectFailureForTests(new Exception("Forces the recovery restart"));
+                var held = await Task.WhenAny(restartInBlockSetup.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+                Assert.True(held == restartInBlockSetup.Task, "The recovery restart never reached block setup");
+
+                var callsWhenParked = holdingStorage.Calls;
+
+                // Supersede; the successor must not init while parked.
+                await substream0.InjectFailureForTests(new Exception("Late failure during block setup"));
+                await Task.Delay(TimeSpan.FromSeconds(2));
+                Assert.Equal(callsWhenParked, holdingStorage.Calls);
+
+                // Release; only then may the successor init.
+                releaseRestart.TrySetResult();
+                generator.Generate(100);
+                await WaitForCount(latestData, "substream_0", ExpectedCount(generator), failures);
+                Assert.Equal(1, holdingStorage.MaxConcurrent);
+            }
+            finally
+            {
+                StreamContext.StartupDuringBlockInitHookForTests = null;
+                releaseRestart.TrySetResult();
+            }
+        }
+
+        // Superseded start must not clobber the successor's created flag.
+        [Fact]
+        public async Task SupersededStartWhoseGateLostTheRaceDoesNotClobberTheSuccessor()
+        {
+            var generator = new DatasetGenerator(_db);
+            generator.Generate(200);
+            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
+
+            int substream0Starts = 0;
+            var restartBeforeGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseRestart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            StreamContext.StartupBeforeGateRegistrationHookForTests = async (streamName) =>
+            {
+                if (!streamName.Contains(TestName) || !streamName.Contains("substream_0"))
+                {
+                    return;
+                }
+                // Park before gate registration, so the successor registers first.
+                if (Interlocked.Increment(ref substream0Starts) == 2)
+                {
+                    restartBeforeGate.TrySetResult();
+                    await releaseRestart.Task;
+                }
+            };
+
+            try
+            {
+                _stream = new DistributedStreamBuilder(TestName)
+                    .AddPlan(BuildPlan)
+                    .WithStateOptionsFactory((_, substreamName) => CreateStateOptions(substreamName, null))
+                    .ConfigureSubstream((substreamName, substreamBuilder) =>
+                    {
+                        var connectorManager = new ConnectorManager();
+                        connectorManager.AddSource(new MockSourceFactory("*", _db, true));
+                        connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, _ => { }));
+                        substreamBuilder.AddConnectorManager(connectorManager);
+                        substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
+                    })
+                    .DistributeAutomatically(2)
+                    .Build();
+                await _stream.StartAsync();
+                await WaitForCount(latestData, "substream_0", ExpectedCount(generator), failures);
+
+                var substream0 = _stream.Substreams["substream_0"];
+
+                // Failure 1: the restart parks before gate registration.
+                await substream0.InjectFailureForTests(new Exception("Forces the recovery restart"));
+                var held = await Task.WhenAny(restartBeforeGate.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+                Assert.True(held == restartBeforeGate.Task, "The recovery restart never reached the pre-gate point");
+
+                // Failure 2: the successor registers first and creates its blocks.
+                await substream0.InjectFailureForTests(new Exception("Supersedes the parked restart"));
+                await WaitForBlocksCreated(substream0);
+
+                // Release; the superseded start must not reset the flag.
+                releaseRestart.TrySetResult();
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                Assert.Equal(1, substream0.BlocksCreatedForTests);
+
+                // Successor stays healthy: a further recovery still converges.
+                await substream0.InjectFailureForTests(new Exception("Later recovery"));
+                generator.Generate(100);
+                await WaitForCount(latestData, "substream_0", ExpectedCount(generator), failures);
+            }
+            finally
+            {
+                StreamContext.StartupBeforeGateRegistrationHookForTests = null;
+                releaseRestart.TrySetResult();
+            }
         }
 
         /// <summary>
@@ -297,6 +522,16 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
             };
         }
 
+        private static async Task WaitForBlocksCreated(FlowtideDotNet.Base.Engine.DataflowStream substream)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            while (substream.BlocksCreatedForTests != 1)
+            {
+                Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(30), "The successor never created its blocks");
+                await Task.Delay(20);
+            }
+        }
+
         private static async Task WaitForCount(
             ConcurrentDictionary<string, EventBatchData> latestData,
             string key,
@@ -306,18 +541,38 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
             var stopwatch = Stopwatch.StartNew();
             while (true)
             {
-                if (latestData.TryGetValue(key, out var batch) && batch.Count == expectedCount)
+                if (TryReadCount(latestData, key, out var count) && count == expectedCount)
                 {
                     return;
                 }
                 if (stopwatch.Elapsed > TimeSpan.FromSeconds(60))
                 {
                     var runningTasks = failures.Count(f => f.Exception?.ToString().Contains("Initialize while there are running tasks") == true);
+                    TryReadCount(latestData, key, out var last);
                     throw new TimeoutException(
-                        $"The result did not reach {expectedCount} rows, last {(latestData.TryGetValue(key, out var last) ? last.Count : 0)}. " +
+                        $"The result did not reach {expectedCount} rows, last {last}. " +
                         $"Failures containing 'Initialize while there are running tasks': {runningTasks} - the failure during the restart orphaned the running start.");
                 }
                 await Task.Delay(20);
+            }
+        }
+
+        // Reads the row count, tolerating a mid-dispose batch.
+        private static bool TryReadCount(ConcurrentDictionary<string, EventBatchData> latestData, string key, out int count)
+        {
+            count = 0;
+            if (!latestData.TryGetValue(key, out var batch))
+            {
+                return false;
+            }
+            try
+            {
+                count = batch.Count;
+                return true;
+            }
+            catch (NullReferenceException)
+            {
+                return false;
             }
         }
     }

--- a/tests/FlowtideDotNet.AcceptanceTests/Distributed/OrphanedStartRecoveryTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Distributed/OrphanedStartRecoveryTests.cs
@@ -139,7 +139,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
         {
             var generator = new DatasetGenerator(_db);
             generator.Generate(200);
-            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var latestData = new ConcurrentDictionary<string, int>();
             var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
 
             // Held on the second initialization: the first is the initial start, the second
@@ -158,7 +158,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
                 {
                     var connectorManager = new ConnectorManager();
                     connectorManager.AddSource(new MockSourceFactory("*", _db, true));
-                    connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, _ => { }));
+                    connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data.Count, 0, _ => { }));
                     substreamBuilder.AddConnectorManager(connectorManager);
                     substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
                 })
@@ -193,7 +193,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
         {
             var generator = new DatasetGenerator(_db);
             generator.Generate(200);
-            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var latestData = new ConcurrentDictionary<string, int>();
             var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
 
             var holdingStorage = new HoldingStorage(
@@ -210,7 +210,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
                 {
                     var connectorManager = new ConnectorManager();
                     connectorManager.AddSource(new MockSourceFactory("*", _db, true));
-                    connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, _ => { }));
+                    connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data.Count, 0, _ => { }));
                     substreamBuilder.AddConnectorManager(connectorManager);
                     substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
                 })
@@ -244,7 +244,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
         {
             var generator = new DatasetGenerator(_db);
             generator.Generate(200);
-            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var latestData = new ConcurrentDictionary<string, int>();
             var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
 
             // Storage only counts inits; parking is via the hook.
@@ -282,7 +282,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
                     {
                         var connectorManager = new ConnectorManager();
                         connectorManager.AddSource(new MockSourceFactory("*", _db, true));
-                        connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, _ => { }));
+                        connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data.Count, 0, _ => { }));
                         substreamBuilder.AddConnectorManager(connectorManager);
                         substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
                     })
@@ -324,7 +324,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
         {
             var generator = new DatasetGenerator(_db);
             generator.Generate(200);
-            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var latestData = new ConcurrentDictionary<string, int>();
             var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
 
             int substream0Starts = 0;
@@ -354,7 +354,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
                     {
                         var connectorManager = new ConnectorManager();
                         connectorManager.AddSource(new MockSourceFactory("*", _db, true));
-                        connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, _ => { }));
+                        connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data.Count, 0, _ => { }));
                         substreamBuilder.AddConnectorManager(connectorManager);
                         substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
                     })
@@ -406,7 +406,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
         {
             var generator = new DatasetGenerator(_db);
             generator.Generate(200);
-            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var latestData = new ConcurrentDictionary<string, int>();
             var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
 
             int substream0Starts = 0;
@@ -447,7 +447,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
                     {
                         var connectorManager = new ConnectorManager();
                         connectorManager.AddSource(new MockSourceFactory("*", _db, true));
-                        connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, _ => { }));
+                        connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data.Count, 0, _ => { }));
                         substreamBuilder.AddConnectorManager(connectorManager);
                         substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
                     })
@@ -533,7 +533,7 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
         }
 
         private static async Task WaitForCount(
-            ConcurrentDictionary<string, EventBatchData> latestData,
+            ConcurrentDictionary<string, int> latestData,
             string key,
             int expectedCount,
             ConcurrentBag<(string Substream, Exception? Exception)> failures)
@@ -541,39 +541,20 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
             var stopwatch = Stopwatch.StartNew();
             while (true)
             {
-                if (TryReadCount(latestData, key, out var count) && count == expectedCount)
+                if (latestData.TryGetValue(key, out var count) && count == expectedCount)
                 {
                     return;
                 }
                 if (stopwatch.Elapsed > TimeSpan.FromSeconds(60))
                 {
                     var runningTasks = failures.Count(f => f.Exception?.ToString().Contains("Initialize while there are running tasks") == true);
-                    TryReadCount(latestData, key, out var last);
+                    latestData.TryGetValue(key, out var last);
                     throw new TimeoutException(
                         $"The result did not reach {expectedCount} rows, last {last}. " +
                         $"Failures containing 'Initialize while there are running tasks': {runningTasks} - the failure during the restart orphaned the running start.");
                 }
                 await Task.Delay(20);
             }
-        }
-
-        // Reads the row count, tolerating a mid-dispose batch.
-        private static bool TryReadCount(ConcurrentDictionary<string, EventBatchData> latestData, string key, out int count)
-        {
-            count = 0;
-            if (!latestData.TryGetValue(key, out var batch) || batch is null)
-            {
-                return false;
-            }
-
-            var batchCount = batch.Count;
-            if (!batchCount.HasValue)
-            {
-                return false;
-            }
-
-            count = batchCount.Value;
-            return true;
         }
     }
 }

--- a/tests/FlowtideDotNet.Cluster.Orleans.Tests/OrleansClusterFixture.cs
+++ b/tests/FlowtideDotNet.Cluster.Orleans.Tests/OrleansClusterFixture.cs
@@ -14,6 +14,7 @@ using FlowtideDotNet.DependencyInjection;
 using FlowtideDotNet.Storage.Persistence.Reservoir;
 using FlowtideDotNet.Storage.Persistence.Reservoir.Internal;
 using FlowtideDotNet.Storage.Persistence.Reservoir.MemoryDisk;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
@@ -35,6 +36,8 @@ namespace FlowtideDotNet.Cluster.Orleans.Tests
             // reach the grains.
             FlowtideDotNet.Base.Engine.Internal.StateMachine.FailureStreamState.RecoveryRestartDelay = TimeSpan.FromMilliseconds(50);
             FlowtideDotNet.Core.Operators.Exchange.SubstreamCommunicationPoint.NotStartedRetrySliceMs = 50;
+            // Handoff drain must survive parallel-load starvation.
+            FlowtideDotNet.Core.Operators.Exchange.SubstreamReadOperator.HandoffDrainTimeout = TimeSpan.FromSeconds(30);
 
             var builder = new TestClusterBuilder(siloCount);
             if (durableStreamState)
@@ -45,6 +48,7 @@ namespace FlowtideDotNet.Cluster.Orleans.Tests
             {
                 builder.AddSiloBuilderConfigurator<TestSiloConfigurator>();
             }
+            builder.AddClientBuilderConfigurator<TestClientConfigurator>();
             Cluster = builder.Build();
             Cluster.Deploy();
         }
@@ -53,6 +57,18 @@ namespace FlowtideDotNet.Cluster.Orleans.Tests
         {
             Cluster.StopAllSilos();
             Cluster.Dispose();
+        }
+
+        // Client must wait out a slow MigrateAsync handoff.
+        private sealed class TestClientConfigurator : IClientBuilderConfigurator
+        {
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+            {
+                clientBuilder.Services.Configure<ClientMessagingOptions>(options =>
+                {
+                    options.ResponseTimeout = TimeSpan.FromSeconds(75);
+                });
+            }
         }
 
         private sealed class TestSiloConfigurator : ISiloConfigurator


### PR DESCRIPTION
This should fix the latest test error that was flaky.