### PR TITLE
Add support to define custom primary keys in insert into statement

### DIFF
--- a/docs/docs/connectors/sqlserver.md
+++ b/docs/docs/connectors/sqlserver.md
@@ -165,16 +165,26 @@ After all data has been merged, the temporary table is cleared of all data.
 ### Custom Primary Keys
 
 In some scenarios you may want to override the table's primary keys or the table might not have a primary key configured.
-In this scenario you can provide column names for the columns you want Flowtide to use as primary keys.
+In this scenario you can declare the columns that Flowtide should use as primary keys in the insert statement:
 
-Ex:
-
-```csharp
-connectorManager.AddSqlServerSink("your regexp on table names", new SqlServerSinkOptions() {
-  ConnectionStringFunc = () => connectionString,
-  CustomPrimaryKeys = new List<string>() { "my_column1", "my_column2" }
-});
+```sql
+INSERT INTO [my-db].[dbo].[my-table] PRIMARY KEY ([my_column1], [my_column2])
+SELECT my_column1, my_column2, my_column3 FROM ...
 ```
+
+The declared columns must all be written by the statement. To learn more, visit the [Insert Into docs](../sql/insertinto.md).
+
+> [!NOTE]
+> The `CustomPrimaryKeys` option on `SqlServerSinkOptions` does the same thing and is still honored, but it is obsolete.
+> It applies the same keys to every table the sink handles, so it cannot be used by a stream that writes to more than one
+> table. When both are given, the keys declared in the statement are used.
+>
+> ```csharp
+> connectorManager.AddSqlServerSink(new SqlServerSinkOptions() {
+>   ConnectionStringFunc = () => connectionString,
+>   CustomPrimaryKeys = new List<string>() { "my_column1", "my_column2" }
+> });
+> ```
 
 ## SQL Table Provider
 

--- a/docs/docs/sql/insertinto.md
+++ b/docs/docs/sql/insertinto.md
@@ -17,3 +17,35 @@ select_statement
 INSERT INTO outputtable
 SELECT column1, column2 FROM inputtable
 ```
+
+## Primary keys
+
+A sink groups the rows it writes by a primary key. Most connectors find the primary key on their own, for instance by
+looking at the destination table, but the *PRIMARY KEY* clause lets the statement decide which columns to use instead.
+
+```sql
+INSERT INTO table_name PRIMARY KEY (column1, column2)
+select_statement
+```
+
+This is useful when the destination has no primary key, when its primary key is not written by the stream, or when a
+stream writes to several tables that each need different keys.
+
+Example:
+
+```sql
+INSERT INTO outputtable PRIMARY KEY (column1)
+SELECT column1, column2 FROM inputtable
+```
+
+Every declared column must be written by the statement, a column that is not part of the select is an error. The clause
+is also placed after the column list when one is given:
+
+```sql
+INSERT INTO outputtable (column1, column2) PRIMARY KEY (column1)
+SELECT a, b FROM inputtable
+```
+
+> [!NOTE]
+> Not all connectors can use declared primary keys. Building the stream fails if the statement declares primary keys for
+> a sink that does not support them, rather than writing the data with other keys than the declared ones.

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/ColumnSqlServerSink.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/ColumnSqlServerSink.cs
@@ -90,10 +90,17 @@ namespace FlowtideDotNet.Connector.SqlServer.SqlServer
             }
 
             List<string>? m_primaryKeyNames = null;
-            if (m_sqlServerSinkOptions.CustomPrimaryKeys != null)
+            if (m_writeRelation.PrimaryKeyNames != null)
+            {
+                // Keys declared per table win over the sink option.
+                m_primaryKeyNames = m_writeRelation.PrimaryKeyNames;
+            }
+#pragma warning disable CS0618 // Obsolete option must keep working until removed.
+            else if (m_sqlServerSinkOptions.CustomPrimaryKeys != null)
             {
                 m_primaryKeyNames = m_sqlServerSinkOptions.CustomPrimaryKeys;
             }
+#pragma warning restore CS0618
             else
             {
                 m_primaryKeyNames = await SqlServerUtils.GetPrimaryKeys(m_connection, m_writeRelation.NamedObject.DotSeperated);
@@ -101,23 +108,10 @@ namespace FlowtideDotNet.Connector.SqlServer.SqlServer
 
             var dbSchema = await SqlServerUtils.GetWriteTableSchema(m_connection, m_writeRelation);
 
-            List<int> primaryKeyIndices = new List<int>();
-            foreach (var primaryKey in m_primaryKeyNames)
-            {
-                int index = -1;
-                for (int i = 0; i < dbSchema.Count; i++)
-                {
-                    if (dbSchema[i].ColumnName.Equals(primaryKey, StringComparison.OrdinalIgnoreCase))
-                    {
-                        index = i;
-                    }
-                }
-                if (index == -1)
-                {
-                    throw new InvalidOperationException("All primary keys of the sink table must be sent to the sink operator.");
-                }
-                primaryKeyIndices.Add(index);
-            }
+            var (primaryKeyIndices, primaryKeyColumnNames) = SqlServerUtils.ResolvePrimaryKeyColumns(
+                dbSchema.Select(x => x.ColumnName).ToList(),
+                m_primaryKeyNames,
+                m_writeRelation.NamedObject.DotSeperated);
             m_primaryKeys = primaryKeyIndices;
 
             m_dataTable = new DataTable();
@@ -189,7 +183,7 @@ namespace FlowtideDotNet.Connector.SqlServer.SqlServer
             {
                 await SqlServerUtils.CreateTemporaryTable(m_connection, dbSchema, m_tmpTableName);
                 m_mergeIntoCommand = m_connection.CreateCommand();
-                var mergeIntoStatement = SqlServerUtils.CreateMergeIntoProcedure(m_tmpTableName, string.Join(".", m_writeRelation.NamedObject.Names.Select(x => $"[{x}]")), m_primaryKeyNames.ToHashSet(), m_dataTable);
+                var mergeIntoStatement = SqlServerUtils.CreateMergeIntoProcedure(m_tmpTableName, string.Join(".", m_writeRelation.NamedObject.Names.Select(x => $"[{x}]")), primaryKeyColumnNames.ToHashSet(), m_dataTable);
                 m_mergeIntoCommand.CommandText = mergeIntoStatement;
                 await m_mergeIntoCommand.PrepareAsync();
             }   

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerSink.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerSink.cs
@@ -123,10 +123,12 @@ namespace FlowtideDotNet.SqlServer.SqlServer
             using var conn = new SqlConnection(connectionStringFunc());
             await conn.OpenAsync();
             List<string>? m_primaryKeyNames = null;
+#pragma warning disable CS0618 // Obsolete option must keep working until removed.
             if (sqlServerSinkOptions.CustomPrimaryKeys != null)
             {
                 m_primaryKeyNames = sqlServerSinkOptions.CustomPrimaryKeys;
             }
+#pragma warning restore CS0618
             else
             {
                 m_primaryKeyNames = await SqlServerUtils.GetPrimaryKeys(conn, writeRelation.NamedObject.DotSeperated);
@@ -168,10 +170,12 @@ namespace FlowtideDotNet.SqlServer.SqlServer
             }
 
             List<string>? m_primaryKeyNames = null;
+#pragma warning disable CS0618 // Obsolete option must keep working until removed.
             if (sqlServerSinkOptions.CustomPrimaryKeys != null)
             {
                 m_primaryKeyNames = sqlServerSinkOptions.CustomPrimaryKeys;
             }
+#pragma warning restore CS0618
             else
             {
                 m_primaryKeyNames = await SqlServerUtils.GetPrimaryKeys(connection, writeRelation.NamedObject.DotSeperated);

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerSinkFactory.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerSinkFactory.cs
@@ -46,6 +46,8 @@ namespace FlowtideDotNet.Connector.SqlServer.SqlServer
             return tableNamesList.ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
 
+        public override bool SupportsPrimaryKeyDeclaration => true;
+
         public override bool CanHandle(WriteRelation writeRelation)
         {
             return _sqlServerTableProvider.TryGetTableInformation(writeRelation.NamedObject.Names, out _);

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerUtils.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServer/SqlServerUtils.cs
@@ -657,6 +657,37 @@ namespace FlowtideDotNet.Substrait.Tests.SqlServer
             return stringBuilder.ToString();
         }
 
+        /// <summary>
+        /// Matches primary key names against the written columns.
+        /// Returns their positions and the casing of the destination table.
+        /// </summary>
+        public static (List<int> Indices, List<string> ColumnNames) ResolvePrimaryKeyColumns(
+            IReadOnlyList<string> writtenColumnNames,
+            IReadOnlyList<string> primaryKeyNames,
+            string destinationTableName)
+        {
+            var indices = new List<int>();
+            var columnNames = new List<string>();
+            foreach (var primaryKey in primaryKeyNames)
+            {
+                int index = -1;
+                for (int i = 0; i < writtenColumnNames.Count; i++)
+                {
+                    if (writtenColumnNames[i].Equals(primaryKey, StringComparison.OrdinalIgnoreCase))
+                    {
+                        index = i;
+                    }
+                }
+                if (index == -1)
+                {
+                    throw new InvalidOperationException($"All primary keys of the sink table must be sent to the sink operator, '{primaryKey}' is not written to '{destinationTableName}'.");
+                }
+                indices.Add(index);
+                columnNames.Add(writtenColumnNames[index]);
+            }
+            return (indices, columnNames);
+        }
+
         public static string CreateMergeIntoProcedure(string tmpTableName, string destinationTableName, HashSet<string> primaryKeys, DataTable dataTable)
         {
             StringBuilder stringBuilder = new StringBuilder();

--- a/src/FlowtideDotNet.Connector.SqlServer/SqlServerSinkOptions.cs
+++ b/src/FlowtideDotNet.Connector.SqlServer/SqlServerSinkOptions.cs
@@ -25,6 +25,7 @@ namespace FlowtideDotNet.Connector.SqlServer
         /// Set custom primary keys for the table.
         /// If not set, the primary keys are collected from the database.
         /// </summary>
+        [Obsolete("Declare the primary keys in the statement instead, 'INSERT INTO table PRIMARY KEY (c1, c2) SELECT ...'. The option applies the same keys to every table the sink handles, which does not work when a stream writes to more than one table.")]
         public List<string>? CustomPrimaryKeys { get; set; }
 
         /// <summary>

--- a/src/FlowtideDotNet.Core/Connectors/AbstractConnectorSinkFactory.cs
+++ b/src/FlowtideDotNet.Core/Connectors/AbstractConnectorSinkFactory.cs
@@ -20,6 +20,11 @@ namespace FlowtideDotNet.Core.Connectors
 {
     public abstract class AbstractConnectorSinkFactory : IConnectorSinkFactory
     {
+        /// <summary>
+        /// <inheritdoc cref="IConnectorSinkFactory.SupportsPrimaryKeyDeclaration"/>
+        /// </summary>
+        public virtual bool SupportsPrimaryKeyDeclaration => false;
+
         public abstract bool CanHandle(WriteRelation writeRelation);
 
         public abstract IStreamEgressVertex CreateSink(WriteRelation writeRelation, IFunctionsRegister functionsRegister, ExecutionDataflowBlockOptions dataflowBlockOptions);

--- a/src/FlowtideDotNet.Core/Connectors/CatalogSinkFactory.cs
+++ b/src/FlowtideDotNet.Core/Connectors/CatalogSinkFactory.cs
@@ -29,6 +29,8 @@ namespace FlowtideDotNet.Core.Connectors
             _inner = inner;
         }
 
+        public bool SupportsPrimaryKeyDeclaration => _inner.SupportsPrimaryKeyDeclaration;
+
         public bool CanHandle(WriteRelation writeRelation)
         {
             var copy = writeRelation.ShallowCopy();

--- a/src/FlowtideDotNet.Core/Connectors/IConnectorSinkFactory.cs
+++ b/src/FlowtideDotNet.Core/Connectors/IConnectorSinkFactory.cs
@@ -20,6 +20,12 @@ namespace FlowtideDotNet.Core.Connectors
 {
     public interface IConnectorSinkFactory
     {
+        /// <summary>
+        /// If the sink uses <see cref="WriteRelation.PrimaryKeyNames"/> declared by the plan.
+        /// Building a stream fails when false and keys are declared.
+        /// </summary>
+        bool SupportsPrimaryKeyDeclaration => false;
+
         bool CanHandle(WriteRelation writeRelation);
 
         /// <summary>

--- a/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
+++ b/src/FlowtideDotNet.Core/Engine/SubstraitVisitor.cs
@@ -14,6 +14,7 @@ using FlowtideDotNet.Base;
 using FlowtideDotNet.Base.Engine;
 using FlowtideDotNet.Base.Vertices;
 using FlowtideDotNet.Core.Compute;
+using FlowtideDotNet.Core.Exceptions;
 using FlowtideDotNet.Core.Operators.Aggregate;
 using FlowtideDotNet.Core.Operators.Aggregate.Column;
 using FlowtideDotNet.Core.Operators.Buffer;
@@ -500,10 +501,20 @@ namespace FlowtideDotNet.Core.Engine
             if (connectorManager != null)
             {
                 var sinkFactory = connectorManager.GetSinkFactory(writeRelation);
+                if (writeRelation.PrimaryKeyNames != null && !sinkFactory.SupportsPrimaryKeyDeclaration)
+                {
+                    throw new FlowtidePrimaryKeyDeclarationNotSupportedException(
+                        $"The connector writing to '{writeRelation.NamedObject.DotSeperated}' cannot use primary keys declared in the plan. Remove the 'PRIMARY KEY' declaration from the insert statement, the connector would otherwise write the data with other primary keys than the declared ones.");
+                }
                 op = sinkFactory.CreateSink(writeRelation, functionsRegister, DefaultBlockOptions);
             }
             else if (readWriteFactory != null)
             {
+                if (writeRelation.PrimaryKeyNames != null)
+                {
+                    throw new FlowtidePrimaryKeyDeclarationNotSupportedException(
+                        $"Primary keys declared in the plan for '{writeRelation.NamedObject.DotSeperated}' are only supported by connectors registered in a connector manager. Remove the 'PRIMARY KEY' declaration from the insert statement or register the connector with a connector manager.");
+                }
                 op = readWriteFactory.GetWriteOperator(writeRelation, functionsRegister, DefaultBlockOptions);
             }
             else

--- a/src/FlowtideDotNet.Core/Exceptions/FlowtidePrimaryKeyDeclarationNotSupportedException.cs
+++ b/src/FlowtideDotNet.Core/Exceptions/FlowtidePrimaryKeyDeclarationNotSupportedException.cs
@@ -1,0 +1,32 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace FlowtideDotNet.Core.Exceptions
+{
+    /// <summary>
+    /// Thrown when a connector cannot use plan declared primary keys.
+    /// </summary>
+    public class FlowtidePrimaryKeyDeclarationNotSupportedException : FlowtideException
+    {
+        public FlowtidePrimaryKeyDeclarationNotSupportedException()
+        {
+        }
+
+        public FlowtidePrimaryKeyDeclarationNotSupportedException(string? message) : base(message)
+        {
+        }
+
+        public FlowtidePrimaryKeyDeclarationNotSupportedException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/FlowtideDotNet.Substrait/CustomProto/custom_proto.proto
+++ b/src/FlowtideDotNet.Substrait/CustomProto/custom_proto.proto
@@ -63,6 +63,13 @@ message TableFunctionRelation {
     }
 }
 
+// Primary keys a plan declares for a write relation.
+// Packed into the advanced extension enhancement of a WriteRel.
+message WriteRelationPrimaryKeys {
+    // Column names, always present in the table schema.
+    repeated string names = 1;
+}
+
 message SubStreamRootRelation {
     // Name of the substream this relation should execute on.
     // Multiple relations can exist that have the same name, then they should all execute on the same substream.

--- a/src/FlowtideDotNet.Substrait/CustomProtoTypeRegistry.cs
+++ b/src/FlowtideDotNet.Substrait/CustomProtoTypeRegistry.cs
@@ -1,0 +1,39 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf.Reflection;
+
+namespace FlowtideDotNet.Substrait
+{
+    /// <summary>
+    /// Custom messages Flowtide packs into 'Any' fields of a plan.
+    /// Shared by the serializer and the deserializer.
+    /// </summary>
+    internal static class CustomProtoTypeRegistry
+    {
+        public static readonly TypeRegistry Instance = TypeRegistry.FromMessages(
+            CustomProtobuf.IterationReferenceReadRelation.Descriptor,
+            CustomProtobuf.IterationRelation.Descriptor,
+            CustomProtobuf.NormalizationRelation.Descriptor,
+            CustomProtobuf.BufferRelation.Descriptor,
+            CustomProtobuf.TopNRelation.Descriptor,
+            CustomProtobuf.TableFunction.Descriptor,
+            CustomProtobuf.TableFunctionRelation.Descriptor,
+            CustomProtobuf.SubStreamRootRelation.Descriptor,
+            CustomProtobuf.StandardOutputTargetReferenceRelation.Descriptor,
+            CustomProtobuf.SubstreamExchangeReferenceRelation.Descriptor,
+            CustomProtobuf.PullExchangeReferenceRelation.Descriptor,
+            CustomProtobuf.SubstreamExchangeTarget.Descriptor,
+            CustomProtobuf.PullBucketExchangeTarget.Descriptor,
+            CustomProtobuf.WriteRelationPrimaryKeys.Descriptor);
+    }
+}

--- a/src/FlowtideDotNet.Substrait/Relations/WriteRelation.cs
+++ b/src/FlowtideDotNet.Substrait/Relations/WriteRelation.cs
@@ -26,6 +26,12 @@ namespace FlowtideDotNet.Substrait.Relations
 
         public bool Overwrite { get; set; } = false;
 
+        /// <summary>
+        /// Primary key columns declared by the plan, using <see cref="TableSchema"/> casing.
+        /// Null when the plan declares none.
+        /// </summary>
+        public List<string>? PrimaryKeyNames { get; set; }
+
         public override TReturn Accept<TReturn, TState>(RelationVisitor<TReturn, TState> visitor, TState state)
         {
             return visitor.VisitWriteRelation(this, state);
@@ -44,7 +50,17 @@ namespace FlowtideDotNet.Substrait.Relations
                 Equals(Input, other.Input) &&
                 Equals(TableSchema, other.TableSchema) &&
                 Equals(NamedObject, other.NamedObject) &&
-                Equals(Overwrite, other.Overwrite);
+                Equals(Overwrite, other.Overwrite) &&
+                PrimaryKeyNamesEqual(other);
+        }
+
+        private bool PrimaryKeyNamesEqual(WriteRelation other)
+        {
+            if (PrimaryKeyNames == null || other.PrimaryKeyNames == null)
+            {
+                return PrimaryKeyNames == null && other.PrimaryKeyNames == null;
+            }
+            return PrimaryKeyNames.SequenceEqual(other.PrimaryKeyNames);
         }
 
         public override int GetHashCode()
@@ -55,6 +71,13 @@ namespace FlowtideDotNet.Substrait.Relations
             code.Add(TableSchema);
             code.Add(NamedObject);
             code.Add(Overwrite);
+            if (PrimaryKeyNames != null)
+            {
+                foreach (var primaryKeyName in PrimaryKeyNames)
+                {
+                    code.Add(primaryKeyName);
+                }
+            }
             return code.ToHashCode();
         }
 
@@ -85,7 +108,8 @@ namespace FlowtideDotNet.Substrait.Relations
                 {
                     Names = new List<string>(TableSchema.Names)
                 },
-                Overwrite = Overwrite
+                Overwrite = Overwrite,
+                PrimaryKeyNames = PrimaryKeyNames != null ? new List<string>(PrimaryKeyNames) : null
             };
             if (TableSchema.Struct != null)
             {

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/CustomStatements.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/CustomStatements.cs
@@ -24,4 +24,18 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
             writer.Write(';');
         }
     };
+
+    /// <summary>
+    /// Insert operation carrying the primary keys declared in the statement.
+    /// </summary>
+    public record FlowtideInsertOperation : InsertOperation
+    {
+        public FlowtideInsertOperation(ObjectName name, Statement.Select? source, Sequence<Ident> primaryKeys)
+            : base(name, source)
+        {
+            PrimaryKeys = primaryKeys;
+        }
+
+        public Sequence<Ident> PrimaryKeys { get; }
+    }
 }

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/FlowtideDialect.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/FlowtideDialect.cs
@@ -155,8 +155,112 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
                 var objName = parser.ParseObjectName();
                 return new BeginSubStream(objName);
             }
+            else if (HasPrimaryKeyDeclaration(parser))
+            {
+                parser.ParseKeyword(Keyword.INSERT);
+                return ParseInsertWithPrimaryKeys(parser);
+            }
 
             return base.ParseStatement(parser);
+        }
+
+        /// <summary>
+        /// Peeks if the insert declares primary keys, consumes nothing.
+        /// </summary>
+        private static bool HasPrimaryKeyDeclaration(Parser parser)
+        {
+            if (parser.PeekToken() is not Word insertWord ||
+                insertWord.Keyword != Keyword.INSERT)
+            {
+                return false;
+            }
+
+            // Read in chunks, peeking token by token is quadratic.
+            var chunkSize = 64;
+            while (true)
+            {
+                var tokens = parser.PeekTokens(chunkSize);
+                var parenthesisDepth = 0;
+                // TABLE can precede the destination name, skip the prefix first.
+                var inTablePrefix = true;
+                for (int i = 1; i < tokens.Count; i++)
+                {
+                    var token = tokens[i];
+                    if (token is EOF)
+                    {
+                        return false;
+                    }
+                    if (inTablePrefix && token is Word prefixWord &&
+                        prefixWord.Keyword is Keyword.OVERWRITE or Keyword.INTO or Keyword.TABLE)
+                    {
+                        continue;
+                    }
+                    inTablePrefix = false;
+                    if (token is LeftParen)
+                    {
+                        parenthesisDepth++;
+                        continue;
+                    }
+                    if (token is RightParen)
+                    {
+                        parenthesisDepth--;
+                        continue;
+                    }
+                    // Tokens inside parenthesis belong to a column list.
+                    if (parenthesisDepth != 0 || token is not Word word)
+                    {
+                        continue;
+                    }
+                    // The query starts here, no declaration was found.
+                    if (word.Keyword is Keyword.SELECT or Keyword.VALUES or Keyword.WITH or Keyword.TABLE)
+                    {
+                        return false;
+                    }
+                    if (word.Keyword == Keyword.PRIMARY)
+                    {
+                        if (i + 1 < tokens.Count)
+                        {
+                            return tokens[i + 1] is Word keyWord && keyWord.Keyword == Keyword.KEY;
+                        }
+                        // Next token is outside the chunk, grow it.
+                        break;
+                    }
+                }
+                if (tokens.Count < chunkSize)
+                {
+                    // Reached the end of the statement.
+                    return false;
+                }
+                chunkSize *= 4;
+            }
+        }
+
+        /// <summary>
+        /// Parses an insert that declares primary keys.
+        /// </summary>
+        private static Statement ParseInsertWithPrimaryKeys(Parser parser)
+        {
+            var overwrite = parser.ParseKeyword(Keyword.OVERWRITE);
+            var into = parser.ParseKeyword(Keyword.INTO);
+            var table = parser.ParseKeyword(Keyword.TABLE);
+            var tableName = parser.ParseObjectName();
+            var columns = parser.ParseParenthesizedColumnList(IsOptional.Optional, false);
+
+            if (!parser.ParseKeywordSequence(Keyword.PRIMARY, Keyword.KEY))
+            {
+                throw Parser.Expected("PRIMARY KEY", parser.PeekToken());
+            }
+            var primaryKeys = parser.ParseParenthesizedColumnList(IsOptional.Mandatory, false);
+
+            var source = parser.ParseQuery();
+
+            return new Statement.Insert(new FlowtideInsertOperation(tableName, source, primaryKeys)
+            {
+                Into = into,
+                Overwrite = overwrite,
+                Table = table,
+                Columns = columns
+            });
         }
 
         public Statement.CreateTable ParseCreateTable(Parser parser, bool orReplace, bool temporary, bool? global, bool transient)

--- a/src/FlowtideDotNet.Substrait/Sql/Internal/SqlSubstraitVisitor.cs
+++ b/src/FlowtideDotNet.Substrait/Sql/Internal/SqlSubstraitVisitor.cs
@@ -133,12 +133,19 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
                 };
             }
 
+            List<string>? primaryKeyNames = null;
+            if (insert.InsertOperation is FlowtideInsertOperation flowtideInsertOperation)
+            {
+                primaryKeyNames = ResolvePrimaryKeyNames(flowtideInsertOperation, tableSchema);
+            }
+
             var writeRelation = new WriteRelation()
             {
                 Input = source.Relation,
                 NamedObject = new FlowtideDotNet.Substrait.Type.NamedTable() { Names = insert.InsertOperation.Name.Values.Select(x => x.Value).ToList() },
                 TableSchema = tableSchema,
-                Overwrite = insert.InsertOperation.Overwrite
+                Overwrite = insert.InsertOperation.Overwrite,
+                PrimaryKeyNames = primaryKeyNames
             };
 
             Relation relation = writeRelation;
@@ -152,6 +159,39 @@ namespace FlowtideDotNet.Substrait.Sql.Internal
             }
 
             return new RelationData(relation, source.EmitData);
+        }
+
+        /// <summary>
+        /// Matches declared primary keys against the written columns.
+        /// Returns the names with table schema casing.
+        /// </summary>
+        private static List<string> ResolvePrimaryKeyNames(FlowtideInsertOperation insertOperation, NamedStruct tableSchema)
+        {
+            var primaryKeyNames = new List<string>();
+            foreach (var primaryKey in insertOperation.PrimaryKeys)
+            {
+                var nameIndex = -1;
+                for (int i = 0; i < tableSchema.Names.Count; i++)
+                {
+                    if (tableSchema.Names[i].Equals(primaryKey.Value, StringComparison.OrdinalIgnoreCase))
+                    {
+                        nameIndex = i;
+                        break;
+                    }
+                }
+                if (nameIndex < 0)
+                {
+                    throw new SubstraitParseException($"Primary key column '{primaryKey.Value}' is not written to table '{insertOperation.Name.ToSql()}', all declared primary keys must be part of the insert.");
+                }
+
+                var name = tableSchema.Names[nameIndex];
+                if (primaryKeyNames.Contains(name))
+                {
+                    throw new SubstraitParseException($"Primary key column '{primaryKey.Value}' is declared more than once for table '{insertOperation.Name.ToSql()}'.");
+                }
+                primaryKeyNames.Add(name);
+            }
+            return primaryKeyNames;
         }
 
         protected override RelationData? VisitCreateView(Statement.CreateView createView, object? state)

--- a/src/FlowtideDotNet.Substrait/SubstraitDeserializer.cs
+++ b/src/FlowtideDotNet.Substrait/SubstraitDeserializer.cs
@@ -1189,13 +1189,29 @@ namespace FlowtideDotNet.Substrait
                     overwrite = true;
                 }
 
+                List<string>? primaryKeyNames = null;
+                if (writeRel.AdvancedExtension?.Enhancement != null)
+                {
+                    var typeName = Google.Protobuf.WellKnownTypes.Any.GetTypeName(writeRel.AdvancedExtension.Enhancement.TypeUrl);
+                    if (typeName == CustomProtobuf.WriteRelationPrimaryKeys.Descriptor.FullName)
+                    {
+                        var primaryKeys = writeRel.AdvancedExtension.Enhancement.Unpack<CustomProtobuf.WriteRelationPrimaryKeys>();
+                        primaryKeyNames = primaryKeys.Names.ToList();
+                    }
+                    else
+                    {
+                        throw new NotImplementedException($"Write relation enhancement '{typeName}' is not supported by deserialization");
+                    }
+                }
+
                 var writeRelation = new WriteRelation()
                 {
                     Input = input,
                     NamedObject = namedTableObj,
                     TableSchema = namedStruct,
                     Emit = emitData,
-                    Overwrite = overwrite
+                    Overwrite = overwrite,
+                    PrimaryKeyNames = primaryKeyNames
                 };
 
                 return writeRelation;
@@ -1595,10 +1611,7 @@ namespace FlowtideDotNet.Substrait
 
         public Plan Deserialize(string json)
         {
-            var typeRegistry = Google.Protobuf.Reflection.TypeRegistry.FromMessages(
-                    CustomProtobuf.IterationReferenceReadRelation.Descriptor,
-                    CustomProtobuf.IterationRelation.Descriptor);
-            var parser = new Google.Protobuf.JsonParser(new Google.Protobuf.JsonParser.Settings(300, typeRegistry));
+            var parser = new Google.Protobuf.JsonParser(new Google.Protobuf.JsonParser.Settings(300, CustomProtoTypeRegistry.Instance));
             var plan = parser.Parse<Protobuf.Plan>(json);
             return Deserialize(plan);
         }

--- a/src/FlowtideDotNet.Substrait/SubstraitSerializer.cs
+++ b/src/FlowtideDotNet.Substrait/SubstraitSerializer.cs
@@ -1289,6 +1289,16 @@ namespace FlowtideDotNet.Substrait
                     writeRel.CreateMode = WriteRel.Types.CreateMode.ReplaceIfExists;
                 }
 
+                if (writeRelation.PrimaryKeyNames != null)
+                {
+                    var primaryKeys = new CustomProtobuf.WriteRelationPrimaryKeys();
+                    primaryKeys.Names.AddRange(writeRelation.PrimaryKeyNames);
+                    writeRel.AdvancedExtension = new Protobuf.AdvancedExtension()
+                    {
+                        Enhancement = Google.Protobuf.WellKnownTypes.Any.Pack(primaryKeys)
+                    };
+                }
+
                 writeRel.Input = Visit(writeRelation.Input, state);
 
                 return new Protobuf.Rel()
@@ -1724,21 +1734,7 @@ namespace FlowtideDotNet.Substrait
         public static string SerializeToJson(Plan plan)
         {
             var protoPlan = Serialize(plan);
-            var typeRegistry = Google.Protobuf.Reflection.TypeRegistry.FromMessages(
-                CustomProtobuf.IterationReferenceReadRelation.Descriptor,
-                CustomProtobuf.IterationRelation.Descriptor,
-                CustomProtobuf.NormalizationRelation.Descriptor,
-                CustomProtobuf.BufferRelation.Descriptor,
-                CustomProtobuf.TopNRelation.Descriptor,
-                CustomProtobuf.TableFunction.Descriptor,
-                CustomProtobuf.TableFunctionRelation.Descriptor,
-                CustomProtobuf.SubStreamRootRelation.Descriptor,
-                CustomProtobuf.StandardOutputTargetReferenceRelation.Descriptor,
-                CustomProtobuf.SubstreamExchangeReferenceRelation.Descriptor,
-                CustomProtobuf.PullExchangeReferenceRelation.Descriptor,
-                CustomProtobuf.SubstreamExchangeTarget.Descriptor,
-                CustomProtobuf.PullBucketExchangeTarget.Descriptor);
-            var settings = new Google.Protobuf.JsonFormatter.Settings(true, typeRegistry)
+            var settings = new Google.Protobuf.JsonFormatter.Settings(true, CustomProtoTypeRegistry.Instance)
                 .WithIndentation();
             var formatter = new Google.Protobuf.JsonFormatter(settings);
             return formatter.Format(protoPlan);

--- a/tests/FlowtideDotNet.Core.Tests/PrimaryKeyDeclarationTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/PrimaryKeyDeclarationTests.cs
@@ -1,0 +1,153 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Base.Vertices;
+using FlowtideDotNet.Core.Compute;
+using FlowtideDotNet.Core.Connectors;
+using FlowtideDotNet.Core.Engine;
+using FlowtideDotNet.Core.Exceptions;
+using FlowtideDotNet.Core.Lineage;
+using FlowtideDotNet.Core.Sinks;
+using FlowtideDotNet.Core.Tests.Failure;
+using FlowtideDotNet.Storage.Persistence.CacheStorage;
+using FlowtideDotNet.Substrait;
+using FlowtideDotNet.Substrait.Relations;
+using FlowtideDotNet.Substrait.Sql;
+using FlowtideDotNet.Substrait.Type;
+using System.Threading.Tasks.Dataflow;
+
+namespace FlowtideDotNet.Core.Tests
+{
+    /// <summary>
+    /// Covers plan declared primary keys and the sink check.
+    /// </summary>
+    public class PrimaryKeyDeclarationTests
+    {
+        private class PrimaryKeyAwareSinkFactory : RegexConnectorSinkFactory
+        {
+            public PrimaryKeyAwareSinkFactory(string regexPattern) : base(regexPattern)
+            {
+            }
+
+            public override bool SupportsPrimaryKeyDeclaration => true;
+
+            public WriteRelation? LastWriteRelation { get; private set; }
+
+            public override IStreamEgressVertex CreateSink(WriteRelation writeRelation, IFunctionsRegister functionsRegister, ExecutionDataflowBlockOptions dataflowBlockOptions)
+            {
+                LastWriteRelation = writeRelation;
+                return new FailureEgress(dataflowBlockOptions, new FailureEgressOptions());
+            }
+
+            public override TableLineageMetadata GetLineageMetadata(WriteRelation writeRelation, bool includeSchema)
+            {
+                return new TableLineageMetadata("test", writeRelation.NamedObject.DotSeperated, default);
+            }
+        }
+
+        private static FlowtideBuilder CreateBuilder(Plan plan, ConnectorManager connectorManager, string directoryName)
+        {
+            return new FlowtideBuilder("test")
+                .AddPlan(plan)
+                .AddConnectorManager(connectorManager)
+                .WithStateOptions(new FlowtideDotNet.Storage.StateManager.StateManagerOptions()
+                {
+                    PersistentStorage = new FileCachePersistentStorage(new FlowtideDotNet.Storage.FileCacheOptions()
+                    {
+                        DirectoryPath = $"./data/tempFiles/{directoryName}"
+                    })
+                });
+        }
+
+        private static Plan GetPlan(string sql)
+        {
+            SqlPlanBuilder builder = new SqlPlanBuilder();
+            builder.AddTableDefinition("a", new NamedStruct()
+            {
+                Names = new List<string>() { "c1", "c2" },
+                Struct = new Struct()
+                {
+                    Types = new List<SubstraitBaseType>() { new AnyType(), new AnyType() }
+                }
+            });
+            builder.Sql(sql);
+            return builder.GetPlan();
+        }
+
+        [Fact]
+        public void SinkThatDoesNotSupportPrimaryKeyDeclarationThrows()
+        {
+            var plan = GetPlan("INSERT INTO test PRIMARY KEY (c1) SELECT c1, c2 FROM a");
+
+            var connectorManager = new ConnectorManager();
+            connectorManager.AddSource(new FailureIngressFactory("*"));
+            connectorManager.AddConsoleSink(".*");
+
+            var e = Assert.Throws<FlowtidePrimaryKeyDeclarationNotSupportedException>(() =>
+            {
+                CreateBuilder(plan, connectorManager, "pkNotSupported").Build();
+            });
+
+            Assert.Equal("The connector writing to 'test' cannot use primary keys declared in the plan. Remove the 'PRIMARY KEY' declaration from the insert statement, the connector would otherwise write the data with other primary keys than the declared ones.", e.Message);
+        }
+
+        [Fact]
+        public void SinkThatSupportsPrimaryKeyDeclarationReceivesTheNames()
+        {
+            var plan = GetPlan("INSERT INTO test PRIMARY KEY (c2, c1) SELECT c1, c2 FROM a");
+
+            var sinkFactory = new PrimaryKeyAwareSinkFactory(".*");
+            var connectorManager = new ConnectorManager();
+            connectorManager.AddSource(new FailureIngressFactory("*"));
+            connectorManager.AddSink(sinkFactory);
+
+            CreateBuilder(plan, connectorManager, "pkSupported").Build();
+
+            Assert.NotNull(sinkFactory.LastWriteRelation);
+            Assert.Equal(new List<string>() { "c2", "c1" }, sinkFactory.LastWriteRelation.PrimaryKeyNames);
+        }
+
+        /// <summary>
+        /// The catalog wrapper must forward what the inner factory supports.
+        /// </summary>
+        [Fact]
+        public void SinkInCatalogReceivesThePrimaryKeyNames()
+        {
+            var plan = GetPlan("INSERT INTO mycatalog.test PRIMARY KEY (c2) SELECT c1, c2 FROM a");
+
+            var sinkFactory = new PrimaryKeyAwareSinkFactory(".*");
+            var connectorManager = new ConnectorManager();
+            connectorManager.AddSource(new FailureIngressFactory("*"));
+            connectorManager.AddCatalog("mycatalog", catalog =>
+            {
+                catalog.AddSink(sinkFactory);
+            });
+
+            CreateBuilder(plan, connectorManager, "pkCatalog").Build();
+
+            Assert.NotNull(sinkFactory.LastWriteRelation);
+            Assert.Equal(new List<string>() { "c2" }, sinkFactory.LastWriteRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void SinkWithoutPrimaryKeyDeclarationIsNotAffected()
+        {
+            var plan = GetPlan("INSERT INTO test SELECT c1, c2 FROM a");
+
+            var connectorManager = new ConnectorManager();
+            connectorManager.AddSource(new FailureIngressFactory("*"));
+            connectorManager.AddConsoleSink(".*");
+
+            CreateBuilder(plan, connectorManager, "pkNone").Build();
+        }
+    }
+}

--- a/tests/FlowtideDotNet.SqlServer.Tests/SinkTests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/SinkTests.cs
@@ -12,6 +12,8 @@
 
 using FlowtideDotNet.Connector.SqlServer.SqlServer;
 using FlowtideDotNet.Substrait.Relations;
+using FlowtideDotNet.Substrait.Tests.SqlServer;
+using System.Data;
 
 namespace FlowtideDotNet.SqlServer.Tests
 {
@@ -47,6 +49,58 @@ namespace FlowtideDotNet.SqlServer.Tests
             }, new System.Threading.Tasks.Dataflow.ExecutionDataflowBlockOptions());
             var tableName = sink.GetTmpTableName();
             Assert.StartsWith("#", tableName);
+        }
+
+        [Fact]
+        public void PrimaryKeyColumnsResolveToTheCasingOfTheDestinationTable()
+        {
+            var (indices, columnNames) = SqlServerUtils.ResolvePrimaryKeyColumns(
+                new List<string>() { "guid-dash", "Name" },
+                new List<string>() { "NAME" },
+                "test-db.dbo.dest");
+
+            Assert.Equal(new List<int>() { 1 }, indices);
+            Assert.Equal(new List<string>() { "Name" }, columnNames);
+        }
+
+        [Fact]
+        public void PrimaryKeyColumnThatIsNotWrittenThrows()
+        {
+            var e = Assert.Throws<InvalidOperationException>(() =>
+            {
+                SqlServerUtils.ResolvePrimaryKeyColumns(
+                    new List<string>() { "guid-dash", "Name" },
+                    new List<string>() { "id" },
+                    "test-db.dbo.dest");
+            });
+
+            Assert.Equal("All primary keys of the sink table must be sent to the sink operator, 'id' is not written to 'test-db.dbo.dest'.", e.Message);
+        }
+
+        /// <summary>
+        /// The merge statement must never update a primary key column.
+        /// </summary>
+        [Fact]
+        public void MergeStatementDoesNotUpdatePrimaryKeyDeclaredWithOtherCasing()
+        {
+            var writtenColumnNames = new List<string>() { "Name", "guid-dash" };
+
+            var dataTable = new DataTable();
+            dataTable.Columns.Add("md_operation");
+            foreach (var columnName in writtenColumnNames)
+            {
+                dataTable.Columns.Add(columnName);
+            }
+
+            var (_, primaryKeyColumnNames) = SqlServerUtils.ResolvePrimaryKeyColumns(
+                writtenColumnNames,
+                new List<string>() { "name" },
+                "dest");
+
+            var statement = SqlServerUtils.CreateMergeIntoProcedure("#tmp", "[dest]", primaryKeyColumnNames.ToHashSet(), dataTable);
+
+            Assert.Contains("UPDATE SET tgt.[guid-dash] = src.[guid-dash]", statement);
+            Assert.DoesNotContain("tgt.[Name] = src.[Name]", statement);
         }
     }
 }

--- a/tests/FlowtideDotNet.SqlServer.Tests/SinkTests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/SinkTests.cs
@@ -85,7 +85,7 @@ namespace FlowtideDotNet.SqlServer.Tests
         {
             var writtenColumnNames = new List<string>() { "Name", "guid-dash" };
 
-            var dataTable = new DataTable();
+            using var dataTable = new DataTable();
             dataTable.Columns.Add("md_operation");
             foreach (var columnName in writtenColumnNames)
             {

--- a/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerE2ETests.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerE2ETests.cs
@@ -803,5 +803,175 @@ namespace FlowtideDotNet.SqlServer.Tests.e2e
             });
             Assert.Equal(1000, result);
         }
+
+        /// <summary>
+        /// Keys declared in the statement replace the table metadata.
+        /// The destination identity primary key is never written.
+        /// </summary>
+        [Fact]
+        public async Task PrimaryKeysDeclaredInStatement()
+        {
+            var testName = "PrimaryKeysDeclaredInStatement";
+
+            await _fixture.RunCommand(@"
+            CREATE TABLE [test-db].[dbo].[test-table8] (
+                [id] [int] primary key,
+                [name] [nvarchar](50) NOT NULL,
+                [guid-dash] [uniqueidentifier] NOT NULL
+            )");
+            await _fixture.RunCommand("ALTER TABLE [test-db].[dbo].[test-table8] ENABLE CHANGE_TRACKING WITH (TRACK_COLUMNS_UPDATED = OFF)");
+            await _fixture.RunCommand(@"
+            CREATE TABLE [test-db].[dbo].[test-dest8] (
+                [id] [int] IDENTITY(1,1) PRIMARY KEY,
+                [name] [nvarchar](50) NOT NULL,
+                [guid-dash] [uniqueidentifier] NOT NULL
+            )");
+
+            await _fixture.RunCommand(@"
+            INSERT INTO [test-db].[dbo].[test-table8] ([id], [name], [guid-dash]) VALUES (1, 'test1', '57f20bbe-3a17-45a7-bacc-614d89bde120');
+            ");
+
+            var testStream = new SqlServerTestStream(testName, _fixture.ConnectionString);
+            testStream.RegisterTableProviders((builder) =>
+            {
+                builder.AddSqlServerProvider(() => _fixture.ConnectionString);
+            });
+            await testStream.StartStream(@"
+                INSERT INTO [test-db].[dbo].[test-dest8] PRIMARY KEY ([name])
+                SELECT
+                    [guid-dash],
+                    [name]
+                FROM [test-db].[dbo].[test-table8]
+            ");
+
+            var count = 0;
+            while (true)
+            {
+                await testStream.SchedulerTick();
+                count = await _fixture.ExecuteReader("SELECT count(*) from [test-db].[dbo].[test-dest8]", (reader) =>
+                {
+                    reader.Read();
+                    return reader.GetInt32(0);
+                });
+                if (count > 0)
+                {
+                    break;
+                }
+            }
+            Assert.Equal(1, count);
+
+            // An update must land on the existing row.
+            await _fixture.RunCommand(@"
+            UPDATE [test-db].[dbo].[test-table8] SET [guid-dash] = '57f20bbe-3a17-45a7-bacc-614d89bde121' WHERE name = 'test1';
+            ");
+
+            var expectedGuid = Guid.Parse("57f20bbe-3a17-45a7-bacc-614d89bde121");
+
+            while (true)
+            {
+                await testStream.SchedulerTick();
+                var g = await _fixture.ExecuteReader("SELECT [guid-dash] from [test-db].[dbo].[test-dest8] WHERE name = 'test1'", (reader) =>
+                {
+                    reader.Read();
+                    return reader.GetGuid(0);
+                });
+                if (g.Equals(expectedGuid))
+                {
+                    break;
+                }
+            }
+
+            count = await _fixture.ExecuteReader("SELECT count(*) from [test-db].[dbo].[test-dest8]", (reader) =>
+            {
+                reader.Read();
+                return reader.GetInt32(0);
+            });
+            Assert.Equal(1, count);
+        }
+
+        /// <summary>
+        /// Declaration, source and destination all use different casing.
+        /// The merge statement itself is covered by SinkTests.
+        /// </summary>
+        [Fact]
+        public async Task PrimaryKeysDeclaredInStatementWithOtherCasing()
+        {
+            var testName = "PrimaryKeysDeclaredInStatementWithOtherCasing";
+
+            await _fixture.RunCommand(@"
+            CREATE TABLE [test-db].[dbo].[test-table9] (
+                [id] [int] primary key,
+                [name] [nvarchar](50) NOT NULL,
+                [guid-dash] [uniqueidentifier] NOT NULL
+            )");
+            await _fixture.RunCommand("ALTER TABLE [test-db].[dbo].[test-table9] ENABLE CHANGE_TRACKING WITH (TRACK_COLUMNS_UPDATED = OFF)");
+            await _fixture.RunCommand(@"
+            CREATE TABLE [test-db].[dbo].[test-dest9] (
+                [id] [int] IDENTITY(1,1) PRIMARY KEY,
+                [Name] [nvarchar](50) NOT NULL,
+                [guid-dash] [uniqueidentifier] NOT NULL
+            )");
+
+            await _fixture.RunCommand(@"
+            INSERT INTO [test-db].[dbo].[test-table9] ([id], [name], [guid-dash]) VALUES (1, 'test1', '57f20bbe-3a17-45a7-bacc-614d89bde120');
+            ");
+
+            var testStream = new SqlServerTestStream(testName, _fixture.ConnectionString);
+            testStream.RegisterTableProviders((builder) =>
+            {
+                builder.AddSqlServerProvider(() => _fixture.ConnectionString);
+            });
+            await testStream.StartStream(@"
+                INSERT INTO [test-db].[dbo].[test-dest9] PRIMARY KEY ([NAME])
+                SELECT
+                    [guid-dash],
+                    [name]
+                FROM [test-db].[dbo].[test-table9]
+            ");
+
+            var count = 0;
+            while (true)
+            {
+                await testStream.SchedulerTick();
+                count = await _fixture.ExecuteReader("SELECT count(*) from [test-db].[dbo].[test-dest9]", (reader) =>
+                {
+                    reader.Read();
+                    return reader.GetInt32(0);
+                });
+                if (count > 0)
+                {
+                    break;
+                }
+            }
+            Assert.Equal(1, count);
+
+            // Forces the merge to take the matched branch.
+            await _fixture.RunCommand(@"
+            UPDATE [test-db].[dbo].[test-table9] SET [guid-dash] = '57f20bbe-3a17-45a7-bacc-614d89bde121' WHERE name = 'test1';
+            ");
+
+            var expectedGuid = Guid.Parse("57f20bbe-3a17-45a7-bacc-614d89bde121");
+
+            while (true)
+            {
+                await testStream.SchedulerTick();
+                var g = await _fixture.ExecuteReader("SELECT [guid-dash] from [test-db].[dbo].[test-dest9] WHERE [Name] = 'test1'", (reader) =>
+                {
+                    reader.Read();
+                    return reader.GetGuid(0);
+                });
+                if (g.Equals(expectedGuid))
+                {
+                    break;
+                }
+            }
+
+            count = await _fixture.ExecuteReader("SELECT count(*) from [test-db].[dbo].[test-dest9]", (reader) =>
+            {
+                reader.Read();
+                return reader.GetInt32(0);
+            });
+            Assert.Equal(1, count);
+        }
     }
 }

--- a/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerTestStream.cs
+++ b/tests/FlowtideDotNet.SqlServer.Tests/e2e/SqlServerTestStream.cs
@@ -58,11 +58,13 @@ namespace FlowtideDotNet.SqlServer.Tests.e2e
             }
             else
             {
+#pragma warning disable CS0618 // Covers the obsolete option until it is removed.
                 factory.AddSqlServerSink(new SqlServerSinkOptions()
                 {
                     ConnectionStringFunc = options?.ConnectionStringFunc != null ? options.ConnectionStringFunc : () => connectionString,
                     CustomPrimaryKeys = customPrimaryKeys
                 });
+#pragma warning restore CS0618
             }
         }
     }

--- a/tests/FlowtideDotNet.Substrait.Tests/SerializeTests.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/SerializeTests.cs
@@ -951,6 +951,47 @@ namespace FlowtideDotNet.Substrait.Tests
             AssertPlanCanSerializeDeserialize(plan);
         }
 
+        [Fact]
+        public void InsertWithPrimaryKeyDeclaration()
+        {
+            SqlPlanBuilder sqlPlanBuilder = new SqlPlanBuilder();
+            sqlPlanBuilder.Sql(@"
+                create table table1 (a any, b any);
+                INSERT INTO outputtable PRIMARY KEY (b, a)
+                SELECT * FROM table1
+            ");
+            var plan = sqlPlanBuilder.GetPlan();
+            AssertPlanCanSerializeDeserialize(plan);
+
+            var json = SubstraitSerializer.SerializeToJson(plan);
+            var deserializedPlan = SubstraitDeserializer.DeserializeFromJson(json);
+            var writeRelation = Assert.IsType<WriteRelation>(deserializedPlan.Relations[0]);
+            Assert.Equal(new List<string>() { "b", "a" }, writeRelation.PrimaryKeyNames);
+        }
+
+        /// <summary>
+        /// The json is hashed, existing plans must keep their hash.
+        /// </summary>
+        [Fact]
+        public void InsertWithoutPrimaryKeyDeclarationDoesNotChangeJson()
+        {
+            SqlPlanBuilder sqlPlanBuilder = new SqlPlanBuilder();
+            sqlPlanBuilder.Sql(@"
+                create table table1 (a any, b any);
+                INSERT INTO outputtable
+                SELECT * FROM table1
+            ");
+            var plan = sqlPlanBuilder.GetPlan();
+
+            var json = SubstraitSerializer.SerializeToJson(plan);
+
+            Assert.DoesNotContain("WriteRelationPrimaryKeys", json);
+            Assert.DoesNotContain("advancedExtension", json);
+
+            var writeRelation = Assert.IsType<WriteRelation>(SubstraitDeserializer.DeserializeFromJson(json).Relations[0]);
+            Assert.Null(writeRelation.PrimaryKeyNames);
+        }
+
         private void AssertPlanCanSerializeDeserialize(Plan plan)
         {
             var json = SubstraitSerializer.SerializeToJson(plan);

--- a/tests/FlowtideDotNet.Substrait.Tests/SqlTests.cs
+++ b/tests/FlowtideDotNet.Substrait.Tests/SqlTests.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Substrait.Exceptions;
 using FlowtideDotNet.Substrait.Expressions;
 using FlowtideDotNet.Substrait.Expressions.IfThen;
 using FlowtideDotNet.Substrait.Expressions.Literals;
@@ -2518,6 +2519,242 @@ namespace FlowtideDotNet.Substrait.Tests
             };
 
             Assert.Equal(expected, plan);
+        }
+
+        [Fact]
+        public void InsertIntoWithPrimaryKeyDeclaration()
+        {
+            builder.Sql(@"
+                CREATE TABLE testtable (
+                    c1 any,
+                    c2 any,
+                    c3 any
+                );
+
+                INSERT INTO output PRIMARY KEY (c2, c1)
+                SELECT c1, c2, c3 FROM testtable;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            Assert.Equal(new List<string>() { "c2", "c1" }, writeRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void InsertIntoWithPrimaryKeyDeclarationAndColumnList()
+        {
+            builder.Sql(@"
+                CREATE TABLE testtable (
+                    c1 any,
+                    c2 any
+                );
+
+                INSERT INTO output (a, b) PRIMARY KEY (b)
+                SELECT c1, c2 FROM testtable;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            Assert.Equal(new List<string>() { "b" }, writeRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void InsertIntoWithPrimaryKeyDeclarationUsesTableSchemaCasing()
+        {
+            builder.Sql(@"
+                CREATE TABLE testtable (
+                    MyColumn any,
+                    c2 any
+                );
+
+                INSERT INTO output PRIMARY KEY (mycolumn)
+                SELECT MyColumn, c2 FROM testtable;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            Assert.Equal(new List<string>() { "MyColumn" }, writeRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void InsertIntoWithPrimaryKeyDeclarationOnDelimitedIdentifier()
+        {
+            builder.Sql(@"
+                CREATE TABLE testtable (
+                    ""my col"" any,
+                    c2 any
+                );
+
+                INSERT INTO output PRIMARY KEY ([my col])
+                SELECT ""my col"", c2 FROM testtable;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            Assert.Equal(new List<string>() { "my col" }, writeRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void InsertIntoWithPrimaryKeyDeclarationBeforeCommonTableExpression()
+        {
+            builder.Sql(@"
+                CREATE TABLE testtable (
+                    c1 any,
+                    c2 any
+                );
+
+                INSERT INTO output PRIMARY KEY (c1)
+                WITH cte AS (SELECT c1, c2 FROM testtable)
+                SELECT c1, c2 FROM cte;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.Single(plan.Relations.OfType<WriteRelation>());
+            Assert.Equal(new List<string>() { "c1" }, writeRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void InsertOverwriteWithPrimaryKeyDeclaration()
+        {
+            builder.Sql(@"
+                CREATE TABLE testtable (
+                    c1 any,
+                    c2 any
+                );
+
+                INSERT OVERWRITE output PRIMARY KEY (c1)
+                SELECT c1, c2 FROM testtable;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            Assert.True(writeRelation.Overwrite);
+            Assert.Equal(new List<string>() { "c1" }, writeRelation.PrimaryKeyNames);
+        }
+
+        /// <summary>
+        /// TABLE can precede the destination name or start a query.
+        /// </summary>
+        [Theory]
+        [InlineData("INSERT OVERWRITE TABLE output PRIMARY KEY (c1)", true)]
+        [InlineData("INSERT INTO TABLE output PRIMARY KEY (c1)", false)]
+        public void InsertIntoTableWithPrimaryKeyDeclaration(string insertStatement, bool expectedOverwrite)
+        {
+            builder.Sql(@$"
+                CREATE TABLE testtable (
+                    c1 any,
+                    c2 any
+                );
+
+                {insertStatement}
+                SELECT c1, c2 FROM testtable;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            Assert.Equal(expectedOverwrite, writeRelation.Overwrite);
+            Assert.Equal(new List<string>() { "output" }, writeRelation.NamedObject.Names);
+            Assert.Equal(new List<string>() { "c1" }, writeRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void InsertOverwriteTableWithoutPrimaryKeyDeclarationHasNoPrimaryKeys()
+        {
+            builder.Sql(@"
+                CREATE TABLE testtable (
+                    c1 any,
+                    c2 any
+                );
+
+                INSERT OVERWRITE TABLE output
+                SELECT c1, c2 FROM testtable;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            Assert.True(writeRelation.Overwrite);
+            Assert.Null(writeRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void InsertIntoWithoutPrimaryKeyDeclarationHasNoPrimaryKeys()
+        {
+            builder.Sql(@"
+                CREATE TABLE testtable (
+                    c1 any,
+                    c2 any
+                );
+
+                INSERT INTO output
+                SELECT c1, c2 FROM testtable;
+            ");
+
+            var plan = builder.GetPlan();
+
+            var writeRelation = Assert.IsType<WriteRelation>(plan.Relations[0]);
+            Assert.Null(writeRelation.PrimaryKeyNames);
+        }
+
+        [Fact]
+        public void InsertIntoWithPrimaryKeyDeclarationOnColumnThatIsNotWritten()
+        {
+            var ex = Assert.Throws<SubstraitParseException>(() =>
+            {
+                builder.Sql(@"
+                    CREATE TABLE testtable (
+                        c1 any,
+                        c2 any
+                    );
+
+                    INSERT INTO output PRIMARY KEY (c3)
+                    SELECT c1, c2 FROM testtable;
+                ");
+            });
+
+            Assert.Equal("Primary key column 'c3' is not written to table 'output', all declared primary keys must be part of the insert.", ex.Message);
+        }
+
+        [Fact]
+        public void InsertIntoWithPrimaryKeyDeclarationOnDuplicateColumn()
+        {
+            var ex = Assert.Throws<SubstraitParseException>(() =>
+            {
+                builder.Sql(@"
+                    CREATE TABLE testtable (
+                        c1 any,
+                        c2 any
+                    );
+
+                    INSERT INTO output PRIMARY KEY (c1, C1)
+                    SELECT c1, c2 FROM testtable;
+                ");
+            });
+
+            Assert.Equal("Primary key column 'C1' is declared more than once for table 'output'.", ex.Message);
+        }
+
+        [Fact]
+        public void InsertIntoWithEmptyPrimaryKeyDeclaration()
+        {
+            Assert.ThrowsAny<Exception>(() =>
+            {
+                builder.Sql(@"
+                    CREATE TABLE testtable (
+                        c1 any
+                    );
+
+                    INSERT INTO output PRIMARY KEY ()
+                    SELECT c1 FROM testtable;
+                ");
+            });
         }
     }
 }


### PR DESCRIPTION
This provides an easier way to define custom primary keys than say sql server sinks CustomPrimaryKeys property.

The only connector right now that uses it is sql server, but this change enables other connectors to utilize the same setup.

The main use case is if there is some other key say auto increment and an insert into should use other columns to handle conflicts.

This fixes #1212 