### PR TITLE
Fix so bulk agg disposes temp data directly after not needed, also in read & sync client

### DIFF
--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/IColumnBulkAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/IColumnBulkAggregation.cs
@@ -32,6 +32,14 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations
         void NewBatch(PrimitiveList<int> weights, EventBatchData batchData);
 
         /// <summary>
+        /// The batch is fully applied and nothing will read the projections again. Release any scratch
+        /// allocated in <see cref="NewBatch"/> here, otherwise the last batch of a stream keeps its
+        /// projected columns alive for as long as the operator lives.
+        /// Only implement this if the measure allocates per batch, the default does nothing.
+        /// </summary>
+        void BatchDone() { }
+
+        /// <summary>
         /// If the measure needs to store any data to its own state handling, if stateless this can return just a ValueTask.CompletedTask
         /// </summary>
         /// <param name="weights"></param>

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/ListAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/ListAggAggregation.cs
@@ -197,6 +197,17 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations.Statef
             }
         }
 
+        /// <summary>
+        /// The tree copies out of the projection during ApplyBatch, so once the batch is applied nothing
+        /// reads it again. Null it as well so a later read throws instead of touching freed memory.
+        /// In shared tree mode NewBatch never allocates, hence the null conditional.
+        /// </summary>
+        public void BatchDone()
+        {
+            _projectedDataColumn?.Dispose();
+            _projectedDataColumn = null;
+        }
+
         public async ValueTask FetchValuesAsync(IColumn[] groupingValuesSorted, int length, Column outputColumn)
         {
             var batch = new EventBatchData(groupingValuesSorted);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/ListUnionDistinctAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/ListUnionDistinctAggAggregation.cs
@@ -277,6 +277,24 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations.Statef
             }
         }
 
+        /// <summary>
+        /// Clear only resets the length, the native capacity stays put, so these three held on to the
+        /// largest batch ever seen for the lifetime of the operator. Free them once the batch is applied
+        /// instead, StoreAsync already reallocates them lazily when they are null.
+        /// The offsets are the ones handed to ColumnWithOffset.CreateFlattened, which takes them by
+        /// reference without copying, so StoreFlattenedAsync deliberately leaves them alone. This is
+        /// their only owner.
+        /// </summary>
+        public void BatchDone()
+        {
+            _offsets?.Dispose();
+            _offsets = null;
+            _projectedDataColumn?.Dispose();
+            _projectedDataColumn = null;
+            _weightList?.Dispose();
+            _weightList = null;
+        }
+
         public async ValueTask FetchValuesAsync(IColumn[] groupingValuesSorted, int length, Column outputColumn)
         {
             var batch = new EventBatchData(groupingValuesSorted);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/MaxAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/MaxAggregation.cs
@@ -205,6 +205,17 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations.Statef
             }
         }
 
+        /// <summary>
+        /// The tree copies out of the projection during ApplyBatch, so once the batch is applied nothing
+        /// reads it again. Null it as well so a later read throws instead of touching freed memory.
+        /// In shared tree mode NewBatch never allocates, hence the null conditional.
+        /// </summary>
+        public void BatchDone()
+        {
+            _projectedDataColumn?.Dispose();
+            _projectedDataColumn = null;
+        }
+
         public async ValueTask FetchValuesAsync(IColumn[] groupingValuesSorted, int length, Column outputColumn)
         {
             var batch = new EventBatchData(groupingValuesSorted);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/MaxByAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/MaxByAggregation.cs
@@ -210,6 +210,18 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations.Statef
             }
         }
 
+        /// <summary>
+        /// The tree copies out of the projections during ApplyBatch, so once the batch is applied nothing
+        /// reads them again. Null them as well so a later read throws instead of touching freed memory.
+        /// </summary>
+        public void BatchDone()
+        {
+            _projectedValueColumn?.Dispose();
+            _projectedValueColumn = null;
+            _projectedOrderByColumn?.Dispose();
+            _projectedOrderByColumn = null;
+        }
+
         public async ValueTask FetchValuesAsync(IColumn[] groupingValuesSorted, int length, Column outputColumn)
         {
             var batch = new EventBatchData(groupingValuesSorted);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/MinAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/MinAggregation.cs
@@ -203,6 +203,17 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations.Statef
             }
         }
 
+        /// <summary>
+        /// The tree copies out of the projection during ApplyBatch, so once the batch is applied nothing
+        /// reads it again. Null it as well so a later read throws instead of touching freed memory.
+        /// In shared tree mode NewBatch never allocates, hence the null conditional.
+        /// </summary>
+        public void BatchDone()
+        {
+            _projectedDataColumn?.Dispose();
+            _projectedDataColumn = null;
+        }
+
         public async ValueTask FetchValuesAsync(IColumn[] groupingValuesSorted, int length, Column outputColumn)
         {
             var batch = new EventBatchData(groupingValuesSorted);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/MinByAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/MinByAggregation.cs
@@ -211,6 +211,18 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations.Statef
             }
         }
 
+        /// <summary>
+        /// The tree copies out of the projections during ApplyBatch, so once the batch is applied nothing
+        /// reads them again. Null them as well so a later read throws instead of touching freed memory.
+        /// </summary>
+        public void BatchDone()
+        {
+            _projectedValueColumn?.Dispose();
+            _projectedValueColumn = null;
+            _projectedOrderByColumn?.Dispose();
+            _projectedOrderByColumn = null;
+        }
+
         public async ValueTask FetchValuesAsync(IColumn[] groupingValuesSorted, int length, Column outputColumn)
         {
             var batch = new EventBatchData(groupingValuesSorted);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/SharedGroupValueTree.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/SharedGroupValueTree.cs
@@ -71,6 +71,17 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations.Statef
             }
         }
 
+        /// <summary>
+        /// The batch is done, the key container copies out of the projected column during ApplyBatch so
+        /// nothing references it after that. Null it out as well so a read after this point throws
+        /// instead of touching freed memory.
+        /// </summary>
+        public void BatchDone()
+        {
+            _projectedDataColumn?.Dispose();
+            _projectedDataColumn = null;
+        }
+
         public ValueTask StoreAsync(PrimitiveList<int> weights, IColumn[] groupValueColumns, ReadOnlySpan<int> sortedByGroupIndices, EventBatchData incoming)
         {
             Debug.Assert(_projectedDataColumn != null);

--- a/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/StringAggAggregation.cs
+++ b/src/FlowtideDotNet.Core/Compute/Columnar/Functions/BulkAggregations/Stateful/StringAggAggregation.cs
@@ -201,6 +201,17 @@ namespace FlowtideDotNet.Core.Compute.Columnar.Functions.BulkAggregations.Statef
             }
         }
 
+        /// <summary>
+        /// The tree copies out of the projection during ApplyBatch, so once the batch is applied nothing
+        /// reads it again. Null it as well so a later read throws instead of touching freed memory.
+        /// In shared tree mode NewBatch never allocates, hence the null conditional.
+        /// </summary>
+        public void BatchDone()
+        {
+            _projectedDataColumn?.Dispose();
+            _projectedDataColumn = null;
+        }
+
         public async ValueTask FetchValuesAsync(IColumn[] groupingValuesSorted, int length, Column outputColumn)
         {
             var batch = new EventBatchData(groupingValuesSorted);

--- a/src/FlowtideDotNet.Core/Operators/Aggregate/Bulk/BulkAggregateOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Aggregate/Bulk/BulkAggregateOperator.cs
@@ -669,6 +669,39 @@ namespace FlowtideDotNet.Core.Operators.Aggregate.Bulk
 
         private async IAsyncEnumerable<StreamEventBatch> ProcessBatch(StreamEventBatch msg, long time)
         {
+            try
+            {
+                await foreach (var batch in ProcessBatchCore(msg, time))
+                {
+                    yield return batch;
+                }
+            }
+            finally
+            {
+                BatchDone();
+            }
+        }
+
+        /// <summary>
+        /// Releases the per batch projections that the measures and shared trees allocate in NewBatch.
+        /// Without this the last batch keeps its columns until the operator is disposed, and since the
+        /// column finalizer does not free anything that memory is gone for good.
+        /// Runs in a finally so it also happens if the consumer stops enumerating early.
+        /// </summary>
+        private void BatchDone()
+        {
+            for (int i = 0; i < _measures.Length; i++)
+            {
+                _measures[i].BatchDone();
+            }
+            foreach (var sharedTree in _sharedTrees.Values)
+            {
+                sharedTree.BatchDone();
+            }
+        }
+
+        private async IAsyncEnumerable<StreamEventBatch> ProcessBatchCore(StreamEventBatch msg, long time)
+        {
             if (msg.Data.Count > 0)
             {
                 // Take first iteration

--- a/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
@@ -504,7 +504,12 @@ namespace FlowtideDotNet.Core.Operators.Read
 
         private void DisposeUnusedColumns(EventBatchData batchData)
         {
-            Debug.Assert(_sortedEmitList != null);
+            // If we emit all columns (no EmitSet), there is nothing to dispose.
+            if (_sortedEmitList == null || _sortedEmitList.Count == batchData.Columns.Count)
+            {
+                return;
+            }
+
             for (int k = 0, sortIndex = 0; k < batchData.Columns.Count; k++)
             {
                 // Go through sorted emit list and check if the column is in the emit list, if not, we need to dispose it

--- a/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
@@ -48,6 +48,7 @@ namespace FlowtideDotNet.Core.Operators.Read
         private List<int>? _primaryKeyColumns;
         private List<int>? _otherColumns;
         private List<int>? _emitList;
+        private List<int>? _sortedEmitList;
         private IBPlusTree<ColumnRowReference, ColumnRowReference, NormalizeKeyStorage, NormalizeValueStorage>? _fullLoadTempTree;
         private IBPlusTree<ColumnRowReference, ColumnRowReference, NormalizeKeyStorage, NormalizeValueStorage>? _persistentTree;
         private IBPlusTree<ColumnRowReference, int, NormalizeKeyStorage, PrimitiveListValueContainer<int>>? _deleteTree;
@@ -197,6 +198,8 @@ namespace FlowtideDotNet.Core.Operators.Read
             if (_readRelation.EmitSet)
             {
                 _emitList = _readRelation.Emit;
+                _sortedEmitList = new List<int>(_readRelation.Emit);
+                _sortedEmitList.Sort();
                 for (int i = 0; i < _readRelation.Emit.Count; i++)
                 {
                     if (!_primaryKeyColumns.Contains(_readRelation.Emit[i]))
@@ -423,6 +426,7 @@ namespace FlowtideDotNet.Core.Operators.Read
                                 shouldDisposeOffsets = false;
                             }
                         }
+                        DisposeUnusedColumns(e.BatchData.EventBatchData);
                         if (shouldDisposeOffsets)
                         {
                             toEmitOffsets.Dispose();
@@ -495,6 +499,24 @@ namespace FlowtideDotNet.Core.Operators.Read
                 }
 
                 ScheduleCheckpoint(TimeSpan.FromMilliseconds(1));
+            }
+        }
+
+        private void DisposeUnusedColumns(EventBatchData batchData)
+        {
+            Debug.Assert(_sortedEmitList != null);
+            for (int k = 0, sortIndex = 0; k < batchData.Columns.Count; k++)
+            {
+                // Go through sorted emit list and check if the column is in the emit list, if not, we need to dispose it
+                // Since its sorted we do a merge check
+                if (sortIndex < _sortedEmitList.Count && _sortedEmitList[sortIndex] == k)
+                {
+                    sortIndex++;
+                }
+                else
+                {
+                    batchData.Columns[k].Dispose();
+                }
             }
         }
 
@@ -610,6 +632,7 @@ namespace FlowtideDotNet.Core.Operators.Read
                             shouldDisposeOffsets = false;
                         }
                     }
+                    DisposeUnusedColumns(columnReadEvent.BatchData.EventBatchData);
                     if (shouldDisposeOffsets)
                     {
                         toEmitOffsets.Dispose();

--- a/src/FlowtideDotNet.MiMalloc/MiMallocApi.cs
+++ b/src/FlowtideDotNet.MiMalloc/MiMallocApi.cs
@@ -23,7 +23,7 @@ namespace FlowtideDotNet.MiMalloc
     /// thread exits (pages with live blocks are abandoned and reclaimed by
     /// other threads, exactly as in native mimalloc).
     /// </summary>
-    public static unsafe class MiMalloc
+    public static unsafe partial class MiMalloc
     {
         /// <summary>
         /// The mimalloc version this port is based on, encoded as in <c>mimalloc.h</c>:
@@ -145,6 +145,19 @@ namespace FlowtideDotNet.MiMalloc
         /// automatically on the first allocation from a thread.
         /// </summary>
         public static void mi_thread_init() => Mi.mi_thread_init();
+
+        /// <summary>
+        /// Mark the current thread as belonging to a thread pool, which makes it shed pages
+        /// aggressively rather than retain them for reuse (it stops retaining full pages and
+        /// declines cross-thread page reclaim).
+        /// <para>
+        /// Only appropriate for threads that park for long periods while holding allocations.
+        /// Do NOT call this for ordinary .NET ThreadPool / TPL worker threads that carry the
+        /// application's main work: shedding pages there leaves mostly-full pages abandoned and
+        /// pins their memory.
+        /// </para>
+        /// </summary>
+        public static void mi_thread_set_in_threadpool() => Mi.mi_thread_set_in_threadpool();
 
         /// <summary>
         /// Release the current thread's heaps (abandoning pages that still contain

--- a/src/FlowtideDotNet.MiMalloc/MiMallocHeapUsage.cs
+++ b/src/FlowtideDotNet.MiMalloc/MiMallocHeapUsage.cs
@@ -1,0 +1,176 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+
+namespace FlowtideDotNet.MiMalloc
+{
+    /// <summary>Usage of one size-class bin, from <see cref="MiMalloc.GetHeapUsage"/>.</summary>
+    public readonly struct MiHeapBinUsage
+    {
+        /// <summary>The size-class bin index.</summary>
+        public int Bin { get; init; }
+        /// <summary>Block size of this bin, in bytes.</summary>
+        public long BlockSize { get; init; }
+        /// <summary>Number of pages in this bin.</summary>
+        public long Pages { get; init; }
+        /// <summary>Bytes of these pages actually committed to the OS.</summary>
+        public long CommittedBytes { get; init; }
+        /// <summary>Bytes currently handed out as live blocks.</summary>
+        public long LiveBytes { get; init; }
+        /// <summary>Total capacity of these pages (all blocks they could ever hold).</summary>
+        public long CapacityBytes { get; init; }
+
+        /// <summary>Committed bytes not handed out (free blocks plus committed-but-uncarved page space).</summary>
+        public long RetainedBytes => CommittedBytes - LiveBytes;
+        /// <summary>Live bytes as a fraction of committed bytes (0..1). Low = sparse pages.</summary>
+        public double Utilization => CommittedBytes == 0 ? 0.0 : (double)LiveBytes / CommittedBytes;
+    }
+
+    /// <summary>
+    /// Exact committed-versus-live accounting obtained by walking a heap's pages.
+    /// Unlike <see cref="MiMallocStats"/> this does not depend on any thread merging its
+    /// statistics: the walk enumerates every page of the heap regardless of which thread
+    /// currently owns it.
+    /// </summary>
+    public readonly struct MiHeapUsage
+    {
+        /// <summary>Total pages in the heap.</summary>
+        public long Pages { get; init; }
+        /// <summary>Total bytes of those pages committed to the OS.</summary>
+        public long CommittedBytes { get; init; }
+        /// <summary>Total bytes currently handed out as live blocks.</summary>
+        public long LiveBytes { get; init; }
+        /// <summary>Total capacity of all pages.</summary>
+        public long CapacityBytes { get; init; }
+        /// <summary>Per size-class breakdown, only bins that hold at least one page, largest retained first.</summary>
+        public IReadOnlyList<MiHeapBinUsage> Bins { get; init; }
+
+        /// <summary>
+        /// Committed bytes not handed out. This is the fragmentation/retention number: memory the
+        /// allocator holds from the OS but is not serving to the application.
+        /// </summary>
+        public long RetainedBytes => CommittedBytes - LiveBytes;
+        /// <summary>Live bytes as a fraction of committed bytes (0..1).</summary>
+        public double Utilization => CommittedBytes == 0 ? 0.0 : (double)LiveBytes / CommittedBytes;
+
+        public override string ToString()
+        {
+            static string MB(long b) => $"{b / (1024.0 * 1024.0):N1} MiB";
+            var sb = new StringBuilder();
+            sb.Append($"heap: {Pages} pages, committed {MB(CommittedBytes)}, live {MB(LiveBytes)}, ")
+              .Append($"retained {MB(RetainedBytes)}, utilization {Utilization:P1}");
+            if (Bins != null)
+            {
+                foreach (var b in Bins)
+                {
+                    sb.AppendLine();
+                    sb.Append($"  bin {b.Bin,2} block {b.BlockSize,8:N0} B: {b.Pages,6} pages, ")
+                      .Append($"committed {MB(b.CommittedBytes),12}, live {MB(b.LiveBytes),12}, ")
+                      .Append($"retained {MB(b.RetainedBytes),12}, util {b.Utilization,6:P1}");
+                }
+            }
+            return sb.ToString();
+        }
+    }
+
+    public static unsafe partial class MiMalloc
+    {
+        // per-bin accumulators for the page walk
+        private struct MiHeapUsageAcc
+        {
+            public fixed long Pages[Mi.MI_BIN_COUNT];
+            public fixed long Committed[Mi.MI_BIN_COUNT];
+            public fixed long Live[Mi.MI_BIN_COUNT];
+            public fixed long Capacity[Mi.MI_BIN_COUNT];
+            public fixed long BlockSize[Mi.MI_BIN_COUNT];
+        }
+
+        private static bool HeapUsageVisitor(mi_heap_t* heap, mi_heap_area_t* area, void* block, nuint block_size, void* arg)
+        {
+            if (block != null) return true;   // area callbacks only (we pass visitBlocks: false)
+            var acc = (MiHeapUsageAcc*)arg;
+            mi_page_t* page = (mi_page_t*)area->reserved1;
+            if (page == null) return true;
+
+            nuint bsize = Mi.mi_page_block_size(page);
+            if (bsize == 0) return true;
+            int bin = (int)Mi._mi_page_stats_bin(page);
+            if (bin < 0 || bin >= Mi.MI_BIN_COUNT) return true;
+
+            acc->Pages[bin] += 1;
+            acc->Committed[bin] += (long)Mi.mi_page_committed(page);
+            acc->Live[bin] += (long)((nuint)page->used * bsize);
+            acc->Capacity[bin] += (long)((nuint)page->capacity * bsize);
+            acc->BlockSize[bin] = (long)bsize;
+            return true;
+        }
+
+        /// <summary>
+        /// Walk every page of the main heap and report committed-versus-live bytes, in total and
+        /// per size-class bin. This is the measurement to use when diagnosing "the allocator holds
+        /// far more memory than my data" — a low <see cref="MiHeapUsage.Utilization"/> in a
+        /// particular bin points straight at the size class responsible.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Cost is O(pages), so call this at checkpoint cadence rather than in a tight polling
+        /// loop. Use <see cref="GetStats"/> for cheap frequent sampling of OS-level totals.
+        /// </para>
+        /// <para>
+        /// The walk reads page counters without synchronization (as the C does). Under concurrent
+        /// allocation a page or two may be counted slightly stale, so treat the result as a gauge
+        /// rather than an exact invariant. It never blocks and never allocates from the heap it
+        /// is walking.
+        /// </para>
+        /// </remarks>
+        public static MiHeapUsage GetHeapUsage()
+        {
+            MiHeapUsageAcc acc = default;
+            mi_heap_t* heap = Mi.mi_heap_main();
+            Mi._mi_heap_visit_blocks(heap, false /* all pages, not just abandoned */,
+                                     false /* areas only, do not enumerate blocks */,
+                                     &HeapUsageVisitor, &acc);
+
+            long pages = 0, committed = 0, live = 0, capacity = 0;
+            var bins = new List<MiHeapBinUsage>();
+            for (int bin = 0; bin < Mi.MI_BIN_COUNT; bin++)
+            {
+                if (acc.Pages[bin] == 0) continue;
+                pages += acc.Pages[bin];
+                committed += acc.Committed[bin];
+                live += acc.Live[bin];
+                capacity += acc.Capacity[bin];
+                bins.Add(new MiHeapBinUsage
+                {
+                    Bin = bin,
+                    BlockSize = acc.BlockSize[bin],
+                    Pages = acc.Pages[bin],
+                    CommittedBytes = acc.Committed[bin],
+                    LiveBytes = acc.Live[bin],
+                    CapacityBytes = acc.Capacity[bin],
+                });
+            }
+            // worst offenders first: most committed-but-unused bytes
+            bins.Sort((a, b) => b.RetainedBytes.CompareTo(a.RetainedBytes));
+
+            return new MiHeapUsage
+            {
+                Pages = pages,
+                CommittedBytes = committed,
+                LiveBytes = live,
+                CapacityBytes = capacity,
+                Bins = bins,
+            };
+        }
+    }
+}

--- a/src/FlowtideDotNet.MiMalloc/MiMallocHeapUsage.cs
+++ b/src/FlowtideDotNet.MiMalloc/MiMallocHeapUsage.cs
@@ -52,6 +52,18 @@ namespace FlowtideDotNet.MiMalloc
         public long LiveBytes { get; init; }
         /// <summary>Total capacity of all pages.</summary>
         public long CapacityBytes { get; init; }
+
+        /// <summary>
+        /// How many of <see cref="Pages"/> did not come from an arena. These are invisible to a
+        /// heap/arena walk while they are live, so a non-zero value here is memory that arena-based
+        /// accounting under-reports. Normally zero or near it.
+        /// </summary>
+        public long NonArenaPages { get; init; }
+        /// <summary>Committed bytes held by the non-arena pages, included in <see cref="CommittedBytes"/>.</summary>
+        public long NonArenaCommittedBytes { get; init; }
+        /// <summary>Live bytes held by the non-arena pages, included in <see cref="LiveBytes"/>.</summary>
+        public long NonArenaLiveBytes { get; init; }
+
         /// <summary>Per size-class breakdown, only bins that hold at least one page, largest retained first.</summary>
         public IReadOnlyList<MiHeapBinUsage> Bins { get; init; }
 
@@ -69,6 +81,11 @@ namespace FlowtideDotNet.MiMalloc
             var sb = new StringBuilder();
             sb.Append($"heap: {Pages} pages, committed {MB(CommittedBytes)}, live {MB(LiveBytes)}, ")
               .Append($"retained {MB(RetainedBytes)}, utilization {Utilization:P1}");
+            if (NonArenaPages > 0)
+            {
+                sb.Append($" (of which non-arena: {NonArenaPages} pages, ")
+                  .Append($"committed {MB(NonArenaCommittedBytes)}, live {MB(NonArenaLiveBytes)})");
+            }
             if (Bins != null)
             {
                 foreach (var b in Bins)
@@ -93,53 +110,80 @@ namespace FlowtideDotNet.MiMalloc
             public fixed long Live[Mi.MI_BIN_COUNT];
             public fixed long Capacity[Mi.MI_BIN_COUNT];
             public fixed long BlockSize[Mi.MI_BIN_COUNT];
+            public long NonArenaPages;
+            public long NonArenaCommitted;
+            public long NonArenaLive;
         }
 
-        private static bool HeapUsageVisitor(mi_heap_t* heap, mi_heap_area_t* area, void* block, nuint block_size, void* arg)
+        private static bool HeapUsageVisitor(mi_page_t* page, void* arg)
         {
-            if (block != null) return true;   // area callbacks only (we pass visitBlocks: false)
-            var acc = (MiHeapUsageAcc*)arg;
-            mi_page_t* page = (mi_page_t*)area->reserved1;
             if (page == null) return true;
+            var acc = (MiHeapUsageAcc*)arg;
 
             nuint bsize = Mi.mi_page_block_size(page);
             if (bsize == 0) return true;
             int bin = (int)Mi._mi_page_stats_bin(page);
             if (bin < 0 || bin >= Mi.MI_BIN_COUNT) return true;
 
+            long committed = (long)Mi.mi_page_committed(page);
+            long live = (long)((nuint)page->used * bsize);
+
             acc->Pages[bin] += 1;
-            acc->Committed[bin] += (long)Mi.mi_page_committed(page);
-            acc->Live[bin] += (long)((nuint)page->used * bsize);
+            acc->Committed[bin] += committed;
+            acc->Live[bin] += live;
             acc->Capacity[bin] += (long)((nuint)page->capacity * bsize);
             acc->BlockSize[bin] = (long)bsize;
+
+            // pages that did not come from an arena are the ones a heap walk cannot reach while they
+            // are still live, so report them separately -- a non-zero figure here is exactly the amount
+            // the old arena-based walk was silently missing.
+            if (page->memid.memkind != mi_memkind_t.MI_MEM_ARENA)
+            {
+                acc->NonArenaPages += 1;
+                acc->NonArenaCommitted += committed;
+                acc->NonArenaLive += live;
+            }
             return true;
         }
 
         /// <summary>
-        /// Walk every page of the main heap and report committed-versus-live bytes, in total and
+        /// Walk every page in the process and report committed-versus-live bytes, in total and
         /// per size-class bin. This is the measurement to use when diagnosing "the allocator holds
         /// far more memory than my data" — a low <see cref="MiHeapUsage.Utilization"/> in a
         /// particular bin points straight at the size class responsible.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Cost is O(pages), so call this at checkpoint cadence rather than in a tight polling
-        /// loop. Use <see cref="GetStats"/> for cheap frequent sampling of OS-level totals.
+        /// This enumerates the page map, so it sees every page regardless of which heap or thread
+        /// owns it and regardless of whether it came from an arena or straight from the OS. An
+        /// earlier version walked the arena page bitmaps instead, which silently omitted live
+        /// non-arena pages and under-reported both live and committed bytes;
+        /// <see cref="MiHeapUsage.NonArenaPages"/> reports how much of the total is memory that
+        /// walk could not have seen.
+        /// </para>
+        /// <para>
+        /// It measures the allocator's PAGES. Arena slices that are committed but not currently
+        /// carved into any page are not counted here — for the true OS-level figure use
+        /// <see cref="MiMallocStats.CommittedBytes"/> from <see cref="GetStats"/>, which is
+        /// maintained atomically on commit/decommit and never lags.
+        /// </para>
+        /// <para>
+        /// Cost is O(address space touched), so call this at checkpoint cadence rather than in a
+        /// tight polling loop. Use <see cref="GetStats"/> for cheap frequent sampling.
         /// </para>
         /// <para>
         /// The walk reads page counters without synchronization (as the C does). Under concurrent
         /// allocation a page or two may be counted slightly stale, so treat the result as a gauge
-        /// rather than an exact invariant. It never blocks and never allocates from the heap it
-        /// is walking.
+        /// rather than an exact invariant. Note that <c>page->used</c> is only decremented when the
+        /// owning thread collects, so pending cross-thread frees make live read HIGH; collect on
+        /// the participating threads first if you need a tight figure. It never blocks and never
+        /// allocates.
         /// </para>
         /// </remarks>
         public static MiHeapUsage GetHeapUsage()
         {
             MiHeapUsageAcc acc = default;
-            mi_heap_t* heap = Mi.mi_heap_main();
-            Mi._mi_heap_visit_blocks(heap, false /* all pages, not just abandoned */,
-                                     false /* areas only, do not enumerate blocks */,
-                                     &HeapUsageVisitor, &acc);
+            Mi._mi_page_map_forall_pages(&HeapUsageVisitor, &acc);
 
             long pages = 0, committed = 0, live = 0, capacity = 0;
             var bins = new List<MiHeapBinUsage>();
@@ -169,6 +213,9 @@ namespace FlowtideDotNet.MiMalloc
                 CommittedBytes = committed,
                 LiveBytes = live,
                 CapacityBytes = capacity,
+                NonArenaPages = acc.NonArenaPages,
+                NonArenaCommittedBytes = acc.NonArenaCommitted,
+                NonArenaLiveBytes = acc.NonArenaLive,
                 Bins = bins,
             };
         }

--- a/src/FlowtideDotNet.MiMalloc/MiMallocStats.cs
+++ b/src/FlowtideDotNet.MiMalloc/MiMallocStats.cs
@@ -1,0 +1,163 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace FlowtideDotNet.MiMalloc
+{
+    /// <summary>
+    /// A snapshot of the allocator's memory usage. Obtained from <see cref="MiMalloc.GetStats"/>.
+    /// All byte values are bytes.
+    /// </summary>
+    public readonly struct MiMallocStats
+    {
+        /// <summary>Address space currently reserved from the OS (virtual, not necessarily backed).</summary>
+        public long ReservedBytes { get; init; }
+        /// <summary>Peak reserved bytes.</summary>
+        public long ReservedPeakBytes { get; init; }
+
+        /// <summary>
+        /// Bytes currently committed (backed by physical memory or page file). This is the number
+        /// that tracks the process working set; <see cref="ReservedBytes"/> is mostly address space.
+        /// </summary>
+        public long CommittedBytes { get; init; }
+        /// <summary>Peak committed bytes.</summary>
+        public long CommittedPeakBytes { get; init; }
+
+        /// <summary>Cumulative bytes purged (decommitted/reset) back to the OS since process start.</summary>
+        public long PurgedBytesTotal { get; init; }
+
+        /// <summary>Number of mimalloc pages currently in use (across all merged heaps).</summary>
+        public long Pages { get; init; }
+        /// <summary>Pages currently abandoned (owned by no thread, awaiting reclaim).</summary>
+        public long PagesAbandoned { get; init; }
+
+        /// <summary>
+        /// Live allocated bytes in normal (non-huge) blocks, as of the last stats merge.
+        /// See the remarks on <see cref="MiMalloc.GetStats"/> about staleness.
+        /// </summary>
+        public long LiveNormalBytes { get; init; }
+        /// <summary>Live allocated bytes in huge blocks, as of the last stats merge.</summary>
+        public long LiveHugeBytes { get; init; }
+
+        /// <summary>Number of arenas created.</summary>
+        public long ArenaCount { get; init; }
+        /// <summary>Threads currently registered with the allocator.</summary>
+        public long Threads { get; init; }
+        /// <summary>Heaps currently alive.</summary>
+        public long Heaps { get; init; }
+        /// <summary>Thread-local heaps (theaps) currently alive.</summary>
+        public long Theaps { get; init; }
+
+        /// <summary>OS allocation calls (mmap / VirtualAlloc) made.</summary>
+        public long OsAllocCalls { get; init; }
+        /// <summary>OS commit calls made.</summary>
+        public long CommitCalls { get; init; }
+        /// <summary>OS purge (decommit/reset) calls made.</summary>
+        public long PurgeCalls { get; init; }
+
+        /// <summary>
+        /// True when the live-allocation figures were folded up from the thread-local heaps before
+        /// this snapshot was taken. When false, <see cref="LiveNormalBytes"/>,
+        /// <see cref="LiveHugeBytes"/> and <see cref="Pages"/> only contain whatever threads
+        /// happened to have merged already, and are typically near zero — they do NOT mean
+        /// "nothing is allocated".
+        /// </summary>
+        public bool LiveStatsMerged { get; init; }
+
+        /// <summary>
+        /// Committed bytes not currently handed out as live blocks: free blocks inside pages plus
+        /// committed-but-unused page space. A large and growing value relative to
+        /// <see cref="CommittedBytes"/> indicates fragmentation or retention.
+        /// <para>
+        /// Null when <see cref="LiveStatsMerged"/> is false, because it cannot be computed from
+        /// unmerged live figures. For an exact value that never depends on merging, use
+        /// <see cref="MiMalloc.GetHeapUsage"/>.
+        /// </para>
+        /// </summary>
+        public long? RetainedBytes
+            => LiveStatsMerged ? CommittedBytes - LiveNormalBytes - LiveHugeBytes : null;
+
+        public override string ToString()
+        {
+            static string MB(long b) => $"{b / (1024.0 * 1024.0):N1} MiB";
+            string live = LiveStatsMerged
+                ? $"live {MB(LiveNormalBytes + LiveHugeBytes)}, retained {MB(RetainedBytes!.Value)}"
+                : "live/retained unknown (thread stats not merged)";
+            return
+                $"mimalloc: reserved {MB(ReservedBytes)} (peak {MB(ReservedPeakBytes)}), " +
+                $"committed {MB(CommittedBytes)} (peak {MB(CommittedPeakBytes)}), " +
+                $"{live}, purged total {MB(PurgedBytesTotal)}, " +
+                $"pages {Pages} ({PagesAbandoned} abandoned), arenas {ArenaCount}, " +
+                $"threads {Threads}, heaps {Heaps}, theaps {Theaps}, " +
+                $"os-calls: alloc {OsAllocCalls}, commit {CommitCalls}, purge {PurgeCalls}";
+        }
+    }
+
+    public static unsafe partial class MiMalloc
+    {
+        /// <summary>
+        /// Take a snapshot of allocator memory usage.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The OS-level figures (<see cref="MiMallocStats.ReservedBytes"/>,
+        /// <see cref="MiMallocStats.CommittedBytes"/>, <see cref="MiMallocStats.PurgedBytesTotal"/>
+        /// and the call counts) are maintained with atomics on process-global state, so they are
+        /// exact and current at the moment of the call. These are the numbers that answer
+        /// "how much memory has mimalloc taken from the OS".
+        /// </para>
+        /// <para>
+        /// The live-allocation figures (<see cref="MiMallocStats.LiveNormalBytes"/>,
+        /// <see cref="MiMallocStats.LiveHugeBytes"/>, <see cref="MiMallocStats.Pages"/>) are
+        /// accumulated per thread-local heap and only folded into the global totals when a thread
+        /// collects or exits, so they lag. Pass <paramref name="mergeThreadStats"/> to fold in the
+        /// CALLING thread's numbers first; other threads' contributions still lag until they
+        /// collect. Use <see cref="MiMalloc.mi_collect"/> on each participating thread for an
+        /// exact figure.
+        /// </para>
+        /// </remarks>
+        /// <param name="mergeThreadStats">
+        /// Merge the calling thread's pending statistics before reading (calls <c>mi_collect(false)</c>).
+        /// </param>
+        public static MiMallocStats GetStats(bool mergeThreadStats = false)
+        {
+            if (mergeThreadStats)
+            {
+                // folds this thread's theap stats up into its heap, and the heap's into the subproc
+                Mi.mi_collect(false);
+                Mi.mi_heap_stats_merge_to_subproc(null);
+            }
+
+            mi_subproc_t* subproc = Mi._mi_subproc_main();
+            mi_stats_t* s = &subproc->stats;
+            return new MiMallocStats
+            {
+                ReservedBytes = s->reserved.current,
+                ReservedPeakBytes = s->reserved.peak,
+                CommittedBytes = s->committed.current,
+                CommittedPeakBytes = s->committed.peak,
+                PurgedBytesTotal = s->purged.total,
+                Pages = s->pages.current,
+                PagesAbandoned = s->pages_abandoned.current,
+                LiveNormalBytes = s->malloc_normal.current,
+                LiveHugeBytes = s->malloc_huge.current,
+                ArenaCount = s->arena_count.total,
+                Threads = s->threads.current,
+                Heaps = s->heaps.current,
+                Theaps = s->theaps.current,
+                OsAllocCalls = s->mmap_calls.total,
+                CommitCalls = s->commit_calls.total,
+                PurgeCalls = s->purge_calls.total,
+                LiveStatsMerged = mergeThreadStats,
+            };
+        }
+    }
+}

--- a/src/FlowtideDotNet.MiMalloc/PageMap.cs
+++ b/src/FlowtideDotNet.MiMalloc/PageMap.cs
@@ -409,6 +409,45 @@ namespace FlowtideDotNet.MiMalloc
             mi_page_map_set_range(null, idx, sub_idx, slice_count);   // todo: avoid committing if not already committed?
         }
 
+        // Visit every distinct page currently registered in the page map.
+        //
+        // Port note: this has no counterpart in the C -- it exists so diagnostics can enumerate pages
+        // independently of where they came from. `_mi_heap_visit_blocks` can only reach pages that are
+        // either in an arena's `pages` bitmap or on the `os_abandoned_pages` list, so a live page that
+        // was allocated outside an arena is invisible to it. The page map has no such gap: every page
+        // is registered here at creation regardless of its memkind.
+        //
+        // `mi_page_map_set_range` writes one entry per slice covered by the page, and those entries are
+        // always a contiguous ascending run, so remembering the previous entry is enough to visit each
+        // page exactly once. Reads are unsynchronized (as the C does elsewhere) -- a page being created
+        // or freed concurrently may be seen or missed, so treat the result as a gauge.
+        // Returns false if the visitor asked to stop.
+        public static bool _mi_page_map_forall_pages(delegate*<mi_page_t*, void*, bool> visitor, void* arg)
+        {
+            mi_assert(visitor != null);
+            if (visitor == null) return false;
+            mi_page_t*** page_map = mi_page_map_get();
+            if (page_map == null || page_map == mi_page_map_empty_get()) return true;   // not initialized yet
+
+            mi_page_t* prev = null;
+            for (nuint idx = 0; idx < mi_page_map_count; idx++)
+            {
+                // never dereference an uncommitted part of the map
+                if (!mi_page_map_is_committed(idx, null)) { prev = null; continue; }
+                mi_page_t** sub = _mi_page_map_at(idx);
+                if (sub == null) { prev = null; continue; }
+                for (nuint sub_idx = 0; sub_idx < MI_PAGE_MAP_SUB_COUNT; sub_idx++)
+                {
+                    mi_page_t* page = sub[sub_idx];
+                    if (page == null) { prev = null; continue; }
+                    if (page == prev) continue;   // still inside the run of the page we just visited
+                    prev = page;
+                    if (!visitor(page, arg)) return false;
+                }
+            }
+            return true;
+        }
+
         // Return NULL for invalid pointers
         public static mi_page_t* _mi_safe_ptr_page(void* p)
         {

--- a/src/FlowtideDotNet.Storage/Memory/FlowtideMemoryAllocation.cs
+++ b/src/FlowtideDotNet.Storage/Memory/FlowtideMemoryAllocation.cs
@@ -31,6 +31,24 @@ namespace FlowtideDotNet.Storage.Memory
         // The managed mimalloc port requires a 64-bit process; on 32-bit fall back to NativeMemory.
         private static readonly bool _useMimalloc = IntPtr.Size == 8;
 
+        /// <summary>
+        /// Whether <see cref="GetAllocationSize"/> can recover a block's size from its pointer alone.
+        /// Only mimalloc can do this; the <see cref="NativeMemory"/> fallback has no equivalent, so a
+        /// caller that needs the size on a free path must remember it itself when this is false.
+        /// </summary>
+        public static bool CanQueryAllocationSize => _useMimalloc;
+
+        /// <summary>
+        /// The size of a block previously returned by <see cref="AllocateAligned"/>. Only valid when
+        /// <see cref="CanQueryAllocationSize"/> is true -- asking mimalloc about a pointer it did not
+        /// hand out reads through a page map that has no entry for it.
+        /// </summary>
+        public static nuint GetAllocationSize(void* ptr)
+        {
+            Debug.Assert(_useMimalloc, "GetAllocationSize is only valid when mimalloc is in use");
+            return MiMalloc.mi_usable_size(ptr);
+        }
+
         static FlowtideMemoryAllocation()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/src/FlowtideDotNet.Storage/Memory/FlowtideMemoryAllocation.cs
+++ b/src/FlowtideDotNet.Storage/Memory/FlowtideMemoryAllocation.cs
@@ -140,7 +140,14 @@ namespace FlowtideDotNet.Storage.Memory
         {
             if (_useMimalloc)
             {
-                MiMalloc.mi_collect(true);
+                // Overallocate a bunch of work items to try and hit all threads in the thread pool to run the collection.
+                for (int i = 0; i < Environment.ProcessorCount * 8; i++)
+                {
+                    ThreadPool.QueueUserWorkItem<object?>((_) =>
+                    {
+                        MiMalloc.mi_collect(true);
+                    }, default, false);
+                }
             }
         }
     }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/CompressedStateSerializer.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/CompressedStateSerializer.cs
@@ -38,12 +38,20 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
         private GCHandle _handle;
         private bool _isInitialized;
 
+        // zstd's free callback is handed only a pointer, so the size has to come from somewhere.
+        // mimalloc can report it from the pointer alone; the NativeMemory fallback cannot, so on that
+        // platform we have to remember it. Null whenever the allocator can answer for itself, which
+        // keeps the 64-bit path free of both the dictionary and the lock.
+        private readonly Dictionary<nint, int>? _allocatedSizes;
+        private readonly object _sizesLock = new object();
+
         public FlowtideZstdCompressor(IMemoryAllocator memoryAllocator, int compressionLevel)
         {
             _memoryAllocator = memoryAllocator;
             this._compressionLevel = compressionLevel;
             _handle = GCHandle.Alloc(this);
             _isInitialized = false;
+            _allocatedSizes = FlowtideMemoryAllocation.CanQueryAllocationSize ? null : new Dictionary<nint, int>();
         }
 
         private void SetParameter(ZSTD_cParameter parameter, int value)
@@ -92,7 +100,6 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
         // instead would put them on the C runtime heap while still reporting them to the metrics, which
         // makes the reported figure impossible to reconcile with what the allocator actually holds --
         // the workspaces are ~0.6 MiB per state client, so that gap is not small.
-        // The alignment is 16, mimalloc's natural maximum, so mi_usable_size matches what was asked for.
         private const int ZstdAllocAlignment = 16;
 
         private static void* CustomAlloc(void* opaque, nuint size)
@@ -100,9 +107,20 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
             GCHandle handle = GCHandle.FromIntPtr((IntPtr)opaque);
             var instance = (FlowtideZstdCompressor)handle.Target!;
             var allocated = FlowtideMemoryAllocation.AllocateAligned((int)size, ZstdAllocAlignment);
-            // register what the allocator really handed over, and read it back the same way on the free
-            // path, so the two can never drift apart
-            instance._memoryAllocator.RegisterAllocationToMetrics((int)MiMalloc.mi_usable_size(allocated.ptr));
+
+            // register whatever the free path will be able to report, so the two can never drift apart
+            int registered = FlowtideMemoryAllocation.CanQueryAllocationSize
+                ? (int)FlowtideMemoryAllocation.GetAllocationSize(allocated.ptr)
+                : allocated.length;
+
+            if (instance._allocatedSizes != null)
+            {
+                lock (instance._sizesLock)
+                {
+                    instance._allocatedSizes[(nint)allocated.ptr] = registered;
+                }
+            }
+            instance._memoryAllocator.RegisterAllocationToMetrics(registered);
             return allocated.ptr;
         }
 
@@ -114,8 +132,29 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
             }
             GCHandle handle = GCHandle.FromIntPtr((IntPtr)opaque);
             var instance = (FlowtideZstdCompressor)handle.Target!;
-            // size has to be read while the block is still ours
-            instance._memoryAllocator.RegisterFreeToMetrics((int)MiMalloc.mi_usable_size(ptr));
+
+            int size;
+            if (instance._allocatedSizes != null)
+            {
+                lock (instance._sizesLock)
+                {
+                    // a pointer we never handed out is not ours to account for
+                    if (!instance._allocatedSizes.Remove((nint)ptr, out size))
+                    {
+                        size = 0;
+                    }
+                }
+            }
+            else
+            {
+                // must be read while the block is still ours
+                size = (int)FlowtideMemoryAllocation.GetAllocationSize(ptr);
+            }
+
+            if (size > 0)
+            {
+                instance._memoryAllocator.RegisterFreeToMetrics(size);
+            }
             FlowtideMemoryAllocation.FreeAligned(ptr, ZstdAllocAlignment);
         }
 

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/CompressedStateSerializer.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/CompressedStateSerializer.cs
@@ -20,6 +20,10 @@ using ZstdSharp.Unsafe;
 
 namespace FlowtideDotNet.Storage.StateManager.Internal
 {
+    // note: alias inside the namespace, the FlowtideDotNet.MiMalloc NAMESPACE otherwise
+    // shadows the type name when resolving from FlowtideDotNet.* namespaces
+    using MiMalloc = FlowtideDotNet.MiMalloc.MiMalloc;
+
     /// <summary>
     /// Implementation of both compressor and decompressor from zstdsharp, only to use own memory allocation
     /// to get that memory to metrics correctly.
@@ -31,16 +35,13 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
         private bool _disposedValue;
         private readonly IMemoryAllocator _memoryAllocator;
         private readonly int _compressionLevel;
-        private SortedList<IntPtr, int> _allocatedMemory;
         private GCHandle _handle;
-        private readonly object _lock = new object();
         private bool _isInitialized;
 
         public FlowtideZstdCompressor(IMemoryAllocator memoryAllocator, int compressionLevel)
         {
             _memoryAllocator = memoryAllocator;
             this._compressionLevel = compressionLevel;
-            _allocatedMemory = new SortedList<nint, int>();
             _handle = GCHandle.Alloc(this);
             _isInitialized = false;
         }
@@ -87,34 +88,35 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
         }
 
 
+        // zstd's workspaces go through the same allocator as everything else. Using NativeMemory here
+        // instead would put them on the C runtime heap while still reporting them to the metrics, which
+        // makes the reported figure impossible to reconcile with what the allocator actually holds --
+        // the workspaces are ~0.6 MiB per state client, so that gap is not small.
+        // The alignment is 16, mimalloc's natural maximum, so mi_usable_size matches what was asked for.
+        private const int ZstdAllocAlignment = 16;
+
         private static void* CustomAlloc(void* opaque, nuint size)
         {
             GCHandle handle = GCHandle.FromIntPtr((IntPtr)opaque);
             var instance = (FlowtideZstdCompressor)handle.Target!;
-            // Register the allocated memory to metrics
-            instance._memoryAllocator.RegisterAllocationToMetrics((int)size);
-            var ptr = NativeMemory.Alloc(size);
-            lock (instance._lock)
-            {
-                instance._allocatedMemory.Add(new nint(ptr), (int)size);
-            }
-            return ptr;
+            var allocated = FlowtideMemoryAllocation.AllocateAligned((int)size, ZstdAllocAlignment);
+            // register what the allocator really handed over, and read it back the same way on the free
+            // path, so the two can never drift apart
+            instance._memoryAllocator.RegisterAllocationToMetrics((int)MiMalloc.mi_usable_size(allocated.ptr));
+            return allocated.ptr;
         }
 
         private static void CustomFree(void* opaque, void* ptr)
         {
+            if (ptr == null)
+            {
+                return;
+            }
             GCHandle handle = GCHandle.FromIntPtr((IntPtr)opaque);
             var instance = (FlowtideZstdCompressor)handle.Target!;
-            lock (instance._lock)
-            {
-                if (instance._allocatedMemory.TryGetValue(new nint(ptr), out var size))
-                {
-                    // Remove allocated memory from metrics
-                    instance._memoryAllocator.RegisterFreeToMetrics(size);
-                    instance._allocatedMemory.Remove(new nint(ptr));
-                }
-            }
-            NativeMemory.Free(ptr);
+            // size has to be read while the block is still ours
+            instance._memoryAllocator.RegisterFreeToMetrics((int)MiMalloc.mi_usable_size(ptr));
+            FlowtideMemoryAllocation.FreeAligned(ptr, ZstdAllocAlignment);
         }
 
         public int Wrap(ReadOnlySpan<byte> src, Span<byte> dest)
@@ -200,9 +202,10 @@ namespace FlowtideDotNet.Storage.StateManager.Internal
             _compressor = new FlowtideZstdCompressor(memoryAllocator, compressionLevel);
         }
 
-        public Task CheckpointAsync<TMetadata>(IStateSerializerCheckpointWriter checkpointWriter, StateClientMetadata<TMetadata> metadata) where TMetadata : IStorageMetadata
+        public async Task CheckpointAsync<TMetadata>(IStateSerializerCheckpointWriter checkpointWriter, StateClientMetadata<TMetadata> metadata) where TMetadata : IStorageMetadata
         {
-            return _serializer.CheckpointAsync(checkpointWriter, metadata);
+            await _serializer.CheckpointAsync(checkpointWriter, metadata);
+            ClearTemporaryAllocations();
         }
 
         public void ClearTemporaryAllocations()

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/LruTableSync.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/LruTableSync.cs
@@ -413,6 +413,11 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
                     }
                     else
                     {
+                        if (m_sameCaheHitsCount >= 1000)
+                        {
+                            FlowtideMemoryAllocation.Collect();
+                            m_sameCaheHitsCount = 0;
+                        }
                         return;
                     }
                 }

--- a/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
+++ b/src/FlowtideDotNet.Storage/StateManager/Internal/Sync/SyncStateClient.cs
@@ -240,6 +240,9 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
 
             await WriteMetadata();
             await session.Commit();
+
+            m_fileCache.ClearTemporaryAllocations();
+            options.ValueSerializer.ClearTemporaryAllocations();
         }
 
         private async Task WriteMetadata()
@@ -422,6 +425,11 @@ namespace FlowtideDotNet.Storage.StateManager.Internal.Sync
             {
                 var bytes = await session.Read(metadataId);
                 metadata = StateClientMetadataSerializer.Deserialize<TMetadata>(bytes, bytes.Length);
+            }
+            m_fileCache.ClearTemporaryAllocations();
+            if (options.ValueSerializer != null)
+            {
+                options.ValueSerializer.ClearTemporaryAllocations();
             }
         }
 

--- a/tests/FlowtideDotNet.MiMalloc.Tests/StatsTests.cs
+++ b/tests/FlowtideDotNet.MiMalloc.Tests/StatsTests.cs
@@ -183,6 +183,104 @@ namespace FlowtideDotNet.MiMalloc.Tests
         }
 
         [Fact]
+        public void GetHeapUsage_CountsMultiSlicePagesOnce()
+        {
+            // A page larger than one 64 KiB slice occupies MANY page-map entries, one per slice.
+            // If the walk did not collapse those runs it would count the same page once per slice
+            // and every figure would be inflated several-fold, so pin that down explicitly.
+            const int size = 2 * 1024 * 1024;
+            const int count = 8;
+
+            var before = MiMalloc.GetHeapUsage();
+
+            var ptrs = new nint[count];
+            for (int i = 0; i < count; i++)
+            {
+                byte* p = (byte*)MiMalloc.mi_malloc(size);
+                Assert.True(p != null);
+                p[0] = 1;
+                p[size - 1] = 1;
+                ptrs[i] = (nint)p;
+            }
+
+            var during = MiMalloc.GetHeapUsage();
+            _output.WriteLine("during: " + during);
+
+            long allocated = count * (long)size;
+            long grew = during.LiveBytes - before.LiveBytes;
+            Assert.True(grew >= allocated, $"live grew by only {grew}, expected >= {allocated}");
+            // the real assertion: each 2 MiB block spans dozens of slices, so a walk that failed to
+            // dedup would report an order of magnitude more than was actually allocated
+            Assert.True(grew < 2 * allocated,
+                $"live grew by {grew} for {allocated} allocated -- pages are being counted more than once");
+
+            long pagesAdded = during.Pages - before.Pages;
+            Assert.True(pagesAdded <= 4 * count,
+                $"{pagesAdded} pages appeared for {count} blocks -- slices are being counted as pages");
+
+            foreach (var ptr in ptrs) { MiMalloc.mi_free((void*)ptr); }
+            MiMalloc.mi_collect(true);
+        }
+
+        [Fact]
+        public void GetHeapUsage_SeesPagesOwnedByAnotherThread()
+        {
+            // The walk enumerates the page map, so it must see another thread's live pages without
+            // that thread merging its statistics or collecting. This is exactly what the GetStats()
+            // live figures cannot do, and why they lag (or go negative) under cross-thread traffic.
+            const int size = 3 * 1024;
+            const int count = 500;
+
+            var before = MiMalloc.GetHeapUsage();
+
+            var ptrs = new nint[count];
+            using var allocated = new ManualResetEventSlim(false);
+            using var release = new ManualResetEventSlim(false);
+            var thread = new Thread(() =>
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    byte* p = (byte*)MiMalloc.mi_malloc(size);
+                    p[0] = 1;
+                    ptrs[i] = (nint)p;
+                }
+                allocated.Set();
+                release.Wait();
+                for (int i = 0; i < count; i++) { MiMalloc.mi_free((void*)ptrs[i]); }
+                MiMalloc.mi_collect(true);
+            });
+            thread.Start();
+            Assert.True(allocated.Wait(TimeSpan.FromSeconds(30)), "allocating thread did not finish");
+
+            // walked from THIS thread, while the owning thread is parked and has merged nothing
+            var during = MiMalloc.GetHeapUsage();
+            _output.WriteLine("during: " + during);
+
+            long grew = during.LiveBytes - before.LiveBytes;
+            Assert.True(grew >= count * (long)size,
+                $"another thread's live bytes were invisible to the walk: grew by {grew}");
+
+            release.Set();
+            Assert.True(thread.Join(TimeSpan.FromSeconds(30)), "freeing thread did not finish");
+        }
+
+        [Fact]
+        public void GetHeapUsage_NonArenaFiguresAreASubsetOfTheTotals()
+        {
+            void* warm = MiMalloc.mi_malloc(64);
+            var u = MiMalloc.GetHeapUsage();
+            MiMalloc.mi_free(warm);
+
+            // non-arena pages are the ones an arena walk cannot reach while live; whatever their
+            // count, they are part of the totals and can never exceed them
+            Assert.True(u.NonArenaPages >= 0);
+            Assert.True(u.NonArenaPages <= u.Pages, $"non-arena pages {u.NonArenaPages} > total {u.Pages}");
+            Assert.True(u.NonArenaLiveBytes <= u.LiveBytes);
+            Assert.True(u.NonArenaCommittedBytes <= u.CommittedBytes);
+            _output.WriteLine($"non-arena: {u.NonArenaPages} pages, live {u.NonArenaLiveBytes}, committed {u.NonArenaCommittedBytes}");
+        }
+
+        [Fact]
         public void GetStats_DoesNotRequireMerge()
         {
             // the OS-level numbers must be readable without merging (the cheap polling path)

--- a/tests/FlowtideDotNet.MiMalloc.Tests/StatsTests.cs
+++ b/tests/FlowtideDotNet.MiMalloc.Tests/StatsTests.cs
@@ -1,0 +1,196 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the public MiMalloc.GetStats() snapshot.
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FlowtideDotNet.MiMalloc.Tests
+{
+    public unsafe class StatsTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public StatsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void GetStats_ReportsOsUsage()
+        {
+            // make sure the allocator is up
+            void* warm = MiMalloc.mi_malloc(64);
+            MiMalloc.mi_free(warm);
+
+            var before = MiMalloc.GetStats(mergeThreadStats: true);
+            _output.WriteLine("before: " + before);
+
+            // hold ~64 MiB live so the OS-level numbers have to move
+            const int count = 64;
+            const int size = 1024 * 1024;
+            var ptrs = new nint[count];
+            for (int i = 0; i < count; i++)
+            {
+                byte* p = (byte*)MiMalloc.mi_malloc(size);
+                Assert.True(p != null);
+                p[0] = 1;
+                p[size - 1] = 1;   // touch both ends so it is really committed
+                ptrs[i] = (nint)p;
+            }
+
+            var during = MiMalloc.GetStats(mergeThreadStats: true);
+            _output.WriteLine("during: " + during);
+
+            // OS-level figures are exact and must reflect the 64 MiB
+            Assert.True(during.ReservedBytes > 0, "nothing reserved from the OS");
+            Assert.True(during.CommittedBytes >= before.CommittedBytes, "committed went backwards");
+            Assert.True(during.CommittedBytes >= count * (long)size, $"committed {during.CommittedBytes} < 64 MiB");
+            Assert.True(during.ReservedBytes >= during.CommittedBytes, "reserved must cover committed");
+            Assert.True(during.OsAllocCalls > 0, "no OS allocation calls recorded");
+            Assert.True(during.ReservedPeakBytes >= during.ReservedBytes);
+            Assert.True(during.CommittedPeakBytes >= during.CommittedBytes);
+
+            // live-allocation figures come from the merged thread stats
+            Assert.True(during.LiveNormalBytes + during.LiveHugeBytes >= count * (long)size,
+                $"live bytes {during.LiveNormalBytes + during.LiveHugeBytes} < 64 MiB");
+            Assert.True(during.Threads >= 1);
+            Assert.True(during.Heaps >= 1);
+
+            foreach (var ptr in ptrs) { MiMalloc.mi_free((void*)ptr); }
+            MiMalloc.mi_collect(true);
+
+            var after = MiMalloc.GetStats(mergeThreadStats: true);
+            _output.WriteLine("after:  " + after);
+
+            // the blocks are gone from the live figures ...
+            Assert.True(after.LiveNormalBytes + after.LiveHugeBytes
+                        < during.LiveNormalBytes + during.LiveHugeBytes,
+                "live bytes did not drop after freeing");
+            // ... and a forced collect must have purged something back to the OS
+            Assert.True(after.PurgedBytesTotal >= before.PurgedBytesTotal, "purge counter went backwards");
+        }
+
+        [Fact]
+        public void GetHeapUsage_CountsLiveBytesWithoutMerging()
+        {
+            // block size chosen to sit in its own bin so the assertions are unambiguous
+            const int size = 3 * 1024;
+            const int count = 400;
+
+            var before = MiMalloc.GetHeapUsage();
+            _output.WriteLine("before: " + before);
+
+            var ptrs = new nint[count];
+            for (int i = 0; i < count; i++)
+            {
+                byte* p = (byte*)MiMalloc.mi_malloc(size);
+                Assert.True(p != null);
+                p[0] = 1;
+                ptrs[i] = (nint)p;
+            }
+
+            // NOTE: no merge, no collect, no per-thread anything -- the walk sees the pages directly
+            var during = MiMalloc.GetHeapUsage();
+            _output.WriteLine("during: " + during);
+
+            long grew = during.LiveBytes - before.LiveBytes;
+            Assert.True(grew >= count * (long)size, $"live bytes only grew by {grew}, expected >= {count * (long)size}");
+            Assert.True(during.CommittedBytes >= during.LiveBytes, "live cannot exceed committed");
+            Assert.True(during.Pages > before.Pages, "no new pages observed");
+            Assert.True(during.Utilization > 0 && during.Utilization <= 1.0);
+
+            // the bin holding our blocks must show up with the right block size
+            long expectedBlockSize = (long)MiMalloc.mi_good_size(size);
+            var bin = during.Bins.FirstOrDefault(b => b.BlockSize == expectedBlockSize);
+            Assert.True(bin.Pages > 0, $"no bin with block size {expectedBlockSize}");
+            Assert.True(bin.LiveBytes >= count * (long)size);
+
+            foreach (var ptr in ptrs) { MiMalloc.mi_free((void*)ptr); }
+            MiMalloc.mi_collect(true);
+
+            var after = MiMalloc.GetHeapUsage();
+            _output.WriteLine("after:  " + after);
+            Assert.True(after.LiveBytes < during.LiveBytes, "live bytes did not drop after freeing");
+        }
+
+        [Fact]
+        public void GetHeapUsage_ExposesSparsePagesAsLowUtilization()
+        {
+            // Reproduce the production symptom: allocate many blocks, then free all but a few
+            // per page. The pages cannot be returned (each still holds a live block), so
+            // committed stays high while live collapses -- exactly what fragmentation looks like.
+            const int size = 5 * 1024;   // its own bin, several blocks per 64 KiB page
+            const int count = 2000;
+
+            var ptrs = new nint[count];
+            for (int i = 0; i < count; i++)
+            {
+                byte* p = (byte*)MiMalloc.mi_malloc(size);
+                Assert.True(p != null);
+                p[0] = 1;
+                ptrs[i] = (nint)p;
+            }
+            nuint goodSize = MiMalloc.mi_good_size(size);
+
+            var full = MiMalloc.GetHeapUsage();
+            var fullBin = full.Bins.First(b => b.BlockSize == (long)goodSize);
+            _output.WriteLine($"full:   pages {fullBin.Pages}, live {fullBin.LiveBytes}, committed {fullBin.CommittedBytes}, util {fullBin.Utilization:P1}");
+            Assert.True(fullBin.Utilization > 0.5, $"expected densely used pages, got {fullBin.Utilization:P1}");
+
+            // keep every 8th block alive, free the rest
+            for (int i = 0; i < count; i++)
+            {
+                if (i % 8 != 0) { MiMalloc.mi_free((void*)ptrs[i]); ptrs[i] = 0; }
+            }
+            MiMalloc.mi_collect(true);
+
+            var sparse = MiMalloc.GetHeapUsage();
+            var sparseBin = sparse.Bins.First(b => b.BlockSize == (long)goodSize);
+            _output.WriteLine($"sparse: pages {sparseBin.Pages}, live {sparseBin.LiveBytes}, committed {sparseBin.CommittedBytes}, util {sparseBin.Utilization:P1}");
+
+            // live dropped ~8x, but the pages are still held: that gap is the fragmentation signal
+            Assert.True(sparseBin.LiveBytes < fullBin.LiveBytes / 4, "live bytes should have collapsed");
+            Assert.True(sparseBin.Utilization < fullBin.Utilization, "utilization should have dropped");
+            Assert.True(sparseBin.RetainedBytes > sparseBin.LiveBytes, "retained should now dominate live");
+
+            foreach (var ptr in ptrs) { if (ptr != 0) MiMalloc.mi_free((void*)ptr); }
+            MiMalloc.mi_collect(true);
+        }
+
+        [Fact]
+        public void GetStats_UnmergedDoesNotClaimRetained()
+        {
+            // the trap: without a merge the live figures are meaningless, so retained must be null
+            var unmerged = MiMalloc.GetStats();
+            Assert.False(unmerged.LiveStatsMerged);
+            Assert.Null(unmerged.RetainedBytes);
+            Assert.Contains("unknown", unmerged.ToString());
+
+            var merged = MiMalloc.GetStats(mergeThreadStats: true);
+            Assert.True(merged.LiveStatsMerged);
+            Assert.NotNull(merged.RetainedBytes);
+        }
+
+        [Fact]
+        public void GetStats_DoesNotRequireMerge()
+        {
+            // the OS-level numbers must be readable without merging (the cheap polling path)
+            var s = MiMalloc.GetStats();
+            Assert.True(s.ReservedBytes > 0);
+            Assert.True(s.CommittedBytes > 0);
+            Assert.True(s.ReservedBytes >= s.CommittedBytes);
+            Assert.False(string.IsNullOrEmpty(s.ToString()));
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Storage.Tests/FlowtideDotNet.Storage.Tests.csproj
+++ b/tests/FlowtideDotNet.Storage.Tests/FlowtideDotNet.Storage.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/FlowtideDotNet.Storage.Tests/Memory/ZstdCompressorMetricsTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/Memory/ZstdCompressorMetricsTests.cs
@@ -1,0 +1,134 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.StateManager.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FlowtideDotNet.Storage.Tests.Memory
+{
+    /// <summary>
+    /// zstd's free callback receives only a pointer, so the size reported on free has to match the size
+    /// reported on allocation or the operator's memory accounting drifts permanently. mimalloc can
+    /// recover the size from the pointer; the NativeMemory fallback cannot, which is why the compressor
+    /// remembers sizes when the allocator cannot answer for itself. These tests pin the invariant that
+    /// matters either way: the accounting returns to where it started.
+    /// </summary>
+    public unsafe class ZstdCompressorMetricsTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ZstdCompressorMetricsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ContextAllocations_AreFullyUnregisteredOnDispose()
+        {
+            using var stream = new StreamMemoryManager("zstdmetrics-" + Guid.NewGuid().ToString("N"));
+            var op = stream.CreateOperatorMemoryManager("compressor");
+
+            long before = stream.GetAllocatedMemory();
+
+            var src = new byte[4096];
+            for (int i = 0; i < src.Length; i++) { src[i] = (byte)(i % 251); }
+            var dest = new byte[8192];
+
+            long during;
+            using (var compressor = new FlowtideZstdCompressor(op, 3))
+            {
+                // forces CreateContexts, and the first compress lazily allocates the match-finder
+                // workspace -- the large block this whole change is about
+                int written = compressor.Wrap(src, dest);
+                Assert.True(written > 0);
+
+                during = stream.GetAllocatedMemory();
+                _output.WriteLine($"before {before:N0}, during {during:N0}");
+                Assert.True(during > before, "zstd context memory was never registered");
+            }
+
+            long after = stream.GetAllocatedMemory();
+            _output.WriteLine($"after {after:N0}");
+
+            // the exact invariant: every byte registered on the way in is unregistered on the way out
+            Assert.Equal(before, after);
+        }
+
+        [Fact]
+        public void ResetContexts_ReturnsAccountingToBaseline()
+        {
+            using var stream = new StreamMemoryManager("zstdreset-" + Guid.NewGuid().ToString("N"));
+            var op = stream.CreateOperatorMemoryManager("compressor");
+
+            var src = new byte[4096];
+            var dest = new byte[8192];
+
+            using var compressor = new FlowtideZstdCompressor(op, 3);
+            compressor.Wrap(src, dest);
+            long afterFirst = stream.GetAllocatedMemory();
+
+            // contexts are recreated lazily, so a reset/use cycle must not accumulate
+            for (int i = 0; i < 3; i++)
+            {
+                compressor.ResetContexts();
+                Assert.Equal(0, stream.GetAllocatedMemory());
+                compressor.Wrap(src, dest);
+                Assert.Equal(afterFirst, stream.GetAllocatedMemory());
+            }
+        }
+
+        [Fact]
+        public void RoundTrip_StillProducesTheOriginalBytes()
+        {
+            // the accounting changes touch the allocator zstd runs on, so prove it still works
+            using var stream = new StreamMemoryManager("zstdroundtrip-" + Guid.NewGuid().ToString("N"));
+            var op = stream.CreateOperatorMemoryManager("compressor");
+
+            var src = new byte[16 * 1024];
+            new Random(42).NextBytes(src);
+            var compressed = new byte[32 * 1024];
+            var restored = new byte[16 * 1024];
+
+            using var compressor = new FlowtideZstdCompressor(op, 3);
+            int written = compressor.Wrap(src, compressed);
+            int read = compressor.Unwrap(compressed.AsSpan(0, written), restored);
+
+            Assert.Equal(src.Length, read);
+            Assert.Equal(src, restored);
+        }
+
+        [Fact]
+        public void GetAllocationSize_AgreesWithWhatWasHandedOut()
+        {
+            if (!FlowtideMemoryAllocation.CanQueryAllocationSize)
+            {
+                // the fallback allocator genuinely cannot answer this; that is why the compressor
+                // keeps its own size map, and asking anyway is what the review caught
+                return;
+            }
+
+            var mem = FlowtideMemoryAllocation.AllocateAligned(1000, 16);
+            try
+            {
+                nuint size = FlowtideMemoryAllocation.GetAllocationSize(mem.ptr);
+                Assert.True(size >= 1000, $"reported {size} for a 1000 byte request");
+                Assert.True((int)size >= mem.length, $"reported {size} but handed out {mem.length}");
+            }
+            finally
+            {
+                FlowtideMemoryAllocation.FreeAligned(mem.ptr, 16);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is done to help clean up not required memory, without this, memory can be quite fragmented when going from a heavily congested stream to very low. So this helps reduce fragmentation and can reduce memory usage.