### PR TITLE
Add common subplan optimizer

### DIFF
--- a/src/FlowtideDotNet.Core/Optimizer/CommonSubPlan/CommonSubPlanCountVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/CommonSubPlan/CommonSubPlanCountVisitor.cs
@@ -1,0 +1,71 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Relations;
+
+namespace FlowtideDotNet.Core.Optimizer.CommonSubPlan
+{
+    /// <summary>
+    /// Counts how many times each subtree value occurs in the plan.
+    /// Only subtrees built entirely from safe value equality types are counted.
+    /// </summary>
+    internal class CommonSubPlanCountVisitor : OptimizerBaseVisitor
+    {
+        /// <summary>
+        /// Occurrence count per subtree value.
+        /// </summary>
+        public Dictionary<Relation, int> Counts { get; } = new Dictionary<Relation, int>();
+
+        /// <summary>
+        /// Node instances whose whole subtree has value based equality.
+        /// </summary>
+        public HashSet<Relation> SafeNodes { get; } = new HashSet<Relation>(ReferenceEqualityComparer.Instance);
+
+        public override Relation Visit(Relation relation, object state)
+        {
+            // Children are visited first through the base visitor
+            var result = base.Visit(relation, state);
+
+            if (CommonSubPlanUtils.HasValueEquality(relation))
+            {
+                bool safe = true;
+                foreach (var child in CommonSubPlanUtils.GetChildren(relation))
+                {
+                    if (!SafeNodes.Contains(child))
+                    {
+                        safe = false;
+                        break;
+                    }
+                }
+                if (safe)
+                {
+                    SafeNodes.Add(relation);
+                    if (CommonSubPlanUtils.IsExtractable(relation))
+                    {
+                        Counts[relation] = Counts.TryGetValue(relation, out var count) ? count + 1 : 1;
+                    }
+                }
+            }
+            return result;
+        }
+
+        public override Relation VisitIterationRelation(IterationRelation iterationRelation, object state)
+        {
+            // Loop internals cannot use references, only visit the input
+            if (iterationRelation.Input != null)
+            {
+                iterationRelation.Input = Visit(iterationRelation.Input, state);
+            }
+            return iterationRelation;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/CommonSubPlan/CommonSubPlanOptimizer.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/CommonSubPlan/CommonSubPlanOptimizer.cs
@@ -1,0 +1,63 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait;
+using FlowtideDotNet.Substrait.Relations;
+
+namespace FlowtideDotNet.Core.Optimizer.CommonSubPlan
+{
+    /// <summary>
+    /// Finds identical subtrees in the plan and computes them only once.
+    /// The subtree is moved to its own plan relation and each usage is replaced
+    /// with a reference relation, so for example the same aggregation used in
+    /// two places becomes a single operator with two outputs.
+    /// </summary>
+    internal static class CommonSubPlanOptimizer
+    {
+        public static Plan Optimize(Plan plan)
+        {
+            // Substream plans place relations in specific streams, sharing
+            // between substreams requires exchanges, skip those plans.
+            foreach (var relation in plan.Relations)
+            {
+                if (relation is SubStreamRootRelation)
+                {
+                    return plan;
+                }
+            }
+
+            var countVisitor = new CommonSubPlanCountVisitor();
+            for (int i = 0; i < plan.Relations.Count; i++)
+            {
+                countVisitor.Visit(plan.Relations[i], null!);
+            }
+
+            bool anyDuplicate = false;
+            foreach (var count in countVisitor.Counts.Values)
+            {
+                if (count >= 2)
+                {
+                    anyDuplicate = true;
+                    break;
+                }
+            }
+            if (!anyDuplicate)
+            {
+                return plan;
+            }
+
+            var replaceVisitor = new CommonSubPlanReplaceVisitor(plan, countVisitor.Counts, countVisitor.SafeNodes);
+            replaceVisitor.Run();
+            return plan;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/CommonSubPlan/CommonSubPlanReplaceVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/CommonSubPlan/CommonSubPlanReplaceVisitor.cs
@@ -1,0 +1,127 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait;
+using FlowtideDotNet.Substrait.Relations;
+
+namespace FlowtideDotNet.Core.Optimizer.CommonSubPlan
+{
+    /// <summary>
+    /// Replaces duplicated subtrees with reference relations.
+    /// The first usage moves the subtree to its own plan relation, all other
+    /// usages reference it so the result is only computed once.
+    /// </summary>
+    internal class CommonSubPlanReplaceVisitor : OptimizerBaseVisitor
+    {
+        private readonly Plan _plan;
+        private readonly Dictionary<Relation, int> _counts;
+        private readonly HashSet<Relation> _safeNodes;
+        private readonly Dictionary<Relation, int> _definitions = new Dictionary<Relation, int>();
+        private bool _atRoot;
+
+        public CommonSubPlanReplaceVisitor(Plan plan, Dictionary<Relation, int> counts, HashSet<Relation> safeNodes)
+        {
+            _plan = plan;
+            _counts = counts;
+            _safeNodes = safeNodes;
+        }
+
+        public void Run()
+        {
+            // Existing shareable top level relations, such as views, become definitions directly
+            for (int i = 0; i < _plan.Relations.Count; i++)
+            {
+                var relation = _plan.Relations[i];
+                if (IsShared(relation) && !_definitions.ContainsKey(relation))
+                {
+                    _definitions.Add(relation, i);
+                }
+            }
+
+            // Count is re-evaluated each iteration so extracted definitions are visited as well
+            for (int i = 0; i < _plan.Relations.Count; i++)
+            {
+                _atRoot = true;
+                _plan.Relations[i] = Visit(_plan.Relations[i], null!);
+            }
+        }
+
+        private bool IsShared(Relation relation)
+        {
+            return _safeNodes.Contains(relation) &&
+                CommonSubPlanUtils.IsExtractable(relation) &&
+                _counts.TryGetValue(relation, out var count) && count >= 2;
+        }
+
+        public override Relation Visit(Relation relation, object state)
+        {
+            var isRoot = _atRoot;
+            _atRoot = false;
+
+            if (isRoot)
+            {
+                // Top level relations are never replaced, they can only act as definitions
+                return base.Visit(relation, state);
+            }
+
+            if (_definitions.TryGetValue(relation, out var relationId))
+            {
+                // This copy of the subtree is discarded, remove its occurrences
+                DecrementCounts(relation);
+                return new ReferenceRelation()
+                {
+                    RelationId = relationId,
+                    ReferenceOutputLength = relation.OutputLength
+                };
+            }
+            if (IsShared(relation))
+            {
+                // First usage, move the subtree to its own relation
+                relationId = _plan.Relations.Count;
+                _plan.Relations.Add(relation);
+                _definitions.Add(relation, relationId);
+                return new ReferenceRelation()
+                {
+                    RelationId = relationId,
+                    ReferenceOutputLength = relation.OutputLength
+                };
+            }
+            return base.Visit(relation, state);
+        }
+
+        /// <summary>
+        /// Removes the occurrences of a discarded subtree so its inner nodes
+        /// are not extracted with only a single remaining usage.
+        /// </summary>
+        private void DecrementCounts(Relation relation)
+        {
+            if (_counts.TryGetValue(relation, out var count))
+            {
+                _counts[relation] = count - 1;
+            }
+            foreach (var child in CommonSubPlanUtils.GetChildren(relation))
+            {
+                DecrementCounts(child);
+            }
+        }
+
+        public override Relation VisitIterationRelation(IterationRelation iterationRelation, object state)
+        {
+            // Loop internals cannot use references, only visit the input
+            if (iterationRelation.Input != null)
+            {
+                iterationRelation.Input = Visit(iterationRelation.Input, state);
+            }
+            return iterationRelation;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/CommonSubPlan/CommonSubPlanUtils.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/CommonSubPlan/CommonSubPlanUtils.cs
@@ -1,0 +1,128 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Relations;
+
+namespace FlowtideDotNet.Core.Optimizer.CommonSubPlan
+{
+    internal static class CommonSubPlanUtils
+    {
+        /// <summary>
+        /// Relation types with verified deep value based equality.
+        /// Only subtrees built entirely from these types can be shared,
+        /// types missing from this list fall back to the base class equality
+        /// which would treat different subtrees as equal.
+        /// Types added here must also return their inputs in <see cref="GetChildren"/>,
+        /// otherwise an unsafe input is never checked.
+        /// </summary>
+        public static bool HasValueEquality(Relation relation)
+        {
+            switch (relation)
+            {
+                case ReadRelation:
+                case VirtualTableReadRelation:
+                case ReferenceRelation:
+                case FilterRelation:
+                case ProjectRelation:
+                case AggregateRelation:
+                case JoinRelation:
+                case MergeJoinRelation:
+                case SetRelation:
+                case SortRelation:
+                case TopNRelation:
+                case FetchRelation:
+                case BufferRelation:
+                case NormalizationRelation:
+                case TableFunctionRelation:
+                case ConsistentPartitionWindowRelation:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Only non leaf subtrees are extracted, sharing plain reads would
+        /// stop later filter pushdown into each read.
+        /// </summary>
+        public static bool IsExtractable(Relation relation)
+        {
+            if (!HasValueEquality(relation))
+            {
+                return false;
+            }
+            foreach (var _ in GetChildren(relation))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Child relations for the value equality types, other types are not needed
+        /// since their subtrees are never shared.
+        /// </summary>
+        public static IEnumerable<Relation> GetChildren(Relation relation)
+        {
+            switch (relation)
+            {
+                case FilterRelation filter:
+                    yield return filter.Input;
+                    break;
+                case ProjectRelation project:
+                    yield return project.Input;
+                    break;
+                case AggregateRelation aggregate:
+                    yield return aggregate.Input;
+                    break;
+                case JoinRelation join:
+                    yield return join.Left;
+                    yield return join.Right;
+                    break;
+                case MergeJoinRelation mergeJoin:
+                    yield return mergeJoin.Left;
+                    yield return mergeJoin.Right;
+                    break;
+                case SetRelation set:
+                    foreach (var input in set.Inputs)
+                    {
+                        yield return input;
+                    }
+                    break;
+                case SortRelation sort:
+                    yield return sort.Input;
+                    break;
+                case TopNRelation topN:
+                    yield return topN.Input;
+                    break;
+                case FetchRelation fetch:
+                    yield return fetch.Input;
+                    break;
+                case BufferRelation buffer:
+                    yield return buffer.Input;
+                    break;
+                case NormalizationRelation normalization:
+                    yield return normalization.Input;
+                    break;
+                case TableFunctionRelation tableFunction:
+                    if (tableFunction.Input != null)
+                    {
+                        yield return tableFunction.Input;
+                    }
+                    break;
+                case ConsistentPartitionWindowRelation window:
+                    yield return window.Input;
+                    break;
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
@@ -47,6 +47,13 @@ namespace FlowtideDotNet.Core.Optimizer
                 plan.Relations[i] = relation;
             }
 
+            // Runs after filter pushdown so subtrees that only differ in pushed
+            // down filters are not merged, but before emits diverge the subtrees.
+            if (settings.FindCommonSubPlans)
+            {
+                plan = CommonSubPlan.CommonSubPlanOptimizer.Optimize(plan);
+            }
+
             plan = JoinProjectionPushdown.JoinProjectionPushdown.Optimize(plan);
 
             for (int i = 0; i < plan.Relations.Count; i++)

--- a/src/FlowtideDotNet.Core/Optimizer/PlanOptimizerSettings.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/PlanOptimizerSettings.cs
@@ -31,6 +31,12 @@ namespace FlowtideDotNet.Core.Optimizer
         /// </summary>
         public bool SimplifyProjection { get; set; } = true;
 
+        /// <summary>
+        /// Finds identical subtrees in the plan and computes them only once,
+        /// each usage references the shared result.
+        /// </summary>
+        public bool FindCommonSubPlans { get; set; } = true;
+
         public int Parallelization { get; set; } = 1;
 
         public bool TryAddWatermarkOutputMode { get; set; } = true;

--- a/src/FlowtideDotNet.Substrait/Expressions/AggregateFunction.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/AggregateFunction.cs
@@ -44,7 +44,8 @@ namespace FlowtideDotNet.Substrait.Expressions
             return other != null &&
                    ExtensionUri == other.ExtensionUri &&
                    ExtensionName == other.ExtensionName &&
-                   Arguments.SequenceEqual(other.Arguments);
+                   Arguments.SequenceEqual(other.Arguments) &&
+                   FunctionOptions.AreEqual(Options, other.Options);
         }
 
         public override int GetHashCode()
@@ -56,6 +57,7 @@ namespace FlowtideDotNet.Substrait.Expressions
             {
                 code.Add(argument);
             }
+            FunctionOptions.AddToHash(ref code, Options);
             return code.ToHashCode();
         }
 

--- a/src/FlowtideDotNet.Substrait/Expressions/FunctionOptions.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/FunctionOptions.cs
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace FlowtideDotNet.Substrait.Expressions
+{
+    /// <summary>
+    /// Shared equality rules for function options, used by scalar, aggregate
+    /// and window functions. Options change how a function behaves, so they are
+    /// part of the function identity.
+    /// </summary>
+    internal static class FunctionOptions
+    {
+        /// <summary>
+        /// No options and empty options mean the same thing to a consumer,
+        /// the sql builder creates an empty list while serialization gives null.
+        /// </summary>
+        public static bool AreEqual(SortedList<string, string>? left, SortedList<string, string>? right)
+        {
+            if ((left?.Count ?? 0) != (right?.Count ?? 0))
+            {
+                return false;
+            }
+            if (left == null || right == null)
+            {
+                return true;
+            }
+            return left.SequenceEqual(right);
+        }
+
+        /// <summary>
+        /// Adds the options to a hash code, null and empty give the same result.
+        /// </summary>
+        public static void AddToHash(ref HashCode code, SortedList<string, string>? options)
+        {
+            if (options == null)
+            {
+                return;
+            }
+            foreach (var option in options)
+            {
+                code.Add(option.Key);
+                code.Add(option.Value);
+            }
+        }
+    }
+}

--- a/src/FlowtideDotNet.Substrait/Expressions/ScalarFunction.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/ScalarFunction.cs
@@ -49,7 +49,8 @@ namespace FlowtideDotNet.Substrait.Expressions
             return other != null &&
                    ExtensionUri == other.ExtensionUri &&
                    ExtensionName == other.ExtensionName &&
-                   Arguments.SequenceEqual(other.Arguments);
+                   Arguments.SequenceEqual(other.Arguments) &&
+                   FunctionOptions.AreEqual(Options, other.Options);
         }
 
         public override int GetHashCode()
@@ -61,6 +62,7 @@ namespace FlowtideDotNet.Substrait.Expressions
             {
                 code.Add(argument);
             }
+            FunctionOptions.AddToHash(ref code, Options);
             return code.ToHashCode();
         }
 

--- a/src/FlowtideDotNet.Substrait/Expressions/WindowFunction.cs
+++ b/src/FlowtideDotNet.Substrait/Expressions/WindowFunction.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Substrait.Relations;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,7 +19,7 @@ using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Substrait.Expressions
 {
-    public class WindowFunction
+    public class WindowFunction : IEquatable<WindowFunction>
     {
         public required string ExtensionUri { get; set; }
         public required string ExtensionName { get; set; }
@@ -30,6 +31,98 @@ namespace FlowtideDotNet.Substrait.Expressions
         public WindowBound? LowerBound { get; set; }
 
         public WindowBound? UpperBound { get; set; }
+
+        public bool Equals(WindowFunction? other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (!ExtensionUri.Equals(other.ExtensionUri))
+            {
+                return false;
+            }
+
+            if (!ExtensionName.Equals(other.ExtensionName))
+            {
+                return false;
+            }
+
+            if (!Arguments.SequenceEqual(other.Arguments))
+            {
+                return false;
+            }
+
+            if (!FunctionOptions.AreEqual(Options, other.Options))
+            {
+                return false;
+            }
+
+            if (LowerBound != null && other.LowerBound != null)
+            {
+                if (!LowerBound.Equals(other.LowerBound))
+                {
+                    return false;
+                }
+            }
+            else if (LowerBound != other.LowerBound)
+            {
+                return false;
+            }
+
+            if (UpperBound != null && other.UpperBound != null)
+            {
+                if (!UpperBound.Equals(other.UpperBound))
+                {
+                    return false;
+                }
+            }
+            else if (UpperBound != other.UpperBound)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is WindowFunction other &&
+                Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            HashCode code = new HashCode();
+            code.Add(ExtensionUri);
+            code.Add(ExtensionName);
+            foreach (var argument in Arguments)
+            {
+                code.Add(argument);
+            }
+            FunctionOptions.AddToHash(ref code, Options);
+            if (LowerBound != null)
+            {
+                code.Add(LowerBound);
+            }
+            if (UpperBound != null)
+            {
+                code.Add(UpperBound);
+            }
+            return code.ToHashCode();
+        }
+
+        public static bool operator ==(WindowFunction? left, WindowFunction? right)
+        {
+            return EqualityComparer<WindowFunction>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(WindowFunction? left, WindowFunction? right)
+        {
+            return !(left == right);
+        }
     }
 
     public enum WindowBoundType
@@ -47,41 +140,217 @@ namespace FlowtideDotNet.Substrait.Expressions
         public abstract WindowBoundType Type { get; }
     }
 
-    public class PreceedingRowWindowBound : WindowBound
+    public class PreceedingRowWindowBound : WindowBound, IEquatable<PreceedingRowWindowBound>
     {
         public long Offset { get; set; }
 
         public override WindowBoundType Type => WindowBoundType.PreceedingRow;
+
+        public bool Equals(PreceedingRowWindowBound? other)
+        {
+            return other != null &&
+                Offset.Equals(other.Offset);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is PreceedingRowWindowBound bounds &&
+                Equals(bounds);
+        }
+
+        public override int GetHashCode()
+        {
+            var code = new HashCode();
+            code.Add(Type);
+            code.Add(Offset);
+            return code.ToHashCode();
+        }
+
+        public static bool operator ==(PreceedingRowWindowBound? left, PreceedingRowWindowBound? right)
+        {
+            return EqualityComparer<PreceedingRowWindowBound>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(PreceedingRowWindowBound? left, PreceedingRowWindowBound? right)
+        {
+            return !(left == right);
+        }
     }
 
-    public class PreceedingRangeWindowBound : WindowBound
+    public class PreceedingRangeWindowBound : WindowBound, IEquatable<PreceedingRangeWindowBound>
     {
         public required Expression Expression { get; set; }
 
         public override WindowBoundType Type => WindowBoundType.PreceedingRange;
+
+        public bool Equals(PreceedingRangeWindowBound? other)
+        {
+            return other != null &&
+                Expression.Equals(other.Expression);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is PreceedingRangeWindowBound bounds &&
+                Equals(bounds);
+        }
+
+        public override int GetHashCode()
+        {
+            var code = new HashCode();
+            code.Add(Type);
+            code.Add(Expression);
+            return code.ToHashCode();
+        }
+
+        public static bool operator ==(PreceedingRangeWindowBound? left, PreceedingRangeWindowBound? right)
+        {
+            return EqualityComparer<PreceedingRangeWindowBound>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(PreceedingRangeWindowBound? left, PreceedingRangeWindowBound? right)
+        {
+            return !(left == right);
+        }
     }
 
-    public class FollowingRowWindowBound : WindowBound
+    public class FollowingRowWindowBound : WindowBound, IEquatable<FollowingRowWindowBound>
     {
         public long Offset { get; set; }
 
         public override WindowBoundType Type => WindowBoundType.FollowingRow;
+
+        public bool Equals(FollowingRowWindowBound? other)
+        {
+            return other != null &&
+                Offset.Equals(other.Offset);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is FollowingRowWindowBound bounds &&
+                Equals(bounds);
+        }
+
+        public override int GetHashCode()
+        {
+            var code = new HashCode();
+            code.Add(Type);
+            code.Add(Offset);
+            return code.ToHashCode();
+        }
+
+        public static bool operator ==(FollowingRowWindowBound? left, FollowingRowWindowBound? right)
+        {
+            return EqualityComparer<FollowingRowWindowBound>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(FollowingRowWindowBound? left, FollowingRowWindowBound? right)
+        {
+            return !(left == right);
+        }
     }
 
-    public class FollowingRangeWindowBound : WindowBound
+    public class FollowingRangeWindowBound : WindowBound, IEquatable<FollowingRangeWindowBound>
     {
         public required Expression Expression { get; set; }
 
         public override WindowBoundType Type => WindowBoundType.FollowingRange;
+
+        public bool Equals(FollowingRangeWindowBound? other)
+        {
+            return other != null &&
+                Expression.Equals(other.Expression);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is FollowingRangeWindowBound bounds &&
+                Equals(bounds);
+        }
+
+        public override int GetHashCode()
+        {
+            var code = new HashCode();
+            code.Add(Type);
+            code.Add(Expression);
+            return code.ToHashCode();
+        }
+
+        public static bool operator ==(FollowingRangeWindowBound? left, FollowingRangeWindowBound? right)
+        {
+            return EqualityComparer<FollowingRangeWindowBound>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(FollowingRangeWindowBound? left, FollowingRangeWindowBound? right)
+        {
+            return !(left == right);
+        }
     }
 
-    public class CurrentRowWindowBound : WindowBound
+    public class CurrentRowWindowBound : WindowBound, IEquatable<CurrentRowWindowBound>
     {
         public override WindowBoundType Type => WindowBoundType.CurrentRow;
+
+        public bool Equals(CurrentRowWindowBound? other)
+        {
+            return other != null;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is CurrentRowWindowBound bounds &&
+                Equals(bounds);
+        }
+
+        public override int GetHashCode()
+        {
+            var code = new HashCode();
+            code.Add(Type);
+            return code.ToHashCode();
+        }
+
+        public static bool operator ==(CurrentRowWindowBound? left, CurrentRowWindowBound? right)
+        {
+            return EqualityComparer<CurrentRowWindowBound>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(CurrentRowWindowBound? left, CurrentRowWindowBound? right)
+        {
+            return !(left == right);
+        }
     }
 
-    public class UnboundedWindowBound : WindowBound
+    public class UnboundedWindowBound : WindowBound, IEquatable<UnboundedWindowBound>
     {
         public override WindowBoundType Type => WindowBoundType.Unbounded;
+
+        public bool Equals(UnboundedWindowBound? other)
+        {
+            return other != null;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is UnboundedWindowBound bounds &&
+                Equals(bounds);
+        }
+
+        public override int GetHashCode()
+        {
+            var code = new HashCode();
+            code.Add(Type);
+            return code.ToHashCode();
+        }
+
+        public static bool operator ==(UnboundedWindowBound? left, UnboundedWindowBound? right)
+        {
+            return EqualityComparer<UnboundedWindowBound>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(UnboundedWindowBound? left, UnboundedWindowBound? right)
+        {
+            return !(left == right);
+        }
     }
 }

--- a/src/FlowtideDotNet.Substrait/Relations/ConsistentPartitionWindowRelation.cs
+++ b/src/FlowtideDotNet.Substrait/Relations/ConsistentPartitionWindowRelation.cs
@@ -8,7 +8,7 @@ using static Substrait.Protobuf.AggregateRel.Types;
 
 namespace FlowtideDotNet.Substrait.Relations
 {
-    public class ConsistentPartitionWindowRelation : Relation
+    public class ConsistentPartitionWindowRelation : Relation, IEquatable<ConsistentPartitionWindowRelation>
     {
         public required Relation Input { get; set; }
 
@@ -35,6 +35,53 @@ namespace FlowtideDotNet.Substrait.Relations
         public override TReturn Accept<TReturn, TState>(RelationVisitor<TReturn, TState> visitor, TState state)
         {
             return visitor.VisitConsistentPartitionWindowRelation(this, state);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ConsistentPartitionWindowRelation relation &&
+                Equals(relation);
+        }
+
+
+        public override int GetHashCode()
+        {
+            var code = new HashCode();
+            code.Add(base.GetHashCode());
+            code.Add(Input);
+            foreach (var windowFunc in WindowFunctions)
+            {
+                code.Add(windowFunc);
+            }
+            foreach (var partition in PartitionBy)
+            {
+                code.Add(partition);
+            }
+            foreach (var order in OrderBy)
+            {
+                code.Add(order);
+            }
+            return code.ToHashCode();
+        }
+
+        public bool Equals(ConsistentPartitionWindowRelation? other)
+        {
+            return other != null &&
+                base.Equals(other) &&
+                Equals(Input, other.Input) &&
+                WindowFunctions.SequenceEqual(other.WindowFunctions) &&
+                PartitionBy.SequenceEqual(other.PartitionBy) &&
+                OrderBy.SequenceEqual(other.OrderBy);
+        }
+
+        public static bool operator ==(ConsistentPartitionWindowRelation? left, ConsistentPartitionWindowRelation? right)
+        {
+            return EqualityComparer<ConsistentPartitionWindowRelation>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(ConsistentPartitionWindowRelation? left, ConsistentPartitionWindowRelation? right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/src/FlowtideDotNet.Substrait/SubstraitDeserializer.cs
+++ b/src/FlowtideDotNet.Substrait/SubstraitDeserializer.cs
@@ -22,6 +22,27 @@ namespace FlowtideDotNet.Substrait
 {
     public class SubstraitDeserializer
     {
+        /// <summary>
+        /// Reads function options, the consumer uses the first supported preference.
+        /// </summary>
+        private static SortedList<string, string>? ReadOptions(
+            Google.Protobuf.Collections.RepeatedField<Protobuf.FunctionOption> options)
+        {
+            if (options.Count == 0)
+            {
+                return null;
+            }
+            var result = new SortedList<string, string>();
+            foreach (var option in options)
+            {
+                if (option.Preference.Count > 0)
+                {
+                    result.Add(option.Name, option.Preference[0]);
+                }
+            }
+            return result;
+        }
+
         private sealed class ExpressionDeserializerImpl
         {
             private readonly Dictionary<uint, string> idToFunctionLookup = new Dictionary<uint, string>();
@@ -393,7 +414,8 @@ namespace FlowtideDotNet.Substrait
                 {
                     ExtensionName = name,
                     ExtensionUri = uri,
-                    Arguments = new List<Expression>()
+                    Arguments = new List<Expression>(),
+                    Options = ReadOptions(aggregateFunction.Options)
                 };
 #pragma warning disable CS0612 // Type or member is obsolete
                 if (aggregateFunction.Args.Count > 0)
@@ -505,6 +527,7 @@ namespace FlowtideDotNet.Substrait
                 {
                     result.Arguments.Add(VisitExpression(arg.Value));
                 }
+                result.Options = ReadOptions(windowRelFunction.Options);
                 return result;
             }
 
@@ -650,7 +673,8 @@ namespace FlowtideDotNet.Substrait
                 {
                     ExtensionUri = uri,
                     ExtensionName = name,
-                    Arguments = args
+                    Arguments = args,
+                    Options = ReadOptions(scalarFunction.Options)
                 };
 
 

--- a/src/FlowtideDotNet.Substrait/SubstraitDeserializer.cs
+++ b/src/FlowtideDotNet.Substrait/SubstraitDeserializer.cs
@@ -37,10 +37,11 @@ namespace FlowtideDotNet.Substrait
             {
                 if (option.Preference.Count > 0)
                 {
-                    result.Add(option.Name, option.Preference[0]);
+                    // Allow duplicate option names by letting later entries win.
+                    result[option.Name] = option.Preference[0];
                 }
             }
-            return result;
+            return result.Count == 0 ? null : result;
         }
 
         private sealed class ExpressionDeserializerImpl

--- a/src/FlowtideDotNet.Substrait/SubstraitSerializer.cs
+++ b/src/FlowtideDotNet.Substrait/SubstraitSerializer.cs
@@ -31,6 +31,28 @@ namespace FlowtideDotNet.Substrait
     /// </summary>
     public class SubstraitSerializer
     {
+        /// <summary>
+        /// Writes function options, each option keeps a single preference value.
+        /// </summary>
+        private static void AddOptions(
+            Google.Protobuf.Collections.RepeatedField<Protobuf.FunctionOption> target,
+            SortedList<string, string>? options)
+        {
+            if (options == null)
+            {
+                return;
+            }
+            foreach (var option in options)
+            {
+                var functionOption = new Protobuf.FunctionOption()
+                {
+                    Name = option.Key
+                };
+                functionOption.Preference.Add(option.Value);
+                target.Add(functionOption);
+            }
+        }
+
         private sealed class SerializerVisitorState
         {
             public int uriCounter = 0;
@@ -290,6 +312,7 @@ namespace FlowtideDotNet.Substrait
                         Value = Visit(arg, state)
                     });
                 }
+                AddOptions(scalar.Options, scalarFunction.Options);
 
                 return new Protobuf.Expression()
                 {
@@ -733,6 +756,7 @@ namespace FlowtideDotNet.Substrait
                                     });
                                 }
                             }
+                            AddOptions(m.Measure_.Options, measure.Measure.Options);
                             if (measure.Measure.OutputType != null)
                             {
                                 m.Measure_.OutputType = state.GetType(measure.Measure.OutputType);
@@ -923,6 +947,8 @@ namespace FlowtideDotNet.Substrait
                 output.FunctionReference = state.GetFunctionExtensionAnchor(windowFunction.ExtensionUri, windowFunction.ExtensionName);
                 output.Invocation = Protobuf.AggregateFunction.Types.AggregationInvocation.Unspecified;
                 
+                AddOptions(output.Options, windowFunction.Options);
+
                 if (windowFunction.LowerBound != null)
                 {
                     output.LowerBound = GetWindowBound(windowFunction.LowerBound);

--- a/tests/FlowtideDotNet.AcceptanceTests/CommonSubPlanTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/CommonSubPlanTests.cs
@@ -1,0 +1,147 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.Optimizer;
+using Xunit.Abstractions;
+
+namespace FlowtideDotNet.AcceptanceTests
+{
+    [Collection("Acceptance tests")]
+    public class CommonSubPlanTests : FlowtideAcceptanceBase
+    {
+        public CommonSubPlanTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        // Nexmark query 5 shape, the count aggregate subtree is used both for
+        // the per user counts and as input to the max aggregate.
+        private const string HotUsersSql = @"
+            INSERT INTO output
+            SELECT UserOrders.userkey, UserOrders.num, UserOrders.starttime
+            FROM (
+              SELECT UserKey AS userkey, count(*) AS num, window_start AS starttime
+              FROM orders INNER JOIN hopping_window(Orderdate, 5, 'MINUTE', 10, 'MINUTE')
+              GROUP BY UserKey, window_start
+            ) AS UserOrders
+            JOIN (
+              SELECT max(CountOrders.num) AS maxn, CountOrders.starttime
+              FROM (
+                SELECT count(*) AS num, window_start AS starttime
+                FROM orders INNER JOIN hopping_window(Orderdate, 5, 'MINUTE', 10, 'MINUTE')
+                GROUP BY UserKey, window_start
+              ) AS CountOrders
+              GROUP BY CountOrders.starttime
+            ) AS MaxOrders
+            ON UserOrders.starttime = MaxOrders.starttime AND
+                UserOrders.num >= MaxOrders.maxn;";
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task UsersWithMostOrdersPerWindow(bool findCommonSubPlans)
+        {
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 1, UserKey = 1, Orderdate = new DateTime(2000, 1, 1, 0, 1, 0) });
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 2, UserKey = 1, Orderdate = new DateTime(2000, 1, 1, 0, 2, 0) });
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 3, UserKey = 1, Orderdate = new DateTime(2000, 1, 1, 0, 3, 0) });
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 4, UserKey = 2, Orderdate = new DateTime(2000, 1, 1, 0, 2, 0) });
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 5, UserKey = 2, Orderdate = new DateTime(2000, 1, 1, 0, 4, 0) });
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 6, UserKey = 2, Orderdate = new DateTime(2000, 1, 1, 0, 6, 0) });
+
+            await StartStream(HotUsersSql, planOptimizerSettings: new PlanOptimizerSettings()
+            {
+                FindCommonSubPlans = findCommonSubPlans
+            });
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(new[]
+            {
+                // Window 23:55 - 00:05, user 1 has 3 orders, user 2 has 2
+                new { userkey = 1, num = 3, starttime = new DateTimeOffset(1999, 12, 31, 23, 55, 0, TimeSpan.Zero) },
+                // Window 00:00 - 00:10, both users have 3 orders
+                new { userkey = 1, num = 3, starttime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero) },
+                new { userkey = 2, num = 3, starttime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero) },
+                // Window 00:05 - 00:15, only user 2 has an order
+                new { userkey = 2, num = 1, starttime = new DateTimeOffset(2000, 1, 1, 0, 5, 0, TimeSpan.Zero) },
+            });
+        }
+
+        public record WindowSumResult(int userkey, long value);
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DuplicatedWindowFunction(bool findCommonSubPlans)
+        {
+            GenerateData();
+
+            await StartStream(@"
+                INSERT INTO output
+                SELECT a.userkey, a.value
+                FROM (
+                  SELECT UserKey AS userkey,
+                    CAST(SUM(DoubleValue) OVER (PARTITION BY CompanyId ORDER BY userkey ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) AS INT) AS value
+                  FROM users
+                ) a
+                JOIN (
+                  SELECT UserKey AS userkey,
+                    CAST(SUM(DoubleValue) OVER (PARTITION BY CompanyId ORDER BY userkey ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) AS INT) AS value
+                  FROM users
+                ) b ON a.userkey = b.userkey;", planOptimizerSettings: new PlanOptimizerSettings()
+            {
+                FindCommonSubPlans = findCommonSubPlans
+            });
+            await WaitForUpdate();
+
+            var expected = Users.GroupBy(x => x.CompanyId)
+                .SelectMany(g =>
+                {
+                    var sum = 0.0;
+                    var orderedByKey = g.OrderBy(x => x.UserKey).ToList();
+                    var values = new Queue<double>();
+                    var output = new List<WindowSumResult>();
+                    for (int i = 0; i < orderedByKey.Count; i++)
+                    {
+                        while (values.Count > 4)
+                        {
+                            sum -= values.Dequeue();
+                        }
+                        values.Enqueue(orderedByKey[i].DoubleValue);
+                        sum += orderedByKey[i].DoubleValue;
+                        output.Add(new WindowSumResult(orderedByKey[i].UserKey, (long)sum));
+                    }
+                    return output;
+                }).ToList();
+
+            AssertCurrentDataEqual(expected);
+        }
+
+        [Fact]
+        public async Task SharedSubtreeUpdatesBothUsages()
+        {
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 1, UserKey = 1, Orderdate = new DateTime(2000, 1, 1, 0, 1, 0) });
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 2, UserKey = 2, Orderdate = new DateTime(2000, 1, 1, 0, 2, 0) });
+
+            await StartStream(HotUsersSql);
+            await WaitForUpdate();
+
+            // A new order makes user 2 the single winner in every window
+            AddOrUpdateOrder(new Entities.Order() { OrderKey = 3, UserKey = 2, Orderdate = new DateTime(2000, 1, 1, 0, 3, 0) });
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(new[]
+            {
+                new { userkey = 2, num = 2, starttime = new DateTimeOffset(1999, 12, 31, 23, 55, 0, TimeSpan.Zero) },
+                new { userkey = 2, num = 2, starttime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero) },
+            });
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Core.Tests/OptimizerTests/CommonSubPlanTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/OptimizerTests/CommonSubPlanTests.cs
@@ -1,0 +1,335 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.Optimizer;
+using FlowtideDotNet.Core.Optimizer.CommonSubPlan;
+using FlowtideDotNet.Substrait.Relations;
+using FlowtideDotNet.Substrait.Sql;
+
+namespace FlowtideDotNet.Core.Tests.OptimizerTests
+{
+    public class CommonSubPlanTests
+    {
+        private const string NexmarkQ5Sql = @"
+            CREATE TABLE bid (auction any, date_time any);
+
+            INSERT INTO output
+            SELECT AuctionBids.auction, AuctionBids.num
+            FROM(
+               SELECT auction, count(*) AS num, window_start AS starttime, window_end AS endtime
+               FROM bid
+               INNER JOIN hopping_window(date_time, 2, 'SECOND', 10, 'SECOND') wind
+               GROUP BY auction, window_start, window_end
+            ) AS AuctionBids
+            JOIN(
+              SELECT max(CountBids.num) AS maxn, CountBids.starttime, CountBids.endtime
+              FROM(
+                SELECT count(*) AS num, window_start AS starttime, window_end AS endtime
+                FROM bid
+                INNER JOIN hopping_window(date_time, 2, 'SECOND', 10, 'SECOND') wind
+                GROUP BY auction, window_start, window_end
+              ) AS CountBids
+              GROUP BY CountBids.starttime, CountBids.endtime
+            ) AS MaxBids
+            ON AuctionBids.starttime = MaxBids.starttime AND
+                AuctionBids.endtime = MaxBids.endtime AND
+                AuctionBids.num >= MaxBids.maxn;";
+
+        private static Substrait.Plan BuildPlan(string sql)
+        {
+            var sqlPlanBuilder = new SqlPlanBuilder();
+            sqlPlanBuilder.Sql(sql);
+            return sqlPlanBuilder.GetPlan();
+        }
+
+        private static List<Relation> CollectRelations(Relation root)
+        {
+            var result = new List<Relation>();
+            void Collect(Relation relation)
+            {
+                result.Add(relation);
+                switch (relation)
+                {
+                    case FilterRelation r: Collect(r.Input); break;
+                    case ProjectRelation r: Collect(r.Input); break;
+                    case AggregateRelation r: Collect(r.Input); break;
+                    case JoinRelation r: Collect(r.Left); Collect(r.Right); break;
+                    case MergeJoinRelation r: Collect(r.Left); Collect(r.Right); break;
+                    case SetRelation r: r.Inputs.ForEach(Collect); break;
+                    case SortRelation r: Collect(r.Input); break;
+                    case WriteRelation r: Collect(r.Input); break;
+                    case RootRelation r: Collect(r.Input); break;
+                    case SubStreamRootRelation r: Collect(r.Input); break;
+                    case TableFunctionRelation r when r.Input != null: Collect(r.Input); break;
+                    case ConsistentPartitionWindowRelation r: Collect(r.Input); break;
+                    case ExchangeRelation r: Collect(r.Input); break;
+                }
+            }
+            Collect(root);
+            return result;
+        }
+
+        private static List<Relation> CollectRelations(Substrait.Plan plan)
+        {
+            return plan.Relations.SelectMany(CollectRelations).ToList();
+        }
+
+        [Fact]
+        public void DuplicateAggregateSubtreeIsShared()
+        {
+            var plan = BuildPlan(NexmarkQ5Sql);
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            Assert.Equal(2, plan.Relations.Count);
+
+            // The shared subtree is the count aggregate over the hopping window
+            var definition = Assert.IsType<AggregateRelation>(plan.Relations[1]);
+            var tableFunction = Assert.IsType<TableFunctionRelation>(definition.Input);
+            Assert.IsType<ReadRelation>(tableFunction.Input);
+
+            var references = CollectRelations(plan.Relations[0]).OfType<ReferenceRelation>().ToList();
+            Assert.Equal(2, references.Count);
+            Assert.All(references, r => Assert.Equal(1, r.RelationId));
+            Assert.All(references, r => Assert.Equal(definition.OutputLength, r.ReferenceOutputLength));
+
+            // Only the shared aggregate reads the table
+            Assert.Single(CollectRelations(plan).OfType<ReadRelation>());
+        }
+
+        [Fact]
+        public void FullOptimizerSharesCountAggregate()
+        {
+            var plan = BuildPlan(NexmarkQ5Sql);
+            plan = PlanOptimizer.Optimize(plan);
+
+            var relations = CollectRelations(plan);
+            Assert.Single(relations.OfType<ReadRelation>());
+            Assert.Single(relations.OfType<TableFunctionRelation>());
+
+            // One count aggregate with three group expressions and one max aggregate
+            var aggregates = relations.OfType<AggregateRelation>().ToList();
+            Assert.Equal(2, aggregates.Count);
+            Assert.Single(aggregates.Where(a => a.Groupings![0].GroupingExpressions.Count == 3));
+            Assert.Single(aggregates.Where(a => a.Groupings![0].GroupingExpressions.Count == 2));
+        }
+
+        [Fact]
+        public void NoDuplicateSubtreesLeavesPlanUnchanged()
+        {
+            var sql = @"
+                CREATE TABLE users (userkey any, name any);
+                INSERT INTO output SELECT userkey, count(*) FROM users GROUP BY userkey;";
+            var plan = BuildPlan(sql);
+            var expected = BuildPlan(sql);
+
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            Assert.Equal(expected.Relations, plan.Relations);
+        }
+
+        [Fact]
+        public void DifferentAggregatesAreNotShared()
+        {
+            var sql = @"
+                CREATE TABLE users (userkey any, name any);
+                INSERT INTO output
+                SELECT a.userkey FROM (SELECT userkey, count(*) AS c FROM users GROUP BY userkey) a
+                JOIN (SELECT name, count(*) AS c FROM users GROUP BY name) b ON a.c = b.c;";
+            var plan = BuildPlan(sql);
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            Assert.Single(plan.Relations);
+            Assert.Empty(CollectRelations(plan).OfType<ReferenceRelation>());
+        }
+
+        [Fact]
+        public void DifferentPushedDownFiltersPreventSharing()
+        {
+            // The filters are pushed into each read before common sub plans run
+            var sql = @"
+                CREATE TABLE users (userkey any, name any);
+                INSERT INTO output
+                SELECT a.userkey FROM (SELECT userkey, count(*) AS c FROM users WHERE name = 'a' GROUP BY userkey) a
+                JOIN (SELECT userkey, count(*) AS c FROM users WHERE name = 'b' GROUP BY userkey) b ON a.userkey = b.userkey;";
+            var plan = BuildPlan(sql);
+            plan = PlanOptimizer.Optimize(plan);
+
+            Assert.Empty(CollectRelations(plan).OfType<ReferenceRelation>());
+            Assert.Equal(2, CollectRelations(plan).OfType<ReadRelation>().Count());
+        }
+
+        [Fact]
+        public void IdenticalFilteredSubtreesAreShared()
+        {
+            var sql = @"
+                CREATE TABLE users (userkey any, name any);
+                INSERT INTO output
+                SELECT a.userkey FROM (SELECT userkey, count(*) AS c FROM users WHERE name = 'a' GROUP BY userkey) a
+                JOIN (SELECT userkey, count(*) AS c FROM users WHERE name = 'a' GROUP BY userkey) b ON a.userkey = b.userkey;";
+            var plan = BuildPlan(sql);
+            plan = PlanOptimizer.Optimize(plan);
+
+            Assert.Equal(2, CollectRelations(plan).OfType<ReferenceRelation>().Count());
+            Assert.Single(CollectRelations(plan).OfType<ReadRelation>());
+        }
+
+        [Fact]
+        public void IdenticalInsertsShareTheWholeQuery()
+        {
+            var sql = @"
+                CREATE TABLE users (userkey any, name any);
+                INSERT INTO output1 SELECT userkey, count(*) FROM users GROUP BY userkey;
+                INSERT INTO output2 SELECT userkey, count(*) FROM users GROUP BY userkey;";
+            var plan = BuildPlan(sql);
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            Assert.Equal(3, plan.Relations.Count);
+            var firstWrite = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            var secondWrite = Assert.IsType<WriteRelation>(plan.Relations[1]);
+            var firstReference = Assert.IsType<ReferenceRelation>(firstWrite.Input);
+            var secondReference = Assert.IsType<ReferenceRelation>(secondWrite.Input);
+            Assert.Equal(2, firstReference.RelationId);
+            Assert.Equal(2, secondReference.RelationId);
+        }
+
+        [Fact]
+        public void InnerSubtreeWithExtraUsageIsSharedSeparately()
+        {
+            // The aggregate subtree is duplicated and its table function input has a third usage
+            var sql = @"
+                CREATE TABLE bid (auction any, date_time any);
+                INSERT INTO output
+                SELECT a.auction FROM (
+                    SELECT auction, count(*) AS num, window_start AS ws FROM bid
+                    INNER JOIN hopping_window(date_time, 2, 'SECOND', 10, 'SECOND')
+                    GROUP BY auction, window_start
+                ) a
+                JOIN (
+                    SELECT auction, count(*) AS num, window_start AS ws FROM bid
+                    INNER JOIN hopping_window(date_time, 2, 'SECOND', 10, 'SECOND')
+                    GROUP BY auction, window_start
+                ) b ON a.auction = b.auction
+                JOIN (
+                    SELECT auction, window_start AS ws FROM bid
+                    INNER JOIN hopping_window(date_time, 2, 'SECOND', 10, 'SECOND')
+                ) c ON a.auction = c.auction;";
+            var plan = BuildPlan(sql);
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            // Main relation, shared aggregate and shared table function
+            Assert.Equal(3, plan.Relations.Count);
+            var projectDefinition = Assert.IsType<ProjectRelation>(plan.Relations[1]);
+            var aggregateDefinition = Assert.IsType<AggregateRelation>(projectDefinition.Input);
+            var innerReference = Assert.IsType<ReferenceRelation>(aggregateDefinition.Input);
+            Assert.Equal(2, innerReference.RelationId);
+            Assert.IsType<TableFunctionRelation>(plan.Relations[2]);
+
+            var references = CollectRelations(plan.Relations[0]).OfType<ReferenceRelation>().ToList();
+            Assert.Equal(2, references.Count(r => r.RelationId == 1));
+            Assert.Single(references.Where(r => r.RelationId == 2));
+            Assert.Single(CollectRelations(plan).OfType<ReadRelation>());
+        }
+
+        [Fact]
+        public void DuplicateWindowSubtreeIsShared()
+        {
+            var sql = @"
+                CREATE TABLE users (userkey any, companyid any, doublevalue any);
+                INSERT INTO output
+                SELECT a.userkey FROM (
+                    SELECT userkey, SUM(doublevalue) OVER (PARTITION BY companyid ORDER BY userkey) AS s FROM users
+                ) a
+                JOIN (
+                    SELECT userkey, SUM(doublevalue) OVER (PARTITION BY companyid ORDER BY userkey) AS s FROM users
+                ) b ON a.s = b.s;";
+            var plan = BuildPlan(sql);
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            Assert.Equal(2, plan.Relations.Count);
+            var references = CollectRelations(plan.Relations[0]).OfType<ReferenceRelation>().ToList();
+            Assert.Equal(2, references.Count);
+            Assert.All(references, r => Assert.Equal(1, r.RelationId));
+            Assert.Single(CollectRelations(plan).OfType<ConsistentPartitionWindowRelation>());
+        }
+
+        [Fact]
+        public void WindowsWithDifferentBoundsAreNotShared()
+        {
+            var sql = @"
+                CREATE TABLE users (userkey any, companyid any, doublevalue any);
+                INSERT INTO output
+                SELECT a.userkey FROM (
+                    SELECT userkey, SUM(doublevalue) OVER (PARTITION BY companyid ORDER BY userkey ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) AS s FROM users
+                ) a
+                JOIN (
+                    SELECT userkey, SUM(doublevalue) OVER (PARTITION BY companyid ORDER BY userkey ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS s FROM users
+                ) b ON a.s = b.s;";
+            var plan = BuildPlan(sql);
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            Assert.Single(plan.Relations);
+            Assert.Empty(CollectRelations(plan).OfType<ReferenceRelation>());
+            Assert.Equal(2, CollectRelations(plan).OfType<ConsistentPartitionWindowRelation>().Count());
+        }
+
+        [Fact]
+        public void WindowsOverDifferentInputsAreNotShared()
+        {
+            var sql = @"
+                CREATE TABLE users (userkey any, companyid any, doublevalue any);
+                CREATE TABLE others (userkey any, companyid any, doublevalue any);
+                INSERT INTO output
+                SELECT a.userkey FROM (
+                    SELECT userkey, SUM(doublevalue) OVER (PARTITION BY companyid ORDER BY userkey) AS s FROM users
+                ) a
+                JOIN (
+                    SELECT userkey, SUM(doublevalue) OVER (PARTITION BY companyid ORDER BY userkey) AS s FROM others
+                ) b ON a.s = b.s;";
+            var plan = BuildPlan(sql);
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            Assert.Single(plan.Relations);
+            Assert.Empty(CollectRelations(plan).OfType<ReferenceRelation>());
+            Assert.Equal(2, CollectRelations(plan).OfType<ConsistentPartitionWindowRelation>().Count());
+        }
+
+        [Fact]
+        public void SubstreamPlansAreSkipped()
+        {
+            var plan = BuildPlan(NexmarkQ5Sql);
+            plan.Relations[0] = new SubStreamRootRelation()
+            {
+                Name = "substream_0",
+                Input = plan.Relations[0]
+            };
+            var relationCount = plan.Relations.Count;
+
+            plan = CommonSubPlanOptimizer.Optimize(plan);
+
+            Assert.Equal(relationCount, plan.Relations.Count);
+            Assert.Empty(CollectRelations(plan).OfType<ReferenceRelation>());
+        }
+
+        [Fact]
+        public void OptimizerCanBeDisabled()
+        {
+            var plan = BuildPlan(NexmarkQ5Sql);
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings()
+            {
+                FindCommonSubPlans = false
+            });
+
+            Assert.Empty(CollectRelations(plan).OfType<ReferenceRelation>());
+            Assert.Equal(2, CollectRelations(plan).OfType<ReadRelation>().Count());
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/ExpressionEquality/AggregateFunctionEquality.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/ExpressionEquality/AggregateFunctionEquality.cs
@@ -92,6 +92,38 @@ namespace FlowtideDotNet.Substrait.Tests.EqualityTests.ExpressionEquality
         }
 
         [Fact]
+        public void OptionsChangedIsNotEqual()
+        {
+            root.Options = new SortedList<string, string>() { { "NULL_TREATMENT", "IGNORE_NULLS" } };
+            clone.Options = new SortedList<string, string>() { { "NULL_TREATMENT", "ACCEPT_NULLS" } };
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void OptionsAddedIsNotEqual()
+        {
+            clone.Options = new SortedList<string, string>() { { "NULL_TREATMENT", "IGNORE_NULLS" } };
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void SameOptionsIsEqual()
+        {
+            root.Options = new SortedList<string, string>() { { "NULL_TREATMENT", "IGNORE_NULLS" } };
+            clone.Options = new SortedList<string, string>() { { "NULL_TREATMENT", "IGNORE_NULLS" } };
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+        }
+
+        [Fact]
+        public void EmptyOptionsEqualsNullOptions()
+        {
+            clone.Options = new SortedList<string, string>();
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+        }
+
+        [Fact]
         public void EqualsOperator()
         {
             Assert.True(root == clone);

--- a/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/ExpressionEquality/ScalarFunctionEquality.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/ExpressionEquality/ScalarFunctionEquality.cs
@@ -92,6 +92,39 @@ namespace FlowtideDotNet.Substrait.Tests.EqualityTests.ExpressionEquality
         }
 
         [Fact]
+        public void OptionsChangedNotEqual()
+        {
+            // Options change how the function behaves, substring uses negative_start
+            root.Options = new SortedList<string, string>() { { "negative_start", "WRAP_FROM_END" } };
+            clone.Options = new SortedList<string, string>() { { "negative_start", "LEFT_OF_BEGINNING" } };
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void OptionsAddedNotEqual()
+        {
+            clone.Options = new SortedList<string, string>() { { "negative_start", "WRAP_FROM_END" } };
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void SameOptionsIsEqual()
+        {
+            root.Options = new SortedList<string, string>() { { "negative_start", "WRAP_FROM_END" } };
+            clone.Options = new SortedList<string, string>() { { "negative_start", "WRAP_FROM_END" } };
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+        }
+
+        [Fact]
+        public void EmptyOptionsEqualsNullOptions()
+        {
+            clone.Options = new SortedList<string, string>();
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+        }
+
+        [Fact]
         public void EqualsOperator()
         {
             Assert.True(root == clone);

--- a/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/ExpressionEquality/WindowBoundEquality.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/ExpressionEquality/WindowBoundEquality.cs
@@ -1,0 +1,143 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.EqualityTests.ExpressionEquality
+{
+    public class WindowBoundEquality
+    {
+        [Fact]
+        public void PreceedingRowIsEqual()
+        {
+            var root = new PreceedingRowWindowBound() { Offset = 3 };
+            var clone = new PreceedingRowWindowBound() { Offset = 3 };
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+            Assert.True(root == clone);
+        }
+
+        [Fact]
+        public void PreceedingRowOffsetChangedNotEqual()
+        {
+            var root = new PreceedingRowWindowBound() { Offset = 3 };
+            var notEqual = new PreceedingRowWindowBound() { Offset = 4 };
+            Assert.NotEqual(root, notEqual);
+            Assert.True(root != notEqual);
+        }
+
+        [Fact]
+        public void FollowingRowIsEqual()
+        {
+            var root = new FollowingRowWindowBound() { Offset = 3 };
+            var clone = new FollowingRowWindowBound() { Offset = 3 };
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+            Assert.True(root == clone);
+        }
+
+        [Fact]
+        public void FollowingRowOffsetChangedNotEqual()
+        {
+            var root = new FollowingRowWindowBound() { Offset = 3 };
+            var notEqual = new FollowingRowWindowBound() { Offset = 4 };
+            Assert.NotEqual(root, notEqual);
+            Assert.True(root != notEqual);
+        }
+
+        [Fact]
+        public void PreceedingRangeIsEqual()
+        {
+            var root = new PreceedingRangeWindowBound() { Expression = new StringLiteral() { Value = "v" } };
+            var clone = new PreceedingRangeWindowBound() { Expression = new StringLiteral() { Value = "v" } };
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+            Assert.True(root == clone);
+        }
+
+        [Fact]
+        public void PreceedingRangeExpressionChangedNotEqual()
+        {
+            var root = new PreceedingRangeWindowBound() { Expression = new StringLiteral() { Value = "v1" } };
+            var notEqual = new PreceedingRangeWindowBound() { Expression = new StringLiteral() { Value = "v2" } };
+            Assert.NotEqual(root, notEqual);
+            Assert.True(root != notEqual);
+        }
+
+        [Fact]
+        public void FollowingRangeIsEqual()
+        {
+            var root = new FollowingRangeWindowBound() { Expression = new StringLiteral() { Value = "v" } };
+            var clone = new FollowingRangeWindowBound() { Expression = new StringLiteral() { Value = "v" } };
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+            Assert.True(root == clone);
+        }
+
+        [Fact]
+        public void FollowingRangeExpressionChangedNotEqual()
+        {
+            var root = new FollowingRangeWindowBound() { Expression = new StringLiteral() { Value = "v1" } };
+            var notEqual = new FollowingRangeWindowBound() { Expression = new StringLiteral() { Value = "v2" } };
+            Assert.NotEqual(root, notEqual);
+            Assert.True(root != notEqual);
+        }
+
+        [Fact]
+        public void CurrentRowIsEqual()
+        {
+            var root = new CurrentRowWindowBound();
+            var clone = new CurrentRowWindowBound();
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+            Assert.True(root == clone);
+        }
+
+        [Fact]
+        public void UnboundedIsEqual()
+        {
+            var root = new UnboundedWindowBound();
+            var clone = new UnboundedWindowBound();
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+            Assert.True(root == clone);
+        }
+
+        [Fact]
+        public void DifferentBoundTypesAreNotEqual()
+        {
+            // Compared through the base type, the same way a window function compares its bounds
+            var bounds = new WindowBound[]
+            {
+                new PreceedingRowWindowBound() { Offset = 1 },
+                new FollowingRowWindowBound() { Offset = 1 },
+                new PreceedingRangeWindowBound() { Expression = new StringLiteral() { Value = "v" } },
+                new FollowingRangeWindowBound() { Expression = new StringLiteral() { Value = "v" } },
+                new CurrentRowWindowBound(),
+                new UnboundedWindowBound()
+            };
+
+            for (int i = 0; i < bounds.Length; i++)
+            {
+                for (int j = 0; j < bounds.Length; j++)
+                {
+                    if (i == j)
+                    {
+                        continue;
+                    }
+                    Assert.False(bounds[i].Equals(bounds[j]), $"{bounds[i].Type} should not equal {bounds[j].Type}");
+                }
+            }
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/ExpressionEquality/WindowFunctionEquality.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/ExpressionEquality/WindowFunctionEquality.cs
@@ -1,0 +1,181 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+
+namespace FlowtideDotNet.Substrait.Tests.EqualityTests.ExpressionEquality
+{
+    public class WindowFunctionEquality
+    {
+        readonly WindowFunction root;
+        readonly WindowFunction clone;
+        readonly WindowFunction notEqual;
+
+        private static WindowFunction Create(string uri, string name, string argument, string optionValue, long lowerOffset)
+        {
+            return new WindowFunction()
+            {
+                ExtensionUri = uri,
+                ExtensionName = name,
+                Arguments = new List<Expression>()
+                {
+                    new StringLiteral() { Value = argument }
+                },
+                Options = new SortedList<string, string>()
+                {
+                    { "option", optionValue }
+                },
+                LowerBound = new PreceedingRowWindowBound() { Offset = lowerOffset },
+                UpperBound = new CurrentRowWindowBound()
+            };
+        }
+
+        public WindowFunctionEquality()
+        {
+            root = Create("uri1", "name1", "arg1", "value1", 1);
+            clone = Create("uri1", "name1", "arg1", "value1", 1);
+            notEqual = Create("uri2", "name2", "arg2", "value2", 2);
+        }
+
+        [Fact]
+        public void IsEqual()
+        {
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void HashCodeIsEqual()
+        {
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+        }
+
+        [Fact]
+        public void IsNotEqual()
+        {
+            Assert.NotEqual(root, notEqual);
+        }
+
+        [Fact]
+        public void ExtensionUriChangedNotEqual()
+        {
+            clone.ExtensionUri = notEqual.ExtensionUri;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void ExtensionNameChangedNotEqual()
+        {
+            clone.ExtensionName = notEqual.ExtensionName;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void ArgumentsChangedNotEqual()
+        {
+            clone.Arguments = notEqual.Arguments;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void OptionsChangedNotEqual()
+        {
+            clone.Options = notEqual.Options;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void OptionsNullNotEqual()
+        {
+            clone.Options = null;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void BothOptionsNullIsEqual()
+        {
+            root.Options = null;
+            clone.Options = null;
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void EmptyOptionsEqualsNullOptions()
+        {
+            // Both mean no options, serialization does not keep them apart
+            root.Options = null;
+            clone.Options = new SortedList<string, string>();
+            Assert.Equal(root, clone);
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+        }
+
+        [Fact]
+        public void LowerBoundChangedNotEqual()
+        {
+            clone.LowerBound = notEqual.LowerBound;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void LowerBoundTypeChangedNotEqual()
+        {
+            // A row bound with the same offset is not a following bound
+            clone.LowerBound = new FollowingRowWindowBound() { Offset = 1 };
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void LowerBoundNullNotEqual()
+        {
+            clone.LowerBound = null;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void UpperBoundChangedNotEqual()
+        {
+            clone.UpperBound = new UnboundedWindowBound();
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void UpperBoundNullNotEqual()
+        {
+            clone.UpperBound = null;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void BothBoundsNullIsEqual()
+        {
+            root.LowerBound = null;
+            root.UpperBound = null;
+            clone.LowerBound = null;
+            clone.UpperBound = null;
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void EqualsOperator()
+        {
+            Assert.True(root == clone);
+            Assert.False(root == notEqual);
+        }
+
+        [Fact]
+        public void NotEqualsOperator()
+        {
+            Assert.True(root != notEqual);
+            Assert.False(root != clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/RelationEquality/ConsistentPartitionWindowRelationEquality.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/EqualityTests/RelationEquality/ConsistentPartitionWindowRelationEquality.cs
@@ -1,0 +1,156 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.Expressions.Literals;
+using FlowtideDotNet.Substrait.Relations;
+
+namespace FlowtideDotNet.Substrait.Tests.EqualityTests.RelationEquality
+{
+    public class ConsistentPartitionWindowRelationEquality
+    {
+        readonly ConsistentPartitionWindowRelation root;
+        readonly ConsistentPartitionWindowRelation clone;
+        readonly ConsistentPartitionWindowRelation notEqual;
+
+        private static ConsistentPartitionWindowRelation Create(string tableName, string functionName, string partitionValue)
+        {
+            return new ConsistentPartitionWindowRelation()
+            {
+                Input = new ReadRelation()
+                {
+                    BaseSchema = new Type.NamedStruct()
+                    {
+                        Names = new List<string>() { "c1" },
+                    },
+                    NamedTable = new Type.NamedTable
+                    {
+                        Names = new List<string>() { tableName }
+                    }
+                },
+                WindowFunctions = new List<WindowFunction>()
+                {
+                    new WindowFunction()
+                    {
+                        ExtensionUri = "uri",
+                        ExtensionName = functionName,
+                        Arguments = new List<Expression>(),
+                        LowerBound = new UnboundedWindowBound(),
+                        UpperBound = new CurrentRowWindowBound()
+                    }
+                },
+                PartitionBy = new List<Expression>()
+                {
+                    new StringLiteral() { Value = partitionValue }
+                },
+                OrderBy = new List<SortField>()
+                {
+                    new SortField()
+                    {
+                        Expression = new StringLiteral() { Value = "sort" },
+                        SortDirection = SortDirection.SortDirectionAscNullsFirst
+                    }
+                },
+                Emit = new List<int>() { 1, 2, 3 }
+            };
+        }
+
+        public ConsistentPartitionWindowRelationEquality()
+        {
+            root = Create("t1", "row_number", "p1");
+            clone = Create("t1", "row_number", "p1");
+            notEqual = Create("t2", "lead", "p2");
+            notEqual.Emit = new List<int>() { 1, 2, 3, 4 };
+        }
+
+        [Fact]
+        public void IsEqual()
+        {
+            Assert.Equal(root, clone);
+        }
+
+        [Fact]
+        public void HashCodeIsEqual()
+        {
+            Assert.Equal(root.GetHashCode(), clone.GetHashCode());
+        }
+
+        [Fact]
+        public void IsNotEqual()
+        {
+            Assert.NotEqual(root, notEqual);
+        }
+
+        [Fact]
+        public void InputChangedNotEqual()
+        {
+            clone.Input = notEqual.Input;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void WindowFunctionsChangedNotEqual()
+        {
+            clone.WindowFunctions = notEqual.WindowFunctions;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void PartitionByChangedNotEqual()
+        {
+            clone.PartitionBy = notEqual.PartitionBy;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void OrderByChangedNotEqual()
+        {
+            clone.OrderBy = new List<SortField>()
+            {
+                new SortField()
+                {
+                    Expression = new StringLiteral() { Value = "sort" },
+                    SortDirection = SortDirection.SortDirectionDescNullsLast
+                }
+            };
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void EmitChangedNotEqual()
+        {
+            clone.Emit = notEqual.Emit;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void EmitNullNotEqual()
+        {
+            clone.Emit = null;
+            Assert.NotEqual(root, clone);
+        }
+
+        [Fact]
+        public void EqualsOperator()
+        {
+            Assert.True(root == clone);
+            Assert.False(root == notEqual);
+        }
+
+        [Fact]
+        public void NotEqualsOperator()
+        {
+            Assert.True(root != notEqual);
+            Assert.False(root != clone);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Substrait.Tests/SerializeTests.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/SerializeTests.cs
@@ -263,6 +263,101 @@ namespace FlowtideDotNet.Substrait.Tests
         }
 
         [Fact]
+        public void SerializeWindowFunctionWithOptions()
+        {
+            SqlPlanBuilder sqlPlanBuilder = new SqlPlanBuilder();
+            sqlPlanBuilder.Sql(@"
+                create table table1 (a any, b any);
+                insert into out
+                select a, LAST_VALUE(b) IGNORE NULLS OVER (PARTITION BY a ORDER BY b) as last_b FROM table1;
+            ");
+            var plan = sqlPlanBuilder.GetPlan();
+
+            // The ignore nulls option changes the result, it has to survive the roundtrip
+            var windowRelation = FindWindowRelation(plan.Relations[0]);
+            Assert.NotNull(windowRelation);
+            Assert.Equal("IGNORE_NULLS", windowRelation.WindowFunctions[0].Options!["NULL_TREATMENT"]);
+
+            AssertPlanCanSerializeDeserialize(plan);
+        }
+
+        [Fact]
+        public void SerializeScalarFunctionWithOptions()
+        {
+            Plan plan = new Plan()
+            {
+                Relations = new List<Relation>()
+                {
+                    new ProjectRelation()
+                    {
+                        Expressions = [new ScalarFunction()
+                        {
+                            ExtensionUri = FunctionsString.Uri,
+                            ExtensionName = FunctionsString.Substring,
+                            Arguments = [new StringLiteral() { Value = "a" }],
+                            Options = new SortedList<string, string>() { { "negative_start", "WRAP_FROM_END" } }
+                        }],
+                        Input = new ReadRelation()
+                        {
+                            BaseSchema = new Type.NamedStruct() { Names = ["a"] },
+                            NamedTable = new Type.NamedTable() { Names = ["a"] }
+                        },
+                    }
+                }
+            };
+
+            AssertPlanCanSerializeDeserialize(plan);
+        }
+
+        [Fact]
+        public void SerializeAggregateFunctionWithOptions()
+        {
+            Plan plan = new Plan()
+            {
+                Relations = new List<Relation>()
+                {
+                    new AggregateRelation()
+                    {
+                        Groupings = new List<AggregateGrouping>(),
+                        Measures = new List<AggregateMeasure>()
+                        {
+                            new AggregateMeasure()
+                            {
+                                Measure = new AggregateFunction()
+                                {
+                                    ExtensionUri = FunctionsArithmetic.Uri,
+                                    ExtensionName = FunctionsArithmetic.Sum,
+                                    Arguments = [new StringLiteral() { Value = "a" }],
+                                    Options = new SortedList<string, string>() { { "NULL_TREATMENT", "IGNORE_NULLS" } }
+                                }
+                            }
+                        },
+                        Input = new ReadRelation()
+                        {
+                            BaseSchema = new Type.NamedStruct() { Names = ["a"] },
+                            NamedTable = new Type.NamedTable() { Names = ["a"] }
+                        },
+                    }
+                }
+            };
+
+            AssertPlanCanSerializeDeserialize(plan);
+        }
+
+        private static ConsistentPartitionWindowRelation? FindWindowRelation(Relation relation)
+        {
+            switch (relation)
+            {
+                case ConsistentPartitionWindowRelation window: return window;
+                case WriteRelation write: return FindWindowRelation(write.Input);
+                case ProjectRelation project: return FindWindowRelation(project.Input);
+                case FilterRelation filter: return FindWindowRelation(filter.Input);
+                case RootRelation root: return FindWindowRelation(root.Input);
+                default: return null;
+            }
+        }
+
+        [Fact]
         public void SerializeMergeJoin()
         {
             var plan = new Plan()


### PR DESCRIPTION
This helps reduce unneccessary work by finding common parts in the plan and moving it to a seperate relation to not calculate identical data twice.

Before:

| Method | Mean    | Error    | StdDev   |
|------- |--------:|---------:|---------:|
| Q5     | 4.464 s | 0.0878 s | 0.1713 s | 

After:

| Method | Mean    | Error    | StdDev   |
|------- |--------:|---------:|---------:|
| Q5     | 3.390 s | 0.0669 s | 0.1099 s |