### PR TITLE
Fix so aliases can be used in WHERE filters

### DIFF
--- a/src/FlowtideDotNet.Substrait/Sql/EmitData.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/EmitData.cs
@@ -33,6 +33,7 @@ namespace FlowtideDotNet.Substrait.Sql
         private SortedDictionary<string, Expression.CompoundIdentifier> compundIdentifiers;
         private List<string> _names;
         private List<SubstraitBaseType> _types;
+        private readonly HashSet<int> _hiddenFromWildcard;
 
         public EmitData()
         {
@@ -40,6 +41,7 @@ namespace FlowtideDotNet.Substrait.Sql
             compundIdentifiers = new SortedDictionary<string, Expression.CompoundIdentifier>(StringComparer.OrdinalIgnoreCase);
             _names = new List<string>();
             _types = new List<SubstraitBaseType>();
+            _hiddenFromWildcard = new HashSet<int>();
         }
 
         public EmitData Clone()
@@ -61,12 +63,14 @@ namespace FlowtideDotNet.Substrait.Sql
             {
                 clone._types.Add(type);
             }
+            clone._hiddenFromWildcard.UnionWith(_hiddenFromWildcard);
             return clone;
         }
 
         public EmitData CloneWithAlias(string alias, List<string>? columnNames)
         {
             var clone = new EmitData();
+            clone._hiddenFromWildcard.UnionWith(_hiddenFromWildcard);
 
             if (columnNames != null)
             {
@@ -162,6 +166,10 @@ namespace FlowtideDotNet.Substrait.Sql
             {
                 _types.Add(type);
             }
+            foreach (var hidden in left._hiddenFromWildcard)
+            {
+                _hiddenFromWildcard.Add(hidden + offset);
+            }
         }
 
         public void UpdateType(int index, SubstraitBaseType type)
@@ -175,8 +183,13 @@ namespace FlowtideDotNet.Substrait.Sql
             Add(new Expression.CompoundIdentifier(new SqlParser.Sequence<Ident>(new List<Ident>() { new Ident(name) })), index, name, type);
         }
 
-        public void Add(Expression expr, int index, string name, SubstraitBaseType type)
+        /// <param name="hiddenFromWildcard">Column exists only for internal use, '*' must not expand to it.</param>
+        public void Add(Expression expr, int index, string name, SubstraitBaseType type, bool hiddenFromWildcard = false)
         {
+            if (hiddenFromWildcard)
+            {
+                _hiddenFromWildcard.Add(index);
+            }
             if (expr is Expression.CompoundIdentifier compound)
             {
                 var k = string.Join(".", compound.Idents.Select(x => x.Value));
@@ -405,6 +418,7 @@ namespace FlowtideDotNet.Substrait.Sql
             var indicesToExpression = emitList
                 .Where(x => ExpressionStartsWith(x.Key, objectName))
                 .SelectMany(x => x.Value.Index.Select(y => new { index = y, expression = x.Key }))
+                .Where(x => !_hiddenFromWildcard.Contains(x.index))
                 .GroupBy(x => x.index)
                 .Select(x => new ExpressionInformation(x.Key, GetName(x.Key), x.Select(z => z.expression).ToList(), _types[x.Key]))
                 .OrderBy(x => x.Index)

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/ContainsWindowFunctionVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/ContainsWindowFunctionVisitor.cs
@@ -24,14 +24,21 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
     {
         private readonly SqlFunctionRegister sqlFunctionRegister;
         private HashSet<Expression.Function> _windowFunctions;
+        private HashSet<string> _identifiers;
 
         public ContainsWindowFunctionVisitor(SqlFunctionRegister sqlFunctionRegister)
         {
             this.sqlFunctionRegister = sqlFunctionRegister;
             _windowFunctions = new HashSet<Expression.Function>();
+            _identifiers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public IReadOnlySet<Expression.Function> WindowFunctions => _windowFunctions;
+
+        /// <summary>
+        /// Unqualified column names seen while visiting, used to find select list alias usage.
+        /// </summary>
+        public IReadOnlySet<string> Identifiers => _identifiers;
 
         public bool VisitSelectItem(SelectItem selectItem)
         {
@@ -111,6 +118,10 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
 
         protected override bool VisitCompoundIdentifier(Expression.CompoundIdentifier compoundIdentifier, object? state)
         {
+            if (compoundIdentifier.Idents.Count == 1)
+            {
+                _identifiers.Add(compoundIdentifier.Idents[0].Value);
+            }
             return false;
         }
 

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/ContainsWindowFunctionVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/ContainsWindowFunctionVisitor.cs
@@ -24,7 +24,7 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
     {
         private readonly SqlFunctionRegister sqlFunctionRegister;
         private HashSet<Expression.Function> _windowFunctions;
-        private HashSet<string> _identifiers;
+        private readonly HashSet<string> _identifiers;
 
         public ContainsWindowFunctionVisitor(SqlFunctionRegister sqlFunctionRegister)
         {

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/SqlSubstraitVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/SqlSubstraitVisitor.cs
@@ -34,9 +34,9 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
         private readonly List<Relation> subRelations;
         private readonly Stack<EmitData> scopeStack = new Stack<EmitData>();
 
-        private SqlExpressionVisitor CreateExpressionVisitor()
+        private SqlExpressionVisitor CreateExpressionVisitor(IReadOnlyDictionary<string, Expression>? columnAliases = null)
         {
-            return new SqlExpressionVisitor(sqlFunctionRegister, q => this.Visit(q, null), scopeStack.ToList());
+            return new SqlExpressionVisitor(sqlFunctionRegister, q => this.Visit(q, null), scopeStack.ToList(), columnAliases);
         }
 
         public SqlSubstraitVisitor(SqlPlanBuilder sqlPlanBuilder, SqlFunctionRegister sqlFunctionRegister)
@@ -531,17 +531,24 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
             {
                 if (select.Selection != null)
                 {
-                    bool selectionContainsWindow = false;
                     ContainsWindowFunctionVisitor containsWindowSelectFunctionVisitor = new ContainsWindowFunctionVisitor(sqlFunctionRegister);
-                    selectionContainsWindow |= containsWindowSelectFunctionVisitor.Visit(select.Selection, default);
+                    bool selectionContainsWindow = containsWindowSelectFunctionVisitor.Visit(select.Selection, default);
+
+                    // Select list aliases the where clause uses, e.g. 'WHERE rownum <= 1' on a ROW_NUMBER() alias
+                    var filterAliases = GetAliasesUsedInFilter(select, containsWindowSelectFunctionVisitor.Identifiers, outNode.EmitData);
+
+                    // Window functions behind such an alias must be computed before the filter,
+                    // the projection then reads that column instead of computing it again
+                    outNode = VisitFilterAliasWindowFunctions(filterAliases.Values, outNode);
+
                     if (selectionContainsWindow)
                     {
                         // Does not include expressions from the window functions in the emit data
-                        outNode = VisitFilterWithWindowExpressions(select.Selection, containsWindowSelectFunctionVisitor, outNode);
+                        outNode = VisitFilterWithWindowExpressions(select.Selection, containsWindowSelectFunctionVisitor, outNode, filterAliases);
                     }
                     else
                     {
-                        var exprVisitor = CreateExpressionVisitor();
+                        var exprVisitor = CreateExpressionVisitor(filterAliases);
                         var expr = exprVisitor.Visit(select.Selection, outNode.EmitData);
                         outNode = new RelationData(new FilterRelation()
                         {
@@ -645,11 +652,71 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
             return outNode;
         }
 
-        private RelationData VisitFilterWithWindowExpressions(Expression filter, ContainsWindowFunctionVisitor containsWindowFunctionVisitor, RelationData parent)
+        /// <summary>
+        /// Finds the select list aliases that the where clause refers to, e.g. 'WHERE rownum &lt;= 1'
+        /// where rownum is declared in the select list. Columns of the input win over an alias.
+        /// </summary>
+        private static Dictionary<string, Expression> GetAliasesUsedInFilter(Select select, IReadOnlySet<string> filterIdentifiers, EmitData emitData)
+        {
+            var aliases = new Dictionary<string, Expression>(StringComparer.OrdinalIgnoreCase);
+
+            if (select.Projection == null || filterIdentifiers.Count == 0)
+            {
+                return aliases;
+            }
+
+            foreach (var item in select.Projection)
+            {
+                if (item is not SelectItem.ExpressionWithAlias exprAlias)
+                {
+                    continue;
+                }
+                string alias = exprAlias.Alias;
+                if (!filterIdentifiers.Contains(alias) || aliases.ContainsKey(alias))
+                {
+                    continue;
+                }
+                var identifier = new Expression.CompoundIdentifier(new Sequence<Ident>(new List<Ident>() { new Ident(alias) }));
+                if (emitData.TryGetEmitIndex(identifier, out _, out _, out _))
+                {
+                    continue;
+                }
+                aliases.Add(alias, exprAlias.Expression);
+            }
+
+            return aliases;
+        }
+
+        /// <summary>
+        /// Computes the window functions that the where clause reaches through a select list alias,
+        /// so the filter and the projection share one window relation.
+        /// </summary>
+        private RelationData VisitFilterAliasWindowFunctions(IEnumerable<Expression> aliasExpressions, RelationData parent)
+        {
+            var containsWindowFunctionVisitor = new ContainsWindowFunctionVisitor(sqlFunctionRegister);
+            bool containsWindow = false;
+            foreach (var aliasExpression in aliasExpressions)
+            {
+                containsWindow |= containsWindowFunctionVisitor.Visit(aliasExpression, default);
+            }
+
+            if (!containsWindow)
+            {
+                return parent;
+            }
+
+            return VisitWindow(containsWindowFunctionVisitor, parent);
+        }
+
+        private RelationData VisitFilterWithWindowExpressions(
+            Expression filter,
+            ContainsWindowFunctionVisitor containsWindowFunctionVisitor,
+            RelationData parent,
+            IReadOnlyDictionary<string, Expression>? columnAliases = null)
         {
             var windowResult = VisitWindow(containsWindowFunctionVisitor, parent);
 
-            var exprVisitor = new SqlExpressionVisitor(sqlFunctionRegister);
+            var exprVisitor = new SqlExpressionVisitor(sqlFunctionRegister, columnAliases: columnAliases);
             var expr = exprVisitor.Visit(filter, windowResult.EmitData);
 
             var filterRelation = new FilterRelation()
@@ -744,6 +811,11 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
             // Go through the found functions, we create one relation per window function at this time
             foreach (var windowFunction in containsWindowFunctionVisitor.WindowFunctions)
             {
+                // Already computed, for example hoisted before a where clause that filters on its alias
+                if (outputData.EmitData.TryGetEmitIndex(windowFunction, out _, out _, out _))
+                {
+                    continue;
+                }
                 if (!sqlFunctionRegister.TryGetWindowMapper(windowFunction.Name, out var mapper))
                 {
                     throw new NotSupportedException($"Window function '{windowFunction.Name}' is not supported");
@@ -804,7 +876,8 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
 
                 for (int i = 0; i  < windowGroup.Value.Count; i++)
                 {
-                    emitData.Add(windowGroup.Value[i].Item1, emitData.Count, $"$window{i}", windowGroup.Value[i].Item3);
+                    // Hidden from '*', the column only exists so the projection can reference the function
+                    emitData.Add(windowGroup.Value[i].Item1, emitData.Count, $"$window{i}", windowGroup.Value[i].Item3, hiddenFromWildcard: true);
                 }
 
 

--- a/src/FlowtideDotNet.Substrait/Sql/SqlExpressionVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/SqlExpressionVisitor.cs
@@ -20,6 +20,7 @@ using FlowtideDotNet.Substrait.Type;
 using SqlParser;
 using SqlParser.Ast;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using static SqlParser.Ast.Expression;
 
@@ -27,18 +28,25 @@ namespace FlowtideDotNet.Substrait.Sql
 {
     public class SqlExpressionVisitor : BaseExpressionVisitor<ExpressionData, EmitData>
     {
+        private static readonly Dictionary<string, SqlParser.Ast.Expression> EmptyColumnAliases = new Dictionary<string, SqlParser.Ast.Expression>();
+
         private readonly SqlFunctionRegister sqlFunctionRegister;
         private readonly Func<Query, RelationData?>? compileQuery;
         private readonly IReadOnlyList<EmitData> parentScopes;
+        private readonly IReadOnlyDictionary<string, SqlParser.Ast.Expression> columnAliases;
+        private readonly HashSet<string> aliasesBeingResolved;
 
         internal SqlExpressionVisitor(
             SqlFunctionRegister sqlFunctionRegister,
             Func<Query, RelationData?>? compileQuery = null,
-            IReadOnlyList<EmitData>? parentScopes = null)
+            IReadOnlyList<EmitData>? parentScopes = null,
+            IReadOnlyDictionary<string, SqlParser.Ast.Expression>? columnAliases = null)
         {
             this.sqlFunctionRegister = sqlFunctionRegister;
             this.compileQuery = compileQuery;
             this.parentScopes = parentScopes ?? System.Array.Empty<EmitData>();
+            this.columnAliases = columnAliases ?? EmptyColumnAliases;
+            this.aliasesBeingResolved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public override ExpressionData Visit(SqlParser.Ast.Expression expression, EmitData state)
@@ -67,7 +75,58 @@ namespace FlowtideDotNet.Substrait.Sql
                 }
             }
 
+            // Fall back on aliases declared in the select list, e.g. 'WHERE rownum <= 1'
+            if (TryGetColumnAlias(expression, out var aliasName, out var aliasExpression))
+            {
+                if (!aliasesBeingResolved.Add(aliasName))
+                {
+                    throw new SubstraitParseException($"Column alias '{aliasName}' references itself.");
+                }
+                try
+                {
+                    return Visit(aliasExpression, state);
+                }
+                finally
+                {
+                    aliasesBeingResolved.Remove(aliasName);
+                }
+            }
+
             return base.Visit(expression, state);
+        }
+
+        private bool TryGetColumnAlias(
+            SqlParser.Ast.Expression expression,
+            [NotNullWhen(true)] out string? aliasName,
+            [NotNullWhen(true)] out SqlParser.Ast.Expression? aliasExpression)
+        {
+            aliasName = default;
+            aliasExpression = default;
+
+            if (columnAliases.Count == 0)
+            {
+                return false;
+            }
+
+            string? identifierName = default;
+            if (expression is SqlParser.Ast.Expression.Identifier identifier)
+            {
+                identifierName = identifier.Ident.Value;
+            }
+            else if (expression is SqlParser.Ast.Expression.CompoundIdentifier compoundIdentifier &&
+                compoundIdentifier.Idents.Count == 1)
+            {
+                identifierName = compoundIdentifier.Idents[0].Value;
+            }
+
+            if (identifierName == null ||
+                !columnAliases.TryGetValue(identifierName, out aliasExpression))
+            {
+                return false;
+            }
+
+            aliasName = identifierName;
+            return true;
         }
 
         protected override ExpressionData VisitBinaryOperation(SqlParser.Ast.Expression.BinaryOp binaryOp, EmitData state)

--- a/tests/FlowtideDotNet.AcceptanceTests/FilterTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/FilterTests.cs
@@ -233,5 +233,34 @@ namespace FlowtideDotNet.AcceptanceTests
             await WaitForUpdate();
             AssertCurrentDataEqual(Users.Where(x => x.Gender == Entities.Gender.Male ^ x.UserKey <= 200).Select(x => new { x.UserKey }));
         }
+
+        [Fact]
+        public async Task SelectListAliasFilter()
+        {
+            GenerateData();
+            await StartStream(@"
+                INSERT INTO output
+                SELECT
+                    u.userkey + 100 as shiftedkey
+                FROM users u
+                WHERE shiftedkey > 200");
+            await WaitForUpdate();
+            AssertCurrentDataEqual(Users.Where(x => x.UserKey + 100 > 200).Select(x => new { shiftedkey = x.UserKey + 100 }));
+        }
+
+        [Fact]
+        public async Task SelectListAliasFilterUsesColumnBeforeAlias()
+        {
+            GenerateData();
+            // 'userkey' is a column of the input, it must win over the alias with the same name
+            await StartStream(@"
+                INSERT INTO output
+                SELECT
+                    u.userkey + 100 as userkey
+                FROM users u
+                WHERE userkey > 200");
+            await WaitForUpdate();
+            AssertCurrentDataEqual(Users.Where(x => x.UserKey > 200).Select(x => new { userkey = x.UserKey + 100 }));
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/WindowFunctionTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/WindowFunctionTests.cs
@@ -912,6 +912,110 @@ namespace FlowtideDotNet.AcceptanceTests
         }
 
         [Fact]
+        public async Task FilterOnRowNumberAlias()
+        {
+            GenerateData();
+
+            // Top N pattern, the where clause reads the row number through its select list alias.
+            // The projected value must be the one that was filtered on, not a recomputed one.
+            await StartStream(@"
+            INSERT INTO output
+            SELECT
+                CompanyId,
+                UserKey,
+                ROW_NUMBER() OVER (PARTITION BY CompanyId ORDER BY UserKey) as rownum
+            FROM users
+            WHERE rownum <= 3
+            ");
+
+            await WaitForUpdate();
+
+            var expected = Users.GroupBy(x => $"{x.CompanyId}")
+                .SelectMany(g =>
+                {
+                    var orderedByKey = g.OrderBy(x => x.UserKey).ToList();
+                    List<RowNumberResult> output = new List<RowNumberResult>();
+                    for (int i = 0; i < orderedByKey.Count; i++)
+                    {
+                        output.Add(new RowNumberResult(orderedByKey[i].CompanyId, orderedByKey[i].UserKey, i + 1));
+                    }
+                    return output;
+                })
+                .Where(x => x.value <= 3).ToList();
+
+            AssertCurrentDataEqual(expected);
+        }
+
+        [Fact]
+        public async Task FilterOnRowNumberAliasFromSubQuery()
+        {
+            GenerateData();
+
+            // The nexmark q6 shape, the row number alias is filtered inside the sub query
+            await StartStream(@"
+            INSERT INTO output
+            SELECT
+                q.CompanyId,
+                q.UserKey,
+                q.rownum
+            FROM (
+                SELECT
+                    CompanyId,
+                    UserKey,
+                    ROW_NUMBER() OVER (PARTITION BY CompanyId ORDER BY UserKey) as rownum
+                FROM users
+                WHERE rownum <= 1
+            ) q
+            ");
+
+            await WaitForUpdate();
+
+            var expected = Users.GroupBy(x => $"{x.CompanyId}")
+                .Select(g =>
+                {
+                    var first = g.OrderBy(x => x.UserKey).First();
+                    return new RowNumberResult(first.CompanyId, first.UserKey, 1);
+                }).ToList();
+
+            AssertCurrentDataEqual(expected);
+        }
+
+        [Fact]
+        public async Task WildcardDoesNotIncludeWindowFunctionColumn()
+        {
+            GenerateData();
+
+            // '*' must expand to the columns of the input only, the window function
+            // gets a column of its own that the wildcard must not pick up
+            await StartStream(@"
+            INSERT INTO output
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY CompanyId ORDER BY UserKey) as rownum
+            FROM (
+                SELECT
+                    CompanyId,
+                    UserKey
+                FROM users
+            ) u
+            ");
+
+            await WaitForUpdate();
+
+            var expected = Users.GroupBy(x => $"{x.CompanyId}")
+                .SelectMany(g =>
+                {
+                    var orderedByKey = g.OrderBy(x => x.UserKey).ToList();
+                    List<RowNumberResult> output = new List<RowNumberResult>();
+                    for (int i = 0; i < orderedByKey.Count; i++)
+                    {
+                        output.Add(new RowNumberResult(orderedByKey[i].CompanyId, orderedByKey[i].UserKey, i + 1));
+                    }
+                    return output;
+                }).ToList();
+
+            AssertCurrentDataEqual(expected);
+        }
+
+        [Fact]
         public async Task LagWithPartitionOneArgument()
         {
             GenerateData();

--- a/tests/FlowtideDotNet.Nexmark/Query6.cs
+++ b/tests/FlowtideDotNet.Nexmark/Query6.cs
@@ -1,12 +1,22 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using BenchmarkDotNet.Attributes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using FlowtideDotNet.Nexmark.Internal.Diagnosers;
 using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Nexmark
 {
+    [EventCountDiagnoser]
     public class Query6 : QueryBase
     {
         [Benchmark]

--- a/tests/FlowtideDotNet.Nexmark/Query6.cs
+++ b/tests/FlowtideDotNet.Nexmark/Query6.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Nexmark
+{
+    public class Query6 : QueryBase
+    {
+        [Benchmark]
+        public async Task Q6()
+        {
+            await Stream.StartStream(@"
+            INSERT INTO output
+            SELECT
+                Q.seller,
+                AVG(Q.price) OVER
+                    (PARTITION BY Q.seller ORDER BY Q.date_time ROWS BETWEEN 10 PRECEDING AND CURRENT ROW) AS avgprice
+            FROM (
+                SELECT *, ROW_NUMBER() OVER (PARTITION BY id, seller ORDER BY price DESC) AS rownum
+                FROM (SELECT A.id, A.seller, B.price, B.date_time
+                    FROM auction AS A,
+                        bid AS B
+                    WHERE A.id = B.auction
+                        and B.date_time between A.dateTime and A.expires) AS J
+                WHERE rownum <= 1
+            ) AS Q;
+            ", planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings()
+            {
+                Parallelization = 1
+            });
+            await Stream.WaitForUpdate();
+        }
+    }
+}


### PR DESCRIPTION
This is required for nexmark query 6