### PR TITLE
Add buffering to bulk join and aggregate operators

### DIFF
--- a/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
@@ -346,7 +346,30 @@ namespace FlowtideDotNet.Base.Vertices
                 }
             }
 
-            return new SingleAsyncEnumerable<IStreamEvent>(lockingEventPrepare);
+            return FlushAndForwardPrepare(lockingEventPrepare);
+        }
+
+        private async IAsyncEnumerable<IStreamEvent> FlushAndForwardPrepare(LockingEventPrepare lockingEventPrepare)
+        {
+            await foreach (var e in OnLockingEventPrepare())
+            {
+                if (e is IRentable rentable)
+                {
+                    rentable.Rent(_links.Count);
+                }
+                yield return new StreamMessage<T>(e, _currentTime);
+            }
+            yield return lockingEventPrepare;
+        }
+
+        /// <summary>
+        /// Called in iteration loops when a locking event prepare is forwarded.
+        /// Emitted data is sent downstream ahead of the prepare event, so buffered
+        /// data becomes visible to the loop before it can settle.
+        /// </summary>
+        protected virtual IAsyncEnumerable<T> OnLockingEventPrepare()
+        {
+            return EmptyAsyncEnumerable<T>.Instance;
         }
 
         private async IAsyncEnumerable<IStreamEvent> HandleInitialDataDoneEvent(int targetId, InitialDataDoneEvent initialDataDoneEvent)
@@ -514,9 +537,31 @@ namespace FlowtideDotNet.Base.Vertices
 
         private async IAsyncEnumerable<IStreamEvent> HandleCheckpointEnumerable(ILockingEvent checkpointEvent)
         {
+            if (checkpointEvent is ICheckpointEvent)
+            {
+                await foreach (var e in OnCheckpointFlush())
+                {
+                    if (e is IRentable rentable)
+                    {
+                        rentable.Rent(_links.Count);
+                    }
+                    yield return new StreamMessage<T>(e, _currentTime);
+                }
+            }
             var transformedEvent = await HandleCheckpoint(checkpointEvent);
             CheckpointSent();
             yield return transformedEvent;
+        }
+
+        /// <summary>
+        /// Called when checkpoint events have aligned on all inputs, before <see cref="OnCheckpoint"/> runs.
+        /// Emitted data is sent downstream ahead of the checkpoint event, allowing
+        /// operators to flush buffered data into the checkpoint.
+        /// Not invoked when the vertex runs with parallel execution.
+        /// </summary>
+        protected virtual IAsyncEnumerable<T> OnCheckpointFlush()
+        {
+            return EmptyAsyncEnumerable<T>.Instance;
         }
 
         private async Task<ILockingEvent> HandleCheckpoint(ILockingEvent lockingEvent)

--- a/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/MultipleInput/MultipleInputVertex.cs
@@ -362,11 +362,6 @@ namespace FlowtideDotNet.Base.Vertices
             yield return lockingEventPrepare;
         }
 
-        /// <summary>
-        /// Called in iteration loops when a locking event prepare is forwarded.
-        /// Emitted data is sent downstream ahead of the prepare event, so buffered
-        /// data becomes visible to the loop before it can settle.
-        /// </summary>
         protected virtual IAsyncEnumerable<T> OnLockingEventPrepare()
         {
             return EmptyAsyncEnumerable<T>.Instance;
@@ -554,10 +549,7 @@ namespace FlowtideDotNet.Base.Vertices
         }
 
         /// <summary>
-        /// Called when checkpoint events have aligned on all inputs, before <see cref="OnCheckpoint"/> runs.
-        /// Emitted data is sent downstream ahead of the checkpoint event, allowing
-        /// operators to flush buffered data into the checkpoint.
-        /// Not invoked when the vertex runs with parallel execution.
+        /// Flush data before the aligned checkpoint event is forwarded, not called in parallel mode
         /// </summary>
         protected virtual IAsyncEnumerable<T> OnCheckpointFlush()
         {

--- a/src/FlowtideDotNet.Base/Vertices/Unary/UnaryVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Unary/UnaryVertex.cs
@@ -351,10 +351,7 @@ namespace FlowtideDotNet.Base.Vertices
         }
 
         /// <summary>
-        /// Called when a checkpoint event arrives, before <see cref="OnCheckpoint"/> runs.
-        /// Emitted data is sent downstream ahead of the checkpoint event, allowing
-        /// operators to flush buffered data into the checkpoint.
-        /// Not invoked when the vertex runs with parallel execution.
+        /// Flush data before the checkpoint event is forwarded, not called in parallel mode
         /// </summary>
         protected virtual IAsyncEnumerable<T> OnCheckpointFlush()
         {

--- a/src/FlowtideDotNet.Base/Vertices/Unary/UnaryVertex.cs
+++ b/src/FlowtideDotNet.Base/Vertices/Unary/UnaryVertex.cs
@@ -335,8 +335,30 @@ namespace FlowtideDotNet.Base.Vertices
 
         private async IAsyncEnumerable<IStreamEvent> HandleCheckpointEnumerable(ILockingEvent checkpointEvent)
         {
+            if (checkpointEvent is ICheckpointEvent)
+            {
+                await foreach (var e in OnCheckpointFlush())
+                {
+                    if (e is IRentable rentable)
+                    {
+                        rentable.Rent(_links.Count);
+                    }
+                    yield return new StreamMessage<T>(e, _currentTime);
+                }
+            }
             var transformedCheckpoint = await HandleCheckpoint(checkpointEvent);
             yield return transformedCheckpoint;
+        }
+
+        /// <summary>
+        /// Called when a checkpoint event arrives, before <see cref="OnCheckpoint"/> runs.
+        /// Emitted data is sent downstream ahead of the checkpoint event, allowing
+        /// operators to flush buffered data into the checkpoint.
+        /// Not invoked when the vertex runs with parallel execution.
+        /// </summary>
+        protected virtual IAsyncEnumerable<T> OnCheckpointFlush()
+        {
+            return EmptyAsyncEnumerable<T>.Instance;
         }
 
         private async IAsyncEnumerable<IStreamEvent> HandleLockEventPrepare(LockingEventPrepare prepare)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Bulk/BulkAggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Bulk/BulkAggregateOperator.cs
@@ -106,6 +106,11 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
         private PrimitiveList<uint>? _retractIterations;
         private uint m_currentIteration;
 
+        // Deferred insert buffering for random group keys
+        private readonly DeferredInsertBuffer _defer = new DeferredInsertBuffer();
+        private long _lastReceiveTime;
+        private uint _pendingIteration;
+
         public BulkAggregateOperator(AggregateRelation aggregateRelation, FunctionsRegister functionsRegister, ExecutionDataflowBlockOptions executionDataflowBlockOptions) : base(executionDataflowBlockOptions)
         {
             this._aggregateRelation = aggregateRelation;
@@ -174,6 +179,12 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
             Debug.Assert(m_temporaryStateValues != null);
             Debug.Assert(m_hasSentInitialData != null);
 
+            if (_defer.HasPending)
+            {
+                // Watermark flush always runs before the checkpoint barrier
+                throw new InvalidOperationException("Deferred aggregate data pending at checkpoint, watermark flush must precede the checkpoint barrier.");
+            }
+
             await _tree.Commit();
 
             if (_temporaryTree != null)
@@ -220,6 +231,13 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
             Debug.Assert(m_hasSentInitialData != null);
             Debug.Assert(weights != null);
             Debug.Assert(iterations != null);
+
+            // Buffered batches must be in state before emitting results
+            await foreach (var batch in FlushPending())
+            {
+                yield return batch;
+            }
+            _defer.ExitBuffering();
 
             int groupLength = m_groupValues.Length;
 
@@ -580,7 +598,58 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
             _retractIterations = new PrimitiveList<uint>(MemoryAllocator);
         }
 
-        public override async IAsyncEnumerable<StreamEventBatch> OnRecieve(StreamEventBatch msg, long time)
+        public override IAsyncEnumerable<StreamEventBatch> OnRecieve(StreamEventBatch msg, long time)
+        {
+            _lastReceiveTime = time;
+            if (_defer.Buffering)
+            {
+                return BufferBatch(msg);
+            }
+            return ProcessBatch(msg, time);
+        }
+
+        private async IAsyncEnumerable<StreamEventBatch> BufferBatch(StreamEventBatch msg)
+        {
+            if (msg.Data.Weights.Count == 0)
+            {
+                yield break;
+            }
+            // Batches from different loop iterations must not merge
+            if (_defer.HasPending && msg.Data.Iterations[0] != _pendingIteration)
+            {
+                await foreach (var batch in FlushPending())
+                {
+                    yield return batch;
+                }
+            }
+            _pendingIteration = msg.Data.Iterations[0];
+            if (_defer.Add(msg.Data))
+            {
+                await foreach (var batch in FlushPending())
+                {
+                    yield return batch;
+                }
+            }
+        }
+
+        private async IAsyncEnumerable<StreamEventBatch> FlushPending()
+        {
+            if (!_defer.HasPending)
+            {
+                yield break;
+            }
+
+            // One sort and insert amortized over all pending rows
+            var combined = _defer.TakePending(MemoryAllocator);
+            var combinedMsg = new StreamEventBatch(combined);
+            await foreach (var batch in ProcessBatch(combinedMsg, _lastReceiveTime))
+            {
+                yield return batch;
+            }
+            combined.Return();
+        }
+
+        private async IAsyncEnumerable<StreamEventBatch> ProcessBatch(StreamEventBatch msg, long time)
         {
             if (msg.Data.Count > 0)
             {
@@ -849,6 +918,9 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
             // Apply the batch, mutator handles calling compute on measures for a group of values
             await _treeBulkInserter.ApplyBatch(_rowReferenceBuffer, _rowValuesBuffer, uniqueCounter, _noDuplicateIndices, _duplicateTags, mutator, totalBatchSize);
 
+            // Unique group count and leaf hits drive the buffering
+            _defer.OnBatchApplied(uniqueCounter, _treeBulkInserter.LeafHitCount);
+
             // Temporary should be moved
             if (_tempIndices.Length < uniqueCounter)
             {
@@ -898,6 +970,12 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
                 yield return new StreamEventBatch(new EventBatchWeighted(weights, iterations, GetEmitBatchData()));
                 InitForwardColumns();
             }
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            _defer.ReturnPending();
+            return base.DisposeAsync();
         }
 
         protected override async Task InitializeOrRestore(IStateManagerClient stateManagerClient)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Bulk/BulkAggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Bulk/BulkAggregateOperator.cs
@@ -181,8 +181,8 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
 
             if (_defer.HasPending)
             {
-                // Watermark flush always runs before the checkpoint barrier
-                throw new InvalidOperationException("Deferred aggregate data pending at checkpoint, watermark flush must precede the checkpoint barrier.");
+                // OnCheckpointFlush always runs before OnCheckpoint
+                throw new InvalidOperationException("Deferred aggregate data pending at checkpoint, OnCheckpointFlush should have flushed it.");
             }
 
             await _tree.Commit();
@@ -221,6 +221,18 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
             }
 
             await m_hasSentInitialData.Commit();
+        }
+
+        // Checkpoints arrive independently of watermarks, keep buffering latched
+        protected override IAsyncEnumerable<StreamEventBatch> OnCheckpointFlush()
+        {
+            return FlushPending();
+        }
+
+        // Buffered data must be visible to the loop before it can settle
+        protected override IAsyncEnumerable<StreamEventBatch> OnLockingEventPrepare()
+        {
+            return FlushPending();
         }
 
         protected override async IAsyncEnumerable<StreamEventBatch> OnWatermark(Watermark watermark)

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Bulk/BulkAggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Bulk/BulkAggregateOperator.cs
@@ -653,12 +653,18 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
 
             // One sort and insert amortized over all pending rows
             var combined = _defer.TakePending(MemoryAllocator);
-            var combinedMsg = new StreamEventBatch(combined);
-            await foreach (var batch in ProcessBatch(combinedMsg, _lastReceiveTime))
+            try
             {
-                yield return batch;
+                var combinedMsg = new StreamEventBatch(combined);
+                await foreach (var batch in ProcessBatch(combinedMsg, _lastReceiveTime))
+                {
+                    yield return batch;
+                }
             }
-            combined.Return();
+            finally
+            {
+                combined.Return();
+            }
         }
 
         private async IAsyncEnumerable<StreamEventBatch> ProcessBatch(StreamEventBatch msg, long time)

--- a/src/FlowtideDotNet.Core/Operators/DeferredInsertBuffer.cs
+++ b/src/FlowtideDotNet.Core/Operators/DeferredInsertBuffer.cs
@@ -30,13 +30,19 @@ namespace FlowtideDotNet.Core.Operators
         private const double TargetDensity = 8.0;
 
         private const int InitialRowCap = 1_000;
-        private const int MaxRowCap = 100_000;
+
+        // Sanity bound for the cap doubling, memory is bounded by bytes
+        private const int MaxRowCap = 1_000_000;
+
+        // Hard memory ceiling, flush happens regardless of row cap
+        private const long MaxPendingBytes = 16 * 1024 * 1024;
 
         // Smaller batches give too noisy a density signal
         private const int MinRowsForSignal = 64;
 
         private readonly List<EventBatchWeighted> _pending = new List<EventBatchWeighted>();
         private int _pendingRows;
+        private long _pendingBytes;
         private int _flushRowCap = InitialRowCap;
 
         public bool Buffering { get; private set; }
@@ -52,7 +58,9 @@ namespace FlowtideDotNet.Core.Operators
             data.Rent(1);
             _pending.Add(data);
             _pendingRows += data.Count;
-            return _pendingRows >= _flushRowCap;
+            // Data size plus weights and iterations
+            _pendingBytes += data.EventBatchData.GetByteSize() + (long)data.Count * 8;
+            return _pendingRows >= _flushRowCap || _pendingBytes >= MaxPendingBytes;
         }
 
         /// <summary>
@@ -92,6 +100,7 @@ namespace FlowtideDotNet.Core.Operators
             }
             _pending.Clear();
             _pendingRows = 0;
+            _pendingBytes = 0;
             return result;
         }
 
@@ -147,6 +156,7 @@ namespace FlowtideDotNet.Core.Operators
             }
             _pending.Clear();
             _pendingRows = 0;
+            _pendingBytes = 0;
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/DeferredInsertBuffer.cs
+++ b/src/FlowtideDotNet.Core/Operators/DeferredInsertBuffer.cs
@@ -17,9 +17,7 @@ using FlowtideDotNet.Storage.Memory;
 namespace FlowtideDotNet.Core.Operators
 {
     /// <summary>
-    /// Buffers batches when inserts touch almost one leaf per row, merged
-    /// flushes amortize the per leaf work. Buffering latches until watermark,
-    /// the flush cap adapts from an estimated leaf count.
+    /// Buffers batches when inserts scatter over leaves, merged flushes amortize the work
     /// </summary>
     internal sealed class DeferredInsertBuffer
     {

--- a/src/FlowtideDotNet.Core/Operators/DeferredInsertBuffer.cs
+++ b/src/FlowtideDotNet.Core/Operators/DeferredInsertBuffer.cs
@@ -1,0 +1,152 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+
+namespace FlowtideDotNet.Core.Operators
+{
+    /// <summary>
+    /// Buffers batches when inserts touch almost one leaf per row, merged
+    /// flushes amortize the per leaf work. Buffering latches until watermark,
+    /// the flush cap adapts from an estimated leaf count.
+    /// </summary>
+    internal sealed class DeferredInsertBuffer
+    {
+        // Density (rows per touched leaf) below this starts buffering
+        private const double EnterDensityThreshold = 4.0;
+
+        // Flush cap targets this density, must exceed the enter threshold
+        private const double TargetDensity = 8.0;
+
+        private const int InitialRowCap = 1_000;
+        private const int MaxRowCap = 100_000;
+
+        // Smaller batches give too noisy a density signal
+        private const int MinRowsForSignal = 64;
+
+        private readonly List<EventBatchWeighted> _pending = new List<EventBatchWeighted>();
+        private int _pendingRows;
+        private int _flushRowCap = InitialRowCap;
+
+        public bool Buffering { get; private set; }
+
+        public bool HasPending => _pending.Count > 0;
+
+        /// <summary>
+        /// Buffers a batch, returns true when the cap is reached.
+        /// </summary>
+        public bool Add(EventBatchWeighted data)
+        {
+            // Keep the batch alive until flushed
+            data.Rent(1);
+            _pending.Add(data);
+            _pendingRows += data.Count;
+            return _pendingRows >= _flushRowCap;
+        }
+
+        /// <summary>
+        /// Takes all pending rows as one batch, caller owns one rent.
+        /// </summary>
+        public EventBatchWeighted TakePending(IMemoryAllocator memoryAllocator)
+        {
+            EventBatchWeighted result;
+            if (_pending.Count == 1)
+            {
+                // Single batch passes through with its rent from Add
+                result = _pending[0];
+            }
+            else
+            {
+                int columnCount = _pending[0].EventBatchData.Columns.Count;
+                var weights = new PrimitiveList<int>(memoryAllocator);
+                var iterations = new PrimitiveList<uint>(memoryAllocator);
+                IColumn[] columns = new IColumn[columnCount];
+                for (int i = 0; i < columnCount; i++)
+                {
+                    columns[i] = Column.Create(memoryAllocator);
+                }
+                foreach (var batch in _pending)
+                {
+                    int count = batch.Count;
+                    weights.AddRangeFrom(batch.Weights, 0, count);
+                    iterations.AddRangeFrom(batch.Iterations, 0, count);
+                    for (int c = 0; c < columnCount; c++)
+                    {
+                        columns[c].InsertRangeFrom(columns[c].Count, batch.EventBatchData.Columns[c], 0, count);
+                    }
+                    batch.Return();
+                }
+                result = new EventBatchWeighted(weights, iterations, new EventBatchData(columns));
+                result.Rent(1);
+            }
+            _pending.Clear();
+            _pendingRows = 0;
+            return result;
+        }
+
+        /// <summary>
+        /// Updates the latch and flush cap from an insert's leaf hits.
+        /// </summary>
+        public void OnBatchApplied(int rowCount, int leafHits)
+        {
+            if (rowCount < MinRowsForSignal || leafHits <= 0)
+            {
+                return;
+            }
+
+            if (rowCount < leafHits * EnterDensityThreshold)
+            {
+                Buffering = true;
+            }
+
+            double estimatedLeaves;
+            if (rowCount >= leafHits * 2)
+            {
+                // Dense, leaves are saturated so hits equal leaves
+                estimatedLeaves = leafHits;
+            }
+            else
+            {
+                // Sparse, birthday estimate, zero collisions keeps growing
+                int collisions = rowCount - leafHits;
+                estimatedLeaves = (double)rowCount * rowCount / (2.0 * Math.Max(collisions, 1));
+            }
+            long desired = (long)(estimatedLeaves * TargetDensity);
+            // At most one doubling per measurement
+            long next = Math.Clamp(desired, _flushRowCap / 2L, _flushRowCap * 2L);
+            _flushRowCap = (int)Math.Clamp(next, InitialRowCap, MaxRowCap);
+        }
+
+        /// <summary>
+        /// Watermark reset to direct inserts, the learned cap is kept.
+        /// </summary>
+        public void ExitBuffering()
+        {
+            Buffering = false;
+        }
+
+        /// <summary>
+        /// Releases pending batches without processing, used on dispose.
+        /// </summary>
+        public void ReturnPending()
+        {
+            foreach (var batch in _pending)
+            {
+                batch.Return();
+            }
+            _pending.Clear();
+            _pendingRows = 0;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -1,15 +1,16 @@
-// Licensed under the Apache License, Version 2.0 (the "License")
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-//  
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Base;
 using FlowtideDotNet.Base.Metrics;
 using FlowtideDotNet.Base.Vertices;
 using FlowtideDotNet.Core.ColumnStore;
@@ -102,6 +103,11 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
         // Metrics
         private ICounter<long>? _eventsCounter;
         private ICounter<long>? _eventsProcessed;
+
+        // Deferred insert buffering for random join keys
+        private readonly DeferredInsertBuffer _leftDefer = new DeferredInsertBuffer();
+        private readonly DeferredInsertBuffer _rightDefer = new DeferredInsertBuffer();
+        private long _lastReceiveTime;
 
         protected readonly Func<EventBatchData, int, EventBatchData, int, bool>? _postCondition;
         private readonly DataValueContainer _dataValueContainer;
@@ -238,6 +244,12 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             Debug.Assert(_leftTree != null);
             Debug.Assert(_rightTree != null);
 
+            if (_leftDefer.HasPending || _rightDefer.HasPending)
+            {
+                // Watermark flush always runs before the checkpoint barrier
+                throw new InvalidOperationException("Deferred join data pending at checkpoint, watermark flush must precede the checkpoint barrier.");
+            }
+
             await _leftTree.Commit();
             await _rightTree.Commit();
 
@@ -276,12 +288,75 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 rightInput!.Flush();
             }
             allInput.WriteLine("End batch");
-            
+
             allInput!.Flush();
 #endif
 
             _eventsProcessed.Add(msg.Data.Weights.Count);
+            _lastReceiveTime = time;
+            if (targetId == 0 ? _leftDefer.Buffering : _rightDefer.Buffering)
+            {
+                return BufferBatch(targetId, msg);
+            }
             return targetId == 0 ? OnRecieveLeft(msg, time) : OnRecieveRight(msg, time);
+        }
+
+        private async IAsyncEnumerable<StreamEventBatch> BufferBatch(int targetId, StreamEventBatch msg)
+        {
+            if (msg.Data.Weights.Count == 0)
+            {
+                yield break;
+            }
+            var buffer = targetId == 0 ? _leftDefer : _rightDefer;
+            if (buffer.Add(msg.Data))
+            {
+                await foreach (var batch in FlushPendingSide(targetId))
+                {
+                    yield return batch;
+                }
+            }
+        }
+
+        private async IAsyncEnumerable<StreamEventBatch> FlushPendingSide(int targetId)
+        {
+            var buffer = targetId == 0 ? _leftDefer : _rightDefer;
+            if (!buffer.HasPending)
+            {
+                yield break;
+            }
+
+            // One sort, probe and insert amortized over all pending rows
+            var combined = buffer.TakePending(MemoryAllocator);
+            var combinedMsg = new StreamEventBatch(combined);
+            var enumerable = targetId == 0
+                ? OnRecieveLeft(combinedMsg, _lastReceiveTime)
+                : OnRecieveRight(combinedMsg, _lastReceiveTime);
+            await foreach (var batch in enumerable)
+            {
+                yield return batch;
+            }
+            combined.Return();
+        }
+
+        protected override async IAsyncEnumerable<StreamEventBatch> OnWatermark(Watermark watermark)
+        {
+            await foreach (var batch in FlushPendingSide(0))
+            {
+                yield return batch;
+            }
+            await foreach (var batch in FlushPendingSide(1))
+            {
+                yield return batch;
+            }
+            _leftDefer.ExitBuffering();
+            _rightDefer.ExitBuffering();
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            _leftDefer.ReturnPending();
+            _rightDefer.ReturnPending();
+            return base.DisposeAsync();
         }
 
         private void CopyCollectedIndices(
@@ -367,7 +442,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 insertValues[i] = new JoinWeights()
                 {
                     weight = msg.Data.Weights[i],
-                    joinWeight = 0 
+                    joinWeight = 0
                 };
             }
 
@@ -434,7 +509,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                     weights.Add(joinStorageValue.weight);
                                     iterations.Add(msg.Data.Iterations[keyIndex]);
                                 }
-                                
+
                                 pageValues.Update(k, joinStorageValue);
                             }
                         }
@@ -546,6 +621,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             targetPositions.Dispose();
 
             await _leftInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, _duplicatesTagBuffer, new JoinWeightsMutator(_leftInputColumnCount), batchSize);
+
+            _leftDefer.OnBatchApplied(keyLength, _leftInserter.LeafHitCount);
         }
 
         private async IAsyncEnumerable<StreamEventBatch> OnRecieveRight(StreamEventBatch msg, long time)
@@ -601,7 +678,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                 insertValues[i] = new JoinWeights()
                 {
                     weight = msg.Data.Weights[i],
-                    joinWeight = 0 
+                    joinWeight = 0
                 };
             }
 
@@ -710,7 +787,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                                     weights.Add(joinStorageValue.weight);
                                     iterations.Add(msg.Data.Iterations[keyIndex]);
                                 }
-                                
+
                                 pageValues.Update(k, joinStorageValue);
                             }
                         }
@@ -795,6 +872,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             targetPositions.Dispose();
 
             await _rightInserter.ApplyBatch(keys, insertValues, keyLength, sortedIndices, _duplicatesTagBuffer, new JoinWeightsMutator(_rightInputColumnCount), batchSize);
+
+            _rightDefer.OnBatchApplied(keyLength, _rightInserter.LeafHitCount);
         }
 
         private StreamEventBatch BuildOutputBatch(StreamEventBatch msg, PrimitiveList<int> foundOffsets, PrimitiveList<int> weights, PrimitiveList<uint> iterations, List<Column>? leftColumns, List<Column>? rightColumns, bool isLeft)
@@ -931,7 +1010,7 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
                     MemoryAllocator = MemoryAllocator
                 });
             _leftInserter = _leftTree.CreateBulkInserter();
-            _leftSearcher = _leftTree.CreateBulkSearcher(_searchLeftComparer); 
+            _leftSearcher = _leftTree.CreateBulkSearcher(_searchLeftComparer);
             _rightTree = await stateManagerClient.GetOrCreateTree("right",
                 new BPlusTreeOptions<ColumnRowReference, JoinWeights, ColumnKeyStorageContainer, JoinWeightsValueContainer>()
                 {

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -246,8 +246,8 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
             if (_leftDefer.HasPending || _rightDefer.HasPending)
             {
-                // Watermark flush always runs before the checkpoint barrier
-                throw new InvalidOperationException("Deferred join data pending at checkpoint, watermark flush must precede the checkpoint barrier.");
+                // OnCheckpointFlush always runs before OnCheckpoint
+                throw new InvalidOperationException("Deferred join data pending at checkpoint, OnCheckpointFlush should have flushed it.");
             }
 
             await _leftTree.Commit();
@@ -350,6 +350,25 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
             }
             _leftDefer.ExitBuffering();
             _rightDefer.ExitBuffering();
+        }
+
+        // Checkpoints arrive independently of watermarks, keep buffering latched
+        protected override async IAsyncEnumerable<StreamEventBatch> OnCheckpointFlush()
+        {
+            await foreach (var batch in FlushPendingSide(0))
+            {
+                yield return batch;
+            }
+            await foreach (var batch in FlushPendingSide(1))
+            {
+                yield return batch;
+            }
+        }
+
+        // Buffered data must be visible to the loop before it can settle
+        protected override IAsyncEnumerable<StreamEventBatch> OnLockingEventPrepare()
+        {
+            return OnCheckpointFlush();
         }
 
         public override ValueTask DisposeAsync()

--- a/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
+++ b/src/FlowtideDotNet.Core/Operators/Join/MergeJoin/ColumnBulkMergeJoin.cs
@@ -327,15 +327,21 @@ namespace FlowtideDotNet.Core.Operators.Join.MergeJoin
 
             // One sort, probe and insert amortized over all pending rows
             var combined = buffer.TakePending(MemoryAllocator);
-            var combinedMsg = new StreamEventBatch(combined);
-            var enumerable = targetId == 0
-                ? OnRecieveLeft(combinedMsg, _lastReceiveTime)
-                : OnRecieveRight(combinedMsg, _lastReceiveTime);
-            await foreach (var batch in enumerable)
+            try
             {
-                yield return batch;
+                var combinedMsg = new StreamEventBatch(combined);
+                var enumerable = targetId == 0
+                    ? OnRecieveLeft(combinedMsg, _lastReceiveTime)
+                    : OnRecieveRight(combinedMsg, _lastReceiveTime);
+                await foreach (var batch in enumerable)
+                {
+                    yield return batch;
+                }
             }
-            combined.Return();
+            finally
+            {
+                combined.Return();
+            }
         }
 
         protected override async IAsyncEnumerable<StreamEventBatch> OnWatermark(Watermark watermark)

--- a/tests/FlowtideDotNet.Base.Tests/VertexCheckpointFlushTests.cs
+++ b/tests/FlowtideDotNet.Base.Tests/VertexCheckpointFlushTests.cs
@@ -94,7 +94,7 @@ namespace FlowtideDotNet.Base.Tests
 
         private sealed class BufferingMultiVertex : MultipleInputVertex<string>
         {
-            public List<string> Buffered = new List<string>();
+            public readonly List<string> Buffered = new List<string>();
             public int FlushCalls;
             public int PrepareFlushCalls;
             public int PendingAtCheckpoint = -1;

--- a/tests/FlowtideDotNet.Base.Tests/VertexCheckpointFlushTests.cs
+++ b/tests/FlowtideDotNet.Base.Tests/VertexCheckpointFlushTests.cs
@@ -1,0 +1,270 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Base.Metrics;
+using FlowtideDotNet.Base.Metrics.Internal;
+using FlowtideDotNet.Base.Utils;
+using FlowtideDotNet.Base.Vertices;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.StateManager;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading.Tasks.Dataflow;
+
+namespace FlowtideDotNet.Base.Tests
+{
+    /// <summary>
+    /// Checkpoints are injected by the engine independently of watermarks, so an
+    /// operator buffering data between watermarks can receive a checkpoint event
+    /// while data is still pending. OnCheckpointFlush lets the operator emit that
+    /// data downstream ahead of the checkpoint event, so it lands inside the same
+    /// checkpoint, before OnCheckpoint commits state.
+    /// </summary>
+    public class VertexCheckpointFlushTests
+    {
+        private sealed class StubVertexHandler : IVertexHandler
+        {
+            public string OperatorId => "op";
+            public string StreamName => "stream";
+            public IMeter Metrics { get; } = new FlowtideMeter(new Meter("test"), new TagList(), () => "test");
+            public IStateManagerClient StateClient => null!;
+            public ILoggerFactory LoggerFactory => NullLoggerFactory.Instance;
+            public IOperatorMemoryManager MemoryManager => null!;
+            public void ScheduleCheckpoint(TimeSpan time, long? checkpointVersion) { }
+            public Task RegisterTrigger(string name, TimeSpan? scheduledInterval = null) => Task.CompletedTask;
+            public Task FailAndRollback(Exception? exception, long? restoreVersion = default) => Task.CompletedTask;
+        }
+
+        private sealed class BufferingUnaryVertex : UnaryVertex<string>
+        {
+            public List<string> Buffered = new List<string>();
+            public int FlushCalls;
+            public int PendingAtCheckpoint = -1;
+
+            // Bounded capacity matches how the engine always runs vertices
+            public BufferingUnaryVertex() : base(new ExecutionDataflowBlockOptions { BoundedCapacity = 100 })
+            {
+            }
+
+            public override string DisplayName => "test";
+
+            public override IAsyncEnumerable<string> OnRecieve(string msg, long time)
+            {
+                Buffered.Add(msg);
+                return EmptyAsyncEnumerable<string>.Instance;
+            }
+
+            protected override IAsyncEnumerable<string> OnCheckpointFlush()
+            {
+                return FlushBuffered();
+            }
+
+            private async IAsyncEnumerable<string> FlushBuffered()
+            {
+                FlushCalls++;
+                foreach (var item in Buffered)
+                {
+                    yield return item;
+                }
+                Buffered.Clear();
+                await Task.CompletedTask;
+            }
+
+            public override Task OnCheckpoint()
+            {
+                PendingAtCheckpoint = Buffered.Count;
+                return Task.CompletedTask;
+            }
+
+            protected override Task InitializeOrRestore(IStateManagerClient stateManagerClient) => Task.CompletedTask;
+            public override Task Compact() => Task.CompletedTask;
+            public override Task DeleteAsync() => Task.CompletedTask;
+        }
+
+        private sealed class BufferingMultiVertex : MultipleInputVertex<string>
+        {
+            public List<string> Buffered = new List<string>();
+            public int FlushCalls;
+            public int PrepareFlushCalls;
+            public int PendingAtCheckpoint = -1;
+
+            // Bounded capacity matches how the engine always runs vertices
+            public BufferingMultiVertex() : base(2, new ExecutionDataflowBlockOptions { BoundedCapacity = 100 })
+            {
+            }
+
+            public override string DisplayName => "test";
+
+            public override IAsyncEnumerable<string> OnRecieve(int targetId, string msg, long time)
+            {
+                Buffered.Add(msg);
+                return EmptyAsyncEnumerable<string>.Instance;
+            }
+
+            protected override IAsyncEnumerable<string> OnCheckpointFlush()
+            {
+                return FlushBuffered(false);
+            }
+
+            protected override IAsyncEnumerable<string> OnLockingEventPrepare()
+            {
+                return FlushBuffered(true);
+            }
+
+            private async IAsyncEnumerable<string> FlushBuffered(bool prepare)
+            {
+                if (prepare)
+                {
+                    PrepareFlushCalls++;
+                }
+                else
+                {
+                    FlushCalls++;
+                }
+                foreach (var item in Buffered)
+                {
+                    yield return item;
+                }
+                Buffered.Clear();
+                await Task.CompletedTask;
+            }
+
+            public override Task OnCheckpoint()
+            {
+                PendingAtCheckpoint = Buffered.Count;
+                return Task.CompletedTask;
+            }
+
+            protected override Task InitializeOrRestore(IStateManagerClient stateManagerClient) => Task.CompletedTask;
+            public override Task Compact() => Task.CompletedTask;
+            public override Task DeleteAsync() => Task.CompletedTask;
+        }
+
+        private static async Task<BufferBlock<IStreamEvent>> SetupVertex<TVertex>(TVertex vertex)
+            where TVertex : IStreamVertex, ISourceBlock<IStreamEvent>
+        {
+            var collector = new BufferBlock<IStreamEvent>();
+            vertex.Setup("stream", "op");
+            vertex.LinkTo(collector, new DataflowLinkOptions());
+            vertex.CreateBlock();
+            vertex.Link();
+            await vertex.Initialize("op", 0, 0, new StubVertexHandler(), null);
+            return collector;
+        }
+
+        private static async Task<IStreamEvent> ReceiveWithTimeout(BufferBlock<IStreamEvent> collector, IStreamVertex vertex)
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var receive = collector.ReceiveAsync(cts.Token);
+            var finished = await Task.WhenAny(receive, vertex.Completion);
+            if (finished == vertex.Completion)
+            {
+                // Surfaces the fault when the transform threw instead of a timeout
+                await vertex.Completion;
+                throw new InvalidOperationException("Vertex completed without emitting");
+            }
+            return await receive;
+        }
+
+        [Fact]
+        public async Task UnaryVertexFlushesBufferedDataBeforeCheckpointEvent()
+        {
+            var vertex = new BufferingUnaryVertex();
+            var collector = await SetupVertex(vertex);
+
+            await vertex.SendAsync(new StreamMessage<string>("a", 1));
+            await vertex.SendAsync(new Checkpoint(0, 1));
+
+            var first = await ReceiveWithTimeout(collector, vertex);
+            var flushed = Assert.IsType<StreamMessage<string>>(first);
+            Assert.Equal("a", flushed.Data);
+
+            var second = await ReceiveWithTimeout(collector, vertex);
+            Assert.IsAssignableFrom<ICheckpointEvent>(second);
+
+            Assert.Equal(1, vertex.FlushCalls);
+            Assert.Equal(0, vertex.PendingAtCheckpoint);
+        }
+
+        [Fact]
+        public async Task UnaryVertexDoesNotFlushForInitWatermarksEvent()
+        {
+            var vertex = new BufferingUnaryVertex();
+            var collector = await SetupVertex(vertex);
+
+            await vertex.SendAsync(new StreamMessage<string>("a", 1));
+            await vertex.SendAsync(new InitWatermarksEvent());
+
+            var first = await ReceiveWithTimeout(collector, vertex);
+            Assert.IsType<InitWatermarksEvent>(first);
+
+            Assert.Equal(0, vertex.FlushCalls);
+            Assert.Single(vertex.Buffered);
+        }
+
+        [Fact]
+        public async Task MultipleInputVertexFlushesAfterBarrierAlignment()
+        {
+            var vertex = new BufferingMultiVertex();
+            var collector = await SetupVertex(vertex);
+
+            await vertex.Targets[0].SendAsync(new StreamMessage<string>("a", 1));
+            await vertex.Targets[1].SendAsync(new StreamMessage<string>("b", 1));
+
+            // First barrier only, alignment is not complete so nothing may be emitted
+            await vertex.Targets[0].SendAsync(new Checkpoint(0, 1));
+            await Task.Delay(200);
+            Assert.False(collector.TryReceive(out _), "Output was emitted before barrier alignment completed");
+            Assert.Equal(0, vertex.FlushCalls);
+
+            // Second barrier completes alignment, flush must precede the checkpoint event
+            await vertex.Targets[1].SendAsync(new Checkpoint(0, 1));
+
+            var first = await ReceiveWithTimeout(collector, vertex);
+            var flushedA = Assert.IsType<StreamMessage<string>>(first);
+            Assert.Equal("a", flushedA.Data);
+
+            var second = await ReceiveWithTimeout(collector, vertex);
+            var flushedB = Assert.IsType<StreamMessage<string>>(second);
+            Assert.Equal("b", flushedB.Data);
+
+            var third = await ReceiveWithTimeout(collector, vertex);
+            Assert.IsAssignableFrom<ICheckpointEvent>(third);
+
+            Assert.Equal(1, vertex.FlushCalls);
+            Assert.Equal(0, vertex.PendingAtCheckpoint);
+        }
+
+        [Fact]
+        public async Task MultipleInputVertexFlushesBeforeForwardingLockingEventPrepare()
+        {
+            var vertex = new BufferingMultiVertex();
+            var collector = await SetupVertex(vertex);
+
+            await vertex.Targets[0].SendAsync(new StreamMessage<string>("a", 1));
+            var prepare = new LockingEventPrepare(new Checkpoint(0, 1), isInitEvent: true);
+            await vertex.Targets[0].SendAsync(prepare);
+
+            var first = await ReceiveWithTimeout(collector, vertex);
+            var flushed = Assert.IsType<StreamMessage<string>>(first);
+            Assert.Equal("a", flushed.Data);
+
+            var second = await ReceiveWithTimeout(collector, vertex);
+            Assert.Same(prepare, second);
+
+            Assert.Equal(1, vertex.PrepareFlushCalls);
+            Assert.Equal(0, vertex.FlushCalls);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Base.Tests/VertexCheckpointFlushTests.cs
+++ b/tests/FlowtideDotNet.Base.Tests/VertexCheckpointFlushTests.cs
@@ -24,13 +24,6 @@ using System.Threading.Tasks.Dataflow;
 
 namespace FlowtideDotNet.Base.Tests
 {
-    /// <summary>
-    /// Checkpoints are injected by the engine independently of watermarks, so an
-    /// operator buffering data between watermarks can receive a checkpoint event
-    /// while data is still pending. OnCheckpointFlush lets the operator emit that
-    /// data downstream ahead of the checkpoint event, so it lands inside the same
-    /// checkpoint, before OnCheckpoint commits state.
-    /// </summary>
     public class VertexCheckpointFlushTests
     {
         private sealed class StubVertexHandler : IVertexHandler
@@ -222,11 +215,10 @@ namespace FlowtideDotNet.Base.Tests
             await vertex.Targets[0].SendAsync(new StreamMessage<string>("a", 1));
             await vertex.Targets[1].SendAsync(new StreamMessage<string>("b", 1));
 
-            // First barrier only, alignment is not complete so nothing may be emitted
+            // The barrier gates its input, this send waits for alignment
             await vertex.Targets[0].SendAsync(new Checkpoint(0, 1));
-            await Task.Delay(200);
-            Assert.False(collector.TryReceive(out _), "Output was emitted before barrier alignment completed");
-            Assert.Equal(0, vertex.FlushCalls);
+            var gatedSend = vertex.Targets[0].SendAsync(new StreamMessage<string>("gated", 1));
+            Assert.False(gatedSend.IsCompleted, "The barrier did not gate its input");
 
             // Second barrier completes alignment, flush must precede the checkpoint event
             await vertex.Targets[1].SendAsync(new Checkpoint(0, 1));
@@ -242,8 +234,12 @@ namespace FlowtideDotNet.Base.Tests
             var third = await ReceiveWithTimeout(collector, vertex);
             Assert.IsAssignableFrom<ICheckpointEvent>(third);
 
+            // A flush per arriving barrier instead of per alignment would be two
             Assert.Equal(1, vertex.FlushCalls);
             Assert.Equal(0, vertex.PendingAtCheckpoint);
+
+            // The gate opens once the checkpoint is sent
+            Assert.True(await gatedSend);
         }
 
         [Fact]

--- a/tests/FlowtideDotNet.Base.Tests/VertexCheckpointFlushTests.cs
+++ b/tests/FlowtideDotNet.Base.Tests/VertexCheckpointFlushTests.cs
@@ -48,7 +48,7 @@ namespace FlowtideDotNet.Base.Tests
 
         private sealed class BufferingUnaryVertex : UnaryVertex<string>
         {
-            public List<string> Buffered = new List<string>();
+            public readonly List<string> Buffered = new List<string>();
             public int FlushCalls;
             public int PendingAtCheckpoint = -1;
 


### PR DESCRIPTION
This helps during random data to try and get more rows touching the same leafs to reduce impact of insert performance.