### PR TITLE
Change set operator to handle operations in bulk like merge join and aggregate

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnComparer.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/TreeStorage/ColumnComparer.cs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using FlowtideDotNet.Core.ColumnStore.BoundarySearching;
 using FlowtideDotNet.Storage.Tree;
 
 namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
@@ -18,6 +19,7 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
     {
         private DataValueContainer dataValueContainer;
         private readonly int columnCount;
+        private readonly ColumnBoundarySearch _columnBoundarySearch;
 
         public bool SeekNextPageForValue => false;
 
@@ -25,6 +27,12 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
         {
             dataValueContainer = new DataValueContainer();
             this.columnCount = columnCount;
+            var columnOrder = new int[columnCount];
+            for (int i = 0; i < columnCount; i++)
+            {
+                columnOrder[i] = i;
+            }
+            _columnBoundarySearch = new ColumnBoundarySearch(columnOrder, columnOrder);
         }
 
         public int CompareTo(in ColumnRowReference x, in ColumnRowReference y)
@@ -70,9 +78,56 @@ namespace FlowtideDotNet.Core.ColumnStore.TreeStorage
             return index;
         }
 
-        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int length)
+        public FindBoundriesResult FindBoundries(in ColumnRowReference key, in ColumnKeyStorageContainer keyContainer, int startIndex, int endIndex)
         {
-            throw new NotImplementedException();
+            int start = startIndex;
+            int end = endIndex;
+
+            if (columnCount == 0)
+            {
+                // No columns, so the whole range matches
+                if (start > end)
+                {
+                    return new FindBoundriesResult(~start, ~start);
+                }
+                return new FindBoundriesResult(start, end);
+            }
+
+            for (int i = 0; i < columnCount; i++)
+            {
+                // Get value by container to skip boxing for each value
+                key.referenceBatch.Columns[i].GetValueAt(key.RowIndex, dataValueContainer, default);
+                var (low, high) = keyContainer._data.Columns[i].SearchBoundries(dataValueContainer, start, end, default);
+
+                if (low < 0)
+                {
+                    return new FindBoundriesResult(low, low);
+                }
+                start = low;
+                end = high;
+            }
+            return new FindBoundriesResult(start, end);
+        }
+
+        void IBplusTreeComparer<ColumnRowReference, ColumnKeyStorageContainer>.FindBoundriesBulk(
+            ReadOnlySpan<ColumnRowReference> keys,
+            ReadOnlySpan<int> sortedLookup,
+            in ColumnKeyStorageContainer keyContainer,
+            Span<int> lowerBounds,
+            Span<int> upperBounds,
+            Span<int> lookupBuffer)
+        {
+            if (columnCount == 0)
+            {
+                // No columns, all keys match the first row
+                var bounds = keyContainer.Count > 0 ? 0 : ~0;
+                lowerBounds.Fill(bounds);
+                upperBounds.Fill(keyContainer.Count > 0 ? keyContainer.Count - 1 : ~0);
+                return;
+            }
+            // All keys come from the same batch
+            var incomingColumns = keys[0].referenceBatch.Columns;
+            _columnBoundarySearch.SearchBoundries(keyContainer._data.Columns, incomingColumns, sortedLookup, lowerBounds, upperBounds, 0, keyContainer.Count - 1, false, lookupBuffer);
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Set/ColumnSetOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Set/ColumnSetOperator.cs
@@ -13,6 +13,7 @@
 using FlowtideDotNet.Base.Metrics;
 using FlowtideDotNet.Base.Vertices;
 using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.Sort;
 using FlowtideDotNet.Core.ColumnStore.TreeStorage;
 using FlowtideDotNet.Core.Operators.Set.Structs;
 using FlowtideDotNet.Storage.DataStructures;
@@ -21,6 +22,7 @@ using FlowtideDotNet.Storage.StateManager;
 using FlowtideDotNet.Storage.Tree;
 using FlowtideDotNet.Substrait.Relations;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Dataflow;
 
 namespace FlowtideDotNet.Core.Operators.Set
@@ -30,10 +32,19 @@ namespace FlowtideDotNet.Core.Operators.Set
     {
         private readonly SetRelation _setRelation;
         private IBPlusTree<ColumnRowReference, TStruct, ColumnKeyStorageContainer, PrimitiveListValueContainer<TStruct>>? _tree;
+        private IBPlusTreeBulkInserter<ColumnRowReference, TStruct, ColumnKeyStorageContainer, PrimitiveListValueContainer<TStruct>>? _bulkInserter;
         private Func<TStruct, int> _weightCalculator;
         private int[] _emit;
         private int _inputLength;
         private readonly string _displayName;
+
+        // Batch buffers, reused between batches
+        private readonly BatchSorter _batchSorter;
+        private readonly IColumn[] _sortColumns;
+        private int[] _sortedIndicesBuffer = Array.Empty<int>();
+        private int[] _duplicateTagsBuffer = Array.Empty<int>();
+        private ColumnRowReference[] _keyBuffer = Array.Empty<ColumnRowReference>();
+        private TStruct[] _valueBuffer = Array.Empty<TStruct>();
 
         // Metrics
         private ICounter<long>? _eventsCounter;
@@ -109,6 +120,9 @@ namespace FlowtideDotNet.Core.Operators.Set
                     _emit[i] = i;
                 }
             }
+
+            _batchSorter = new BatchSorter(_inputLength);
+            _sortColumns = new IColumn[_inputLength];
         }
 
         private static int UnionDistinctWeightFunction(TStruct weights)
@@ -189,59 +203,59 @@ namespace FlowtideDotNet.Core.Operators.Set
 
         public override async IAsyncEnumerable<StreamEventBatch> OnRecieve(int targetId, StreamEventBatch msg, long time)
         {
-            Debug.Assert(_tree != null);
+            Debug.Assert(_bulkInserter != null);
             Debug.Assert(_eventsCounter != null);
             Debug.Assert(_eventsProcessed != null);
 
-            PrimitiveList<int> foundOffsets = new PrimitiveList<int>(MemoryAllocator);
-            PrimitiveList<int> outputWeights = new PrimitiveList<int>(MemoryAllocator);
-            PrimitiveList<uint> iterations = new PrimitiveList<uint>(MemoryAllocator);
-
             var weights = msg.Data.Weights;
-            _eventsCounter.Add(weights.Count);
-            for (int i = 0; i < weights.Count; i++)
+            var rowCount = weights.Count;
+            _eventsCounter.Add(rowCount);
+
+            if (rowCount == 0)
             {
+                yield break;
+            }
+
+            var batchData = msg.Data.EventBatchData;
+
+            if (_keyBuffer.Length < rowCount)
+            {
+                _keyBuffer = new ColumnRowReference[rowCount];
+                _valueBuffer = new TStruct[rowCount];
+            }
+            var keys = _keyBuffer;
+            var values = _valueBuffer;
+
+            // Row index is the key, required by the inserter
+            for (int i = 0; i < rowCount; i++)
+            {
+                keys[i] = new ColumnRowReference() { referenceBatch = batchData, RowIndex = i };
                 var inputWeight = new TStruct();
                 inputWeight.SetValue(targetId, weights[i]);
-                var rowRef = new ColumnRowReference() { referenceBatch = msg.Data.EventBatchData, RowIndex = i };
+                values[i] = inputWeight;
 
 #if DEBUG_WRITE
                 Debug.Assert(allInput != null);
-                allInput.WriteLine($"{targetId}, {weights[i]} {rowRef}");
+                allInput.WriteLine($"{targetId}, {weights[i]} {keys[i]}");
 #endif
-
-                await _tree.RMWNoResult(rowRef, inputWeight, (input, current, exists) =>
-                {
-                    if (exists)
-                    {
-                        var previousWeight = _weightCalculator(current);
-                        InputWeightExtensions.Add(ref current, input);
-                        var newWeight = _weightCalculator(current);
-
-                        var difference = newWeight - previousWeight;
-                        if (difference != 0)
-                        {
-                            outputWeights.Add(difference);
-                            foundOffsets.Add(i);
-                            iterations.Add(msg.Data.Iterations[i]);
-                        }
-
-                        if (current.IsAllZero())
-                        {
-                            return (current, GenericWriteOperation.Delete);
-                        }
-                        return (current, GenericWriteOperation.Upsert);
-                    }
-                    var weight = _weightCalculator(input);
-                    if (weight != 0)
-                    {
-                        iterations.Add(msg.Data.Iterations[i]);
-                        outputWeights.Add(weight);
-                        foundOffsets.Add(i);
-                    }
-                    return (input, GenericWriteOperation.Upsert);
-                });
             }
+
+            PrimitiveList<int> foundOffsets = new PrimitiveList<int>(MemoryAllocator, rowCount);
+            PrimitiveList<int> outputWeights = new PrimitiveList<int>(MemoryAllocator, rowCount);
+            PrimitiveList<uint> iterations = new PrimitiveList<uint>(MemoryAllocator, rowCount);
+
+            var sortedIndices = SortBatch(batchData, rowCount);
+            var batchByteSize = batchData.GetByteSize() + (rowCount * Unsafe.SizeOf<TStruct>());
+
+            // Apply the whole batch, mutator collects the output
+            await _bulkInserter.ApplyBatch(
+                keys,
+                values,
+                rowCount,
+                sortedIndices,
+                _duplicateTagsBuffer,
+                new SetWeightsMutator<TStruct>(_weightCalculator, msg.Data.Iterations, foundOffsets, outputWeights, iterations),
+                batchByteSize);
 
             if (outputWeights.Count > 0)
             {
@@ -249,7 +263,7 @@ namespace FlowtideDotNet.Core.Operators.Set
                 IColumn[] outputColumns = new IColumn[_emit.Length];
                 for (int i = 0; i < _emit.Length; i++)
                 {
-                    outputColumns[i] = ColumnWithOffset.CreateFlattened(msg.Data.EventBatchData.Columns[_emit[i]], foundOffsets, MemoryAllocator, out var offsetUsed);
+                    outputColumns[i] = ColumnWithOffset.CreateFlattened(batchData.Columns[_emit[i]], foundOffsets, MemoryAllocator, out var offsetUsed);
                     if (offsetUsed)
                     {
                         shouldDisposeOffsets = false;
@@ -273,10 +287,48 @@ namespace FlowtideDotNet.Core.Operators.Set
 
                 yield return new StreamEventBatch(new EventBatchWeighted(outputWeights, iterations, batch));
             }
+            else
+            {
+                foundOffsets.Dispose();
+                outputWeights.Dispose();
+                iterations.Dispose();
+            }
 #if DEBUG_WRITE
             Debug.Assert(allInput != null);
             allInput.Flush();
 #endif
+        }
+
+        /// <summary>
+        /// Sort by the full row and tag duplicates.
+        /// </summary>
+        private int[] SortBatch(EventBatchData batchData, int rowCount)
+        {
+            if (_sortedIndicesBuffer.Length < rowCount)
+            {
+                _sortedIndicesBuffer = new int[rowCount];
+                _duplicateTagsBuffer = new int[rowCount];
+            }
+            for (int i = 0; i < rowCount; i++)
+            {
+                _sortedIndicesBuffer[i] = i;
+            }
+
+            if (_inputLength == 0)
+            {
+                // No columns to sort by, all rows are equal
+                Array.Clear(_duplicateTagsBuffer, 0, rowCount);
+                return _sortedIndicesBuffer;
+            }
+
+            for (int i = 0; i < _inputLength; i++)
+            {
+                _sortColumns[i] = batchData.Columns[i];
+            }
+            var indicesSpan = _sortedIndicesBuffer.AsSpan(0, rowCount);
+            var tagsSpan = _duplicateTagsBuffer.AsSpan(0, rowCount);
+            _batchSorter.SortDataWithTags(_sortColumns, ref indicesSpan, ref tagsSpan);
+            return _sortedIndicesBuffer;
         }
 
         protected override async Task InitializeOrRestore(IStateManagerClient stateManagerClient)
@@ -311,8 +363,10 @@ namespace FlowtideDotNet.Core.Operators.Set
                 Comparer = new ColumnComparer(_inputLength),
                 KeySerializer = new ColumnStoreSerializer(_inputLength, MemoryAllocator),
                 ValueSerializer = new PrimitiveListValueContainerSerializer<TStruct>(MemoryAllocator),
+                UseByteBasedPageSizes = true,
                 MemoryAllocator = MemoryAllocator
             });
+            _bulkInserter = _tree.CreateBulkInserter();
         }
     }
 }

--- a/src/FlowtideDotNet.Core/Operators/Set/SetWeightsMutator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Set/SetWeightsMutator.cs
@@ -1,0 +1,102 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Core.Operators.Set.Structs;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Tree;
+using System.Runtime.CompilerServices;
+
+namespace FlowtideDotNet.Core.Operators.Set
+{
+    /// <summary>
+    /// Adds the input weights and collects the output rows.
+    /// </summary>
+    internal readonly struct SetWeightsMutator<TStruct> : IRowMutator<ColumnRowReference, TStruct>
+        where TStruct : unmanaged, IInputWeight
+    {
+        private readonly Func<TStruct, int> _weightCalculator;
+        private readonly PrimitiveList<uint> _inputIterations;
+        private readonly PrimitiveList<int> _outputOffsets;
+        private readonly PrimitiveList<int> _outputWeights;
+        private readonly PrimitiveList<uint> _outputIterations;
+
+        public SetWeightsMutator(
+            Func<TStruct, int> weightCalculator,
+            PrimitiveList<uint> inputIterations,
+            PrimitiveList<int> outputOffsets,
+            PrimitiveList<int> outputWeights,
+            PrimitiveList<uint> outputIterations)
+        {
+            _weightCalculator = weightCalculator;
+            _inputIterations = inputIterations;
+            _outputOffsets = outputOffsets;
+            _outputWeights = outputWeights;
+            _outputIterations = outputIterations;
+        }
+
+        public void GetSizePrefixSum(ColumnRowReference[] keys, ReadOnlySpan<int> indices, Span<int> sizes)
+        {
+            // All keys come from the same batch
+            var columns = keys[0].referenceBatch.GetColumns_Unsafe();
+            for (int i = 0; i < columns.Length; i++)
+            {
+                columns[i].GetPrefixSumByteSizes(indices, sizes);
+            }
+
+            var valueByteSize = Unsafe.SizeOf<TStruct>();
+            var cumulativeValueBytes = 0;
+            for (int i = 0; i < indices.Length; i++)
+            {
+                cumulativeValueBytes += valueByteSize;
+                sizes[i] += cumulativeValueBytes;
+            }
+        }
+
+        public GenericWriteOperation Process(ColumnRowReference key, bool exists, in TStruct existingData, ref TStruct incomingData, int sortedIndex)
+        {
+            if (exists)
+            {
+                var previousWeight = _weightCalculator(existingData);
+                InputWeightExtensions.Add(ref incomingData, existingData);
+                var newWeight = _weightCalculator(incomingData);
+
+                var difference = newWeight - previousWeight;
+                if (difference != 0)
+                {
+                    AddOutputRow(key.RowIndex, difference);
+                }
+
+                if (incomingData.IsAllZero())
+                {
+                    return GenericWriteOperation.Delete;
+                }
+                return GenericWriteOperation.Upsert;
+            }
+
+            var weight = _weightCalculator(incomingData);
+            if (weight != 0)
+            {
+                AddOutputRow(key.RowIndex, weight);
+            }
+            // Always store, another input can add weight later
+            return GenericWriteOperation.Upsert;
+        }
+
+        private void AddOutputRow(int rowIndex, int weight)
+        {
+            _outputWeights.Add(weight);
+            _outputOffsets.Add(rowIndex);
+            _outputIterations.Add(_inputIterations[rowIndex]);
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/DistributedMode/DistributeOperatorsVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/DistributedMode/DistributeOperatorsVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed under the Apache License, Version 2.0 (the "License")
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -225,6 +225,79 @@ namespace FlowtideDotNet.Core.Optimizer.DistributedMode
                 PartitionKeyColumns = partitionKeyColumns
             });
             return union;
+        }
+
+        public override Relation VisitSetRelation(SetRelation setRelation, object state)
+        {
+            Debug.Assert(_plan != null);
+
+            // Union all keeps no state, there is nothing to gain from distributing it
+            if (_substreamCount < 2 ||
+                setRelation.Operation == SetOperation.UnionAll ||
+                setRelation.Inputs[0].OutputLength == 0)
+            {
+                for (int i = 0; i < setRelation.Inputs.Count; i++)
+                {
+                    setRelation.Inputs[i] = Visit(setRelation.Inputs[i], state);
+                }
+                return setRelation;
+            }
+
+            // The key of a set operation is the whole row, so every input is scattered on all
+            // its columns and equal rows from all the inputs end up in the same substream.
+            var inputLength = setRelation.Inputs[0].OutputLength;
+            var allColumns = new List<int>(inputLength);
+            for (int i = 0; i < inputLength; i++)
+            {
+                allColumns.Add(i);
+            }
+
+            if (setRelation.Inputs.Count == 1 && IsCoPartitionedWithJoinBelow(setRelation.Inputs[0], allColumns))
+            {
+                // A merge join below is partitioned on columns the whole row covers, so every
+                // row is already in one join partition. Distribute the join instead, the lane
+                // pushdown then moves this into the lanes without another shuffle.
+                setRelation.Inputs[0] = Visit(setRelation.Inputs[0], state);
+                return setRelation;
+            }
+
+            var copySubstreams = GetCopySubstreams();
+
+            var references = new Relation[setRelation.Inputs.Count][];
+            for (int i = 0; i < setRelation.Inputs.Count; i++)
+            {
+                // The fields are kept on the exchange, so each one gets its own list
+                List<FieldReference> fields = new List<FieldReference>(inputLength);
+                for (int f = 0; f < inputLength; f++)
+                {
+                    fields.Add(new DirectFieldReference()
+                    {
+                        ReferenceSegment = new StructReferenceSegment() { Field = f }
+                    });
+                }
+                references[i] = AddScatterExchange(setRelation.Inputs[i], fields, copySubstreams);
+            }
+
+            var copies = new Relation[_substreamCount];
+            for (int p = 0; p < _substreamCount; p++)
+            {
+                var inputs = new List<Relation>(setRelation.Inputs.Count);
+                for (int i = 0; i < setRelation.Inputs.Count; i++)
+                {
+                    inputs.Add(references[i][p]);
+                }
+
+                copies[p] = new SetRelation()
+                {
+                    Inputs = inputs,
+                    Operation = setRelation.Operation,
+                    Emit = setRelation.Emit
+                };
+            }
+
+            // The output rows still carry the values they were partitioned on, the mapping
+            // gives null when the emit drops one of them.
+            return GatherCopies(copies, copySubstreams, LanePushdownVisitor.MapColumnsThroughEmit(allColumns, setRelation.Emit));
         }
 
         public override Relation VisitMergeJoinRelation(MergeJoinRelation mergeJoinRelation, object state)

--- a/src/FlowtideDotNet.Core/Optimizer/DistributedMode/LanePushdownVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/DistributedMode/LanePushdownVisitor.cs
@@ -1,4 +1,4 @@
-// Licensed under the Apache License, Version 2.0 (the "License")
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -70,6 +70,40 @@ namespace FlowtideDotNet.Core.Optimizer.DistributedMode
                 return union;
             }
             return projectRelation;
+        }
+
+        public override Relation VisitSetRelation(SetRelation setRelation, object state)
+        {
+            for (int i = 0; i < setRelation.Inputs.Count; i++)
+            {
+                setRelation.Inputs[i] = Visit(setRelation.Inputs[i], state);
+            }
+
+            // Only a single input operation can move into the lanes, the inputs of a multi
+            // input operation are not scattered into the same lanes. Union all is also the
+            // lane union itself, which must not be moved into its own lanes.
+            if (setRelation.Operation == SetOperation.UnionAll ||
+                setRelation.Inputs.Count != 1)
+            {
+                return setRelation;
+            }
+
+            if (setRelation.Inputs[0] is SetRelation union && _laneUnions.TryGetValue(union, out var lane) &&
+                lane.PartitionKeyColumns != null)
+            {
+                // The key is the whole row, so it always covers the lane partition keys
+                PushIntoLanes(lane, input => new SetRelation()
+                {
+                    Inputs = new List<Relation>() { input },
+                    Operation = setRelation.Operation,
+                    Emit = setRelation.Emit,
+                    Hint = setRelation.Hint
+                });
+                // A set operation keeps the columns of its rows, only the emit moves them
+                lane.PartitionKeyColumns = MapColumnsThroughEmit(lane.PartitionKeyColumns, setRelation.Emit);
+                return union;
+            }
+            return setRelation;
         }
 
         public override Relation VisitAggregateRelation(AggregateRelation aggregateRelation, object state)

--- a/src/FlowtideDotNet.Core/Optimizer/GroupByToDistinct/GroupByToDistinctOptimizer.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/GroupByToDistinct/GroupByToDistinctOptimizer.cs
@@ -1,0 +1,95 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Substrait;
+using FlowtideDotNet.Substrait.Relations;
+
+namespace FlowtideDotNet.Core.Optimizer.GroupByToDistinct
+{
+    /// <summary>
+    /// Rewrites a group by without measures into a distinct.
+    /// </summary>
+    internal static class GroupByToDistinctOptimizer
+    {
+        public static Plan Optimize(Plan plan)
+        {
+            var visitor = new GroupByToDistinctVisitor();
+            for (int i = 0; i < plan.Relations.Count; i++)
+            {
+                plan.Relations[i] = visitor.Visit(plan.Relations[i], null!);
+            }
+            return plan;
+        }
+    }
+
+    internal class GroupByToDistinctVisitor : OptimizerBaseVisitor
+    {
+        public override Relation VisitAggregateRelation(AggregateRelation aggregateRelation, object state)
+        {
+            aggregateRelation.Input = Visit(aggregateRelation.Input, state);
+
+            if (!CanRewrite(aggregateRelation))
+            {
+                return aggregateRelation;
+            }
+
+            var groupingExpressions = aggregateRelation.Groupings![0].GroupingExpressions;
+            var inputLength = aggregateRelation.Input.OutputLength;
+
+            // Project the grouping values, emit only those columns
+            var projectEmit = new List<int>(groupingExpressions.Count);
+            for (int i = 0; i < groupingExpressions.Count; i++)
+            {
+                projectEmit.Add(inputLength + i);
+            }
+
+            var projectRelation = new ProjectRelation()
+            {
+                Input = aggregateRelation.Input,
+                Expressions = groupingExpressions,
+                Emit = projectEmit
+            };
+
+            return new SetRelation()
+            {
+                Operation = SetOperation.UnionDistinct,
+                Inputs = new List<Relation>() { projectRelation },
+                // Emit points at the grouping values, keep it
+                Emit = aggregateRelation.Emit,
+                Hint = aggregateRelation.Hint
+            };
+        }
+
+        private static bool CanRewrite(AggregateRelation aggregateRelation)
+        {
+            if (aggregateRelation.Measures != null && aggregateRelation.Measures.Count > 0)
+            {
+                return false;
+            }
+            if (aggregateRelation.Groupings == null)
+            {
+                return false;
+            }
+            // Grouping sets add a grouping id we cant produce
+            if (aggregateRelation.Groupings.Count != 1)
+            {
+                return false;
+            }
+            // Group by with no expressions returns a single row
+            if (aggregateRelation.Groupings[0].GroupingExpressions.Count == 0)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/FlowtideDotNet.Core/Optimizer/Parallelize/ParallelizeVisitor.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/Parallelize/ParallelizeVisitor.cs
@@ -218,6 +218,95 @@ namespace FlowtideDotNet.Core.Optimizer.MergeJoinParallelize
             return setRelation;
         }
 
+        public override Relation VisitSetRelation(SetRelation setRelation, object state)
+        {
+            Debug.Assert(_plan != null);
+
+            // Union all keeps no state, there is nothing to gain from partitioning it
+            if (parallelCount < 2 ||
+                setRelation.Operation == SetOperation.UnionAll ||
+                setRelation.Inputs[0].OutputLength == 0)
+            {
+                for (int i = 0; i < setRelation.Inputs.Count; i++)
+                {
+                    setRelation.Inputs[i] = Visit(setRelation.Inputs[i], state);
+                }
+                return setRelation;
+            }
+
+            // The key of a set operation is the whole row. Every input is scattered on all its
+            // columns, so equal rows from all the inputs end up in the same partition.
+            var inputLength = setRelation.Inputs[0].OutputLength;
+
+            var exchangeIds = new int[setRelation.Inputs.Count];
+            var exchangeLengths = new int[setRelation.Inputs.Count];
+
+            for (int i = 0; i < setRelation.Inputs.Count; i++)
+            {
+                List<ExchangeTarget> exchangeTargets = new List<ExchangeTarget>();
+                for (int p = 0; p < parallelCount; p++)
+                {
+                    exchangeTargets.Add(new StandardOutputExchangeTarget()
+                    {
+                        PartitionIds = new List<int>() { p }
+                    });
+                }
+
+                List<FieldReference> fields = new List<FieldReference>();
+                for (int f = 0; f < inputLength; f++)
+                {
+                    fields.Add(new DirectFieldReference()
+                    {
+                        ReferenceSegment = new StructReferenceSegment() { Field = f }
+                    });
+                }
+
+                var exchange = new ExchangeRelation()
+                {
+                    ExchangeKind = new ScatterExchangeKind()
+                    {
+                        Fields = fields
+                    },
+                    Input = setRelation.Inputs[i],
+                    Targets = exchangeTargets,
+                    PartitionCount = parallelCount
+                };
+
+                exchangeIds[i] = _plan.Relations.Count;
+                exchangeLengths[i] = exchange.OutputLength;
+                _plan.Relations.Add(exchange);
+            }
+
+            SetRelation[] parallelSets = new SetRelation[parallelCount];
+
+            for (int p = 0; p < parallelCount; p++)
+            {
+                var inputs = new List<Relation>();
+                for (int i = 0; i < setRelation.Inputs.Count; i++)
+                {
+                    inputs.Add(new StandardOutputExchangeReferenceRelation()
+                    {
+                        TargetId = p,
+                        ReferenceOutputLength = exchangeLengths[i],
+                        RelationId = exchangeIds[i]
+                    });
+                }
+
+                parallelSets[p] = new SetRelation()
+                {
+                    Inputs = inputs,
+                    Operation = setRelation.Operation,
+                    Emit = setRelation.Emit
+                };
+            }
+
+            return new SetRelation()
+            {
+                Inputs = new List<Relation>(parallelSets),
+                Operation = SetOperation.UnionAll
+            };
+        }
+
         public override Relation VisitMergeJoinRelation(MergeJoinRelation mergeJoinRelation, object state)
         {
             Debug.Assert(_plan != null);

--- a/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
@@ -74,10 +74,8 @@ namespace FlowtideDotNet.Core.Optimizer
                 plan = WindowJoin.TumblingWindowJoinKeyOptimizer.Optimize(plan);
             }
 
-            // Runs before emit optimizations so the projection is simplified.
-            // Aggregates are partitioned in distributed mode, set operations are not.
-            if (settings.GroupByToDistinct &&
-                settings.DistributedPlanOptions == null)
+            // Runs before emit optimizations so the projection is simplified
+            if (settings.GroupByToDistinct)
             {
                 plan = GroupByToDistinct.GroupByToDistinctOptimizer.Optimize(plan);
             }

--- a/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
@@ -74,6 +74,15 @@ namespace FlowtideDotNet.Core.Optimizer
                 plan = WindowJoin.TumblingWindowJoinKeyOptimizer.Optimize(plan);
             }
 
+            // Runs before emit optimizations so the projection is simplified.
+            // Aggregates are partitioned in parallel and distributed mode.
+            if (settings.GroupByToDistinct &&
+                settings.Parallelization <= 1 &&
+                settings.DistributedPlanOptions == null)
+            {
+                plan = GroupByToDistinct.GroupByToDistinctOptimizer.Optimize(plan);
+            }
+
             // Try and remove any direct field references if possible
             if (settings.SimplifyProjection)
             {

--- a/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/PlanOptimizer.cs
@@ -1,4 +1,4 @@
-// Licensed under the Apache License, Version 2.0 (the "License")
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -75,9 +75,8 @@ namespace FlowtideDotNet.Core.Optimizer
             }
 
             // Runs before emit optimizations so the projection is simplified.
-            // Aggregates are partitioned in parallel and distributed mode.
+            // Aggregates are partitioned in distributed mode, set operations are not.
             if (settings.GroupByToDistinct &&
-                settings.Parallelization <= 1 &&
                 settings.DistributedPlanOptions == null)
             {
                 plan = GroupByToDistinct.GroupByToDistinctOptimizer.Optimize(plan);

--- a/src/FlowtideDotNet.Core/Optimizer/PlanOptimizerSettings.cs
+++ b/src/FlowtideDotNet.Core/Optimizer/PlanOptimizerSettings.cs
@@ -37,6 +37,11 @@ namespace FlowtideDotNet.Core.Optimizer
         /// </summary>
         public bool FindCommonSubPlans { get; set; } = true;
 
+        /// <summary>
+        /// Rewrites a group by without measures into a distinct.
+        /// </summary>
+        public bool GroupByToDistinct { get; set; } = true;
+
         public int Parallelization { get; set; } = 1;
 
         public bool TryAddWatermarkOutputMode { get; set; } = true;

--- a/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/AggregateTests.cs
@@ -3369,5 +3369,89 @@ namespace FlowtideDotNet.AcceptanceTests
                 AssertExpected();
             }
         }
+
+        /// <summary>
+        /// Group by without measures, with and without the rewrite.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GroupByWithoutMeasures(bool groupByToDistinct)
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                AddUser(new Entities.User
+                {
+                    UserKey = i,
+                    CompanyId = "co_" + (i % 10),
+                    Visits = i % 5 == 0 ? null : i % 4
+                });
+            }
+
+            await StartStream(@"
+                INSERT INTO output
+                SELECT companyId, visits
+                FROM users
+                GROUP BY companyId, visits",
+                planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings { GroupByToDistinct = groupByToDistinct });
+
+            void AssertExpected()
+            {
+                AssertCurrentDataEqual(Users.Select(x => new { x.CompanyId, x.Visits }).Distinct().ToList());
+            }
+
+            await WaitForUpdate();
+            AssertExpected();
+
+            // All combinations still have members left
+            foreach (var user in Users.Where(x => x.UserKey % 3 == 0).ToList())
+            {
+                DeleteUser(user);
+            }
+            await WaitForUpdate();
+            AssertExpected();
+
+            // Removes the combinations that have three visits
+            foreach (var user in Users.Where(x => x.Visits == 3).ToList())
+            {
+                DeleteUser(user);
+            }
+            await WaitForUpdate();
+            AssertExpected();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GroupByWithoutMeasuresOnExpression(bool groupByToDistinct)
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                AddUser(new Entities.User { UserKey = i, CompanyId = "co_" + (i % 10), Visits = i % 4 });
+            }
+
+            await StartStream(@"
+                INSERT INTO output
+                SELECT visits + 1
+                FROM users
+                GROUP BY visits + 1",
+                planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings { GroupByToDistinct = groupByToDistinct });
+
+            void AssertExpected()
+            {
+                AssertCurrentDataEqual(Users.Select(x => new { Value = x.Visits + 1 }).Distinct().ToList());
+            }
+
+            await WaitForUpdate();
+            AssertExpected();
+
+            // Removes one of the values completely
+            foreach (var user in Users.Where(x => x.Visits == 2).ToList())
+            {
+                DeleteUser(user);
+            }
+            await WaitForUpdate();
+            AssertExpected();
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/Distributed/DistributedStreamE2ETests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/Distributed/DistributedStreamE2ETests.cs
@@ -1,4 +1,4 @@
-// Licensed under the Apache License, Version 2.0 (the "License")
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -4016,6 +4016,200 @@ namespace FlowtideDotNet.AcceptanceTests.Distributed
             })
             .Select(x => new UserKeyRow(x.UserKey))
             .ToList();
+        }
+
+        /// <summary>
+        /// A set operation is partitioned across the substreams, both of its inputs must be
+        /// scattered the same way for equal rows to meet in the same substream.
+        /// </summary>
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task DistributedUnionDistinctProducesCorrectOutput(int substreamCount)
+        {
+            _generator.Generate(500);
+
+            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
+            var testName = $"e2e_union_distinct_{substreamCount}";
+
+            _stream = new DistributedStreamBuilder(testName)
+                .AddPlan(() =>
+                {
+                    var sqlPlanBuilder = new SqlPlanBuilder();
+                    sqlPlanBuilder.AddTableProvider(new DatasetTableProvider(_db));
+                    sqlPlanBuilder.Sql(@"
+                    INSERT INTO output
+                    SELECT userkey FROM users
+                    UNION DISTINCT
+                    SELECT userkey FROM orders;
+                    ");
+                    return sqlPlanBuilder.GetPlan();
+                })
+                .WithStateOptionsFactory((streamName, substreamName) => CreateStateOptions(testName, substreamName))
+                .ConfigureSubstream((substreamName, substreamBuilder) =>
+                {
+                    var connectorManager = new ConnectorManager();
+                    connectorManager.AddSource(new MockSourceFactory("*", _db, false));
+                    connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, watermark => { }));
+                    substreamBuilder.AddConnectorManager(connectorManager);
+                    substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
+                })
+                .DistributeAutomatically(substreamCount)
+                .Build();
+
+            await _stream.StartAsync();
+
+            await WaitForSinkData(latestData, failures, "substream_0", GetExpectedUnionDistinctResult());
+
+            _generator.Generate(500);
+
+            await WaitForSinkData(latestData, failures, "substream_0", GetExpectedUnionDistinctResult());
+
+            // Deleting from one input must not remove a value the other input still has
+            foreach (var order in _generator.Orders.Take(100).ToList())
+            {
+                _generator.DeleteOrder(order);
+            }
+
+            await WaitForSinkData(latestData, failures, "substream_0", GetExpectedUnionDistinctResult());
+
+            Assert.Empty(failures);
+        }
+
+        private List<UserKeyRow> GetExpectedUnionDistinctResult()
+        {
+            return _generator.Users.Select(x => (long)x.UserKey)
+                .Union(_generator.Orders.Select(x => (long)x.UserKey))
+                .Select(x => new UserKeyRow(x))
+                .ToList();
+        }
+
+        /// <summary>
+        /// The rows that cancel each other sit in different inputs, they only meet when both
+        /// inputs are scattered into the same substream.
+        /// </summary>
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public async Task DistributedExceptProducesCorrectOutput(int substreamCount)
+        {
+            _generator.Generate(500);
+
+            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
+            var testName = $"e2e_except_{substreamCount}";
+
+            _stream = new DistributedStreamBuilder(testName)
+                .AddPlan(() =>
+                {
+                    var sqlPlanBuilder = new SqlPlanBuilder();
+                    sqlPlanBuilder.AddTableProvider(new DatasetTableProvider(_db));
+                    sqlPlanBuilder.Sql(@"
+                    INSERT INTO output
+                    SELECT userkey FROM users
+                    EXCEPT DISTINCT
+                    SELECT userkey FROM orders;
+                    ");
+                    return sqlPlanBuilder.GetPlan();
+                })
+                .WithStateOptionsFactory((streamName, substreamName) => CreateStateOptions(testName, substreamName))
+                .ConfigureSubstream((substreamName, substreamBuilder) =>
+                {
+                    var connectorManager = new ConnectorManager();
+                    connectorManager.AddSource(new MockSourceFactory("*", _db, false));
+                    connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, watermark => { }));
+                    substreamBuilder.AddConnectorManager(connectorManager);
+                    substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
+                })
+                .DistributeAutomatically(substreamCount)
+                .Build();
+
+            await _stream.StartAsync();
+
+            await WaitForSinkData(latestData, failures, "substream_0", GetExpectedExceptResult());
+
+            // Removing the orders of a user brings that user back into the output
+            foreach (var order in _generator.Orders.Take(100).ToList())
+            {
+                _generator.DeleteOrder(order);
+            }
+
+            await WaitForSinkData(latestData, failures, "substream_0", GetExpectedExceptResult());
+
+            Assert.Empty(failures);
+        }
+
+        private List<UserKeyRow> GetExpectedExceptResult()
+        {
+            return _generator.Users.Select(x => (long)x.UserKey)
+                .Distinct()
+                .Except(_generator.Orders.Select(x => (long)x.UserKey).Distinct())
+                .Select(x => new UserKeyRow(x))
+                .ToList();
+        }
+
+        /// <summary>
+        /// A distinct on the join key stays inside the partition lanes, the join is already
+        /// partitioned on it so no second shuffle is added.
+        /// </summary>
+        [Fact]
+        public async Task CoPartitionedDistinctOverJoinIsDistributed()
+        {
+            _generator.Generate(500);
+
+            var latestData = new ConcurrentDictionary<string, EventBatchData>();
+            var failures = new ConcurrentBag<(string Substream, Exception? Exception)>();
+
+            _stream = new DistributedStreamBuilder("e2e_distinct_over_join")
+                .AddPlan(() =>
+                {
+                    var sqlPlanBuilder = new SqlPlanBuilder();
+                    sqlPlanBuilder.AddTableProvider(new DatasetTableProvider(_db));
+                    sqlPlanBuilder.Sql(@"
+                    INSERT INTO output
+                    SELECT DISTINCT o.userkey FROM orders o
+                    INNER JOIN users u ON o.userkey = u.userkey;
+                    ");
+                    return sqlPlanBuilder.GetPlan();
+                })
+                .WithStateOptionsFactory((streamName, substreamName) => CreateStateOptions("e2e_distinct_over_join", substreamName))
+                .ConfigureSubstream((substreamName, substreamBuilder) =>
+                {
+                    var connectorManager = new ConnectorManager();
+                    connectorManager.AddSource(new MockSourceFactory("*", _db, false));
+                    connectorManager.AddSink(new MockSinkFactory("*", data => latestData[substreamName] = data, 0, watermark => { }));
+                    substreamBuilder.AddConnectorManager(connectorManager);
+                    substreamBuilder.WithFailureListener(e => failures.Add((substreamName, e)));
+                })
+                .DistributeAutomatically(2)
+                .Build();
+
+            await _stream.StartAsync();
+
+            await WaitForSinkData(latestData, failures, "substream_0", GetExpectedDistinctOverJoinResult());
+
+            _generator.Generate(500);
+
+            await WaitForSinkData(latestData, failures, "substream_0", GetExpectedDistinctOverJoinResult());
+
+            foreach (var order in _generator.Orders.Take(100).ToList())
+            {
+                _generator.DeleteOrder(order);
+            }
+
+            await WaitForSinkData(latestData, failures, "substream_0", GetExpectedDistinctOverJoinResult());
+
+            Assert.Empty(failures);
+        }
+
+        private List<UserKeyRow> GetExpectedDistinctOverJoinResult()
+        {
+            return _generator.Orders
+                .Join(_generator.Users, o => o.UserKey, u => u.UserKey, (o, u) => (long)o.UserKey)
+                .Distinct()
+                .Select(x => new UserKeyRow(x))
+                .ToList();
         }
 
         private record UserKeyRow(long UserKey);

--- a/tests/FlowtideDotNet.AcceptanceTests/SetTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/SetTests.cs
@@ -384,5 +384,164 @@ namespace FlowtideDotNet.AcceptanceTests
 
             AssertCurrentDataEqual(expected);
         }
+
+        /// <summary>
+        /// Partitioned distinct, equal rows must land in the same partition.
+        /// </summary>
+        [Theory]
+        [InlineData(2)]
+        [InlineData(4)]
+        public async Task TestUnionDistinctParallel(int parallelization)
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                AddUser(new Entities.User { UserKey = i, FirstName = "n" + (i % 250) });
+            }
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT FirstName FROM users WHERE UserKey < 500
+            UNION DISTINCT
+            SELECT FirstName FROM users WHERE UserKey >= 500",
+            planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings() { Parallelization = parallelization });
+
+            void AssertExpected()
+            {
+                AssertCurrentDataEqual(Users.Select(x => new { x.FirstName }).Distinct().ToList());
+            }
+
+            await WaitForUpdate();
+            AssertExpected();
+
+            // Removes some values completely, others keep members
+            foreach (var user in Users.Where(x => (x.UserKey % 250) < 20).ToList())
+            {
+                DeleteUser(user);
+            }
+            await WaitForUpdate();
+            AssertExpected();
+        }
+
+        /// <summary>
+        /// Both inputs are the same subplan and share a reference to it.
+        /// </summary>
+        [Theory]
+        [InlineData(2)]
+        [InlineData(4)]
+        public async Task TestUnionDistinctParallelSharedInput(int parallelization)
+        {
+            GenerateData();
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT UserKey FROM users
+            UNION DISTINCT
+            SELECT UserKey FROM users",
+            planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings() { Parallelization = parallelization });
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(Users.Select(u => new { u.UserKey }).ToList());
+        }
+
+        /// <summary>
+        /// Both inputs must be scattered the same way for the rows to meet.
+        /// </summary>
+        [Theory]
+        [InlineData(2)]
+        [InlineData(4)]
+        public async Task TestExceptAllParallel(int parallelization)
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                AddUser(new Entities.User { UserKey = i, FirstName = "n" + (i % 100) });
+            }
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT FirstName FROM users
+            EXCEPT ALL
+            SELECT FirstName FROM users WHERE UserKey < 500",
+            planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings() { Parallelization = parallelization });
+
+            await WaitForUpdate();
+            AssertCurrentDataEqual(ExpectedExceptAllByFirstName());
+
+            foreach (var user in Users.Where(x => x.UserKey % 10 == 7).ToList())
+            {
+                DeleteUser(user);
+            }
+            await WaitForUpdate();
+            AssertCurrentDataEqual(ExpectedExceptAllByFirstName());
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(4)]
+        public async Task TestIntersectDistinctParallel(int parallelization)
+        {
+            for (int i = 0; i < 600; i++)
+            {
+                AddUser(new Entities.User { UserKey = i, FirstName = "n" + (i % 200) });
+            }
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT FirstName FROM users
+            INTERSECT DISTINCT
+            SELECT FirstName FROM users WHERE UserKey % 2 = 0",
+            planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings() { Parallelization = parallelization });
+
+            await WaitForUpdate();
+            AssertCurrentDataEqual(ExpectedIntersectByFirstName());
+
+            foreach (var user in Users.Where(x => x.UserKey % 2 == 0 && (x.UserKey % 200) % 4 == 0).ToList())
+            {
+                DeleteUser(user);
+            }
+            await WaitForUpdate();
+            AssertCurrentDataEqual(ExpectedIntersectByFirstName());
+        }
+
+        /// <summary>
+        /// A group by without measures becomes a distinct, it must still partition.
+        /// </summary>
+        [Theory]
+        [InlineData(2)]
+        [InlineData(4)]
+        public async Task TestGroupByWithoutMeasuresParallel(int parallelization)
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                AddUser(new Entities.User
+                {
+                    UserKey = i,
+                    CompanyId = "co_" + (i % 10),
+                    Visits = i % 5 == 0 ? null : i % 4
+                });
+            }
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT companyId, visits
+            FROM users
+            GROUP BY companyId, visits",
+            planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings() { Parallelization = parallelization });
+
+            void AssertExpected()
+            {
+                AssertCurrentDataEqual(Users.Select(x => new { x.CompanyId, x.Visits }).Distinct().ToList());
+            }
+
+            await WaitForUpdate();
+            AssertExpected();
+
+            foreach (var user in Users.Where(x => x.Visits == 3).ToList())
+            {
+                DeleteUser(user);
+            }
+            await WaitForUpdate();
+            AssertExpected();
+        }
     }
 }

--- a/tests/FlowtideDotNet.AcceptanceTests/SetTests.cs
+++ b/tests/FlowtideDotNet.AcceptanceTests/SetTests.cs
@@ -217,5 +217,172 @@ namespace FlowtideDotNet.AcceptanceTests
 
             AssertCurrentDataEqual(expected);
         }
+
+        /// <summary>
+        /// Tiny pages so a batch hits many leaves.
+        /// </summary>
+        [Fact]
+        public async Task TestUnionDistinctMultipleLeaves()
+        {
+            SetPageSizeBytes(256);
+            for (int i = 0; i < 1000; i++)
+            {
+                AddUser(new Entities.User { UserKey = i, FirstName = "n" + i });
+            }
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT UserKey FROM users
+            UNION DISTINCT
+            SELECT UserKey + 500 FROM users");
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(
+                Users.Select(x => new { x.UserKey })
+                    .Union(Users.Select(x => new { UserKey = x.UserKey + 500 }))
+                    .ToList());
+
+            // Delete every third user in one batch
+            foreach (var user in Users.Where(x => x.UserKey % 3 == 0).ToList())
+            {
+                DeleteUser(user);
+            }
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(
+                Users.Select(x => new { x.UserKey })
+                    .Union(Users.Select(x => new { UserKey = x.UserKey + 500 }))
+                    .ToList());
+        }
+
+        /// <summary>
+        /// Same value ten times, tests duplicates in a batch.
+        /// </summary>
+        [Fact]
+        public async Task TestExceptAllMultipleLeavesWithDuplicateRows()
+        {
+            SetPageSizeBytes(256);
+            for (int i = 0; i < 1000; i++)
+            {
+                AddUser(new Entities.User { UserKey = i, FirstName = "n" + (i % 100) });
+            }
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT FirstName FROM users
+            EXCEPT ALL
+            SELECT FirstName FROM users WHERE UserKey < 500");
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(ExpectedExceptAllByFirstName());
+
+            // Delete rows on both sides at once
+            foreach (var user in Users.Where(x => x.UserKey % 10 == 7).ToList())
+            {
+                DeleteUser(user);
+            }
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(ExpectedExceptAllByFirstName());
+        }
+
+        private class FirstNameRow
+        {
+            public string? FirstName { get; set; }
+        }
+
+        private List<FirstNameRow> ExpectedExceptAllByFirstName()
+        {
+            return Users
+                .GroupBy(x => x.FirstName)
+                .SelectMany(g => Enumerable.Repeat(
+                    new FirstNameRow() { FirstName = g.Key },
+                    g.Count() - g.Count(u => u.UserKey < 500)))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Values disappear from one input over many leaves.
+        /// </summary>
+        [Fact]
+        public async Task TestIntersectDistinctMultipleLeavesWithDeletes()
+        {
+            SetPageSizeBytes(256);
+            for (int i = 0; i < 600; i++)
+            {
+                AddUser(new Entities.User { UserKey = i, FirstName = "n" + (i % 200) });
+            }
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT FirstName FROM users
+            INTERSECT DISTINCT
+            SELECT FirstName FROM users WHERE UserKey % 2 = 0");
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(ExpectedIntersectByFirstName());
+
+            // These users share parity, removes the value completely
+            foreach (var user in Users.Where(x => x.UserKey % 2 == 0 && (x.UserKey % 200) % 4 == 0).ToList())
+            {
+                DeleteUser(user);
+            }
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(ExpectedIntersectByFirstName());
+        }
+
+        private List<FirstNameRow> ExpectedIntersectByFirstName()
+        {
+            var right = Users.Where(x => x.UserKey % 2 == 0).Select(x => x.FirstName).ToHashSet();
+            return Users
+                .Select(x => x.FirstName)
+                .Where(x => right.Contains(x))
+                .Distinct()
+                .Select(x => new FirstNameRow() { FirstName = x })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Rename rotation deletes and adds a value in one batch.
+        /// </summary>
+        [Fact]
+        public async Task TestUnionDistinctMultipleLeavesWithRenameRotation()
+        {
+            SetPageSizeBytes(256);
+            const int userCount = 600;
+            for (int i = 0; i < userCount; i++)
+            {
+                AddUser(new Entities.User { UserKey = i, FirstName = "n" + i });
+            }
+
+            await StartStream(@"
+            INSERT INTO output
+            SELECT FirstName FROM users WHERE UserKey < 500
+            UNION DISTINCT
+            SELECT FirstName FROM users WHERE UserKey >= 500");
+
+            await WaitForUpdate();
+
+            var expected = Users.Select(x => new { x.FirstName }).Distinct().ToList();
+            AssertCurrentDataEqual(expected);
+
+            var namesByUserKey = Users.OrderBy(x => x.UserKey).Select(x => x.FirstName).ToList();
+            foreach (var user in Users.OrderBy(x => x.UserKey).ToList())
+            {
+                user.FirstName = namesByUserKey[(user.UserKey + 1) % userCount];
+                AddOrUpdateUser(user);
+            }
+
+            await WaitForUpdate();
+
+            AssertCurrentDataEqual(expected);
+        }
     }
 }

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnComparerBoundaryTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/ColumnComparerBoundaryTests.cs
@@ -1,0 +1,98 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Core.ColumnStore.DataValues;
+using FlowtideDotNet.Core.ColumnStore.TreeStorage;
+using FlowtideDotNet.Storage.Memory;
+using FlowtideDotNet.Storage.Tree;
+
+namespace FlowtideDotNet.Core.Tests.ColumnStore
+{
+    /// <summary>
+    /// An empty key container is the normal state of the root leaf before the first insert,
+    /// the boundary search must report not found instead of a bound inside the container.
+    /// </summary>
+    public class ColumnComparerBoundaryTests
+    {
+        private static ColumnRowReference CreateKey(long value)
+        {
+            var column = Column.Create(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(value));
+            return new ColumnRowReference()
+            {
+                referenceBatch = new EventBatchData(new IColumn[] { column }),
+                RowIndex = 0
+            };
+        }
+
+        [Fact]
+        public void FindBoundriesOnEmptyContainerReportsNotFound()
+        {
+            var comparer = new ColumnComparer(1);
+            var container = new ColumnKeyStorageContainer(1, GlobalMemoryManager.Instance);
+            var key = CreateKey(5);
+
+            var result = comparer.FindBoundries(key, container, 0, container.Count - 1);
+
+            // Not found, the insert position is the bitwise complement of index 0
+            Assert.True(result.lowerBounds < 0);
+            Assert.Equal(0, ~result.lowerBounds);
+            Assert.True(result.upperBounds < 0);
+        }
+
+        [Fact]
+        public void FindBoundriesBulkOnEmptyContainerReportsNotFound()
+        {
+            IBplusTreeComparer<ColumnRowReference, ColumnKeyStorageContainer> comparer = new ColumnComparer(1);
+            var container = new ColumnKeyStorageContainer(1, GlobalMemoryManager.Instance);
+            var keys = new ColumnRowReference[] { CreateKey(5) };
+
+            var lowerBounds = new int[1];
+            var upperBounds = new int[1];
+            var lookupBuffer = new int[1];
+
+            comparer.FindBoundriesBulk(keys, new int[] { 0 }, container, lowerBounds, upperBounds, lookupBuffer);
+
+            Assert.True(lowerBounds[0] < 0);
+            Assert.Equal(0, ~lowerBounds[0]);
+        }
+
+        [Fact]
+        public void FindBoundriesBulkWithNoLookupsDoesNothing()
+        {
+            IBplusTreeComparer<ColumnRowReference, ColumnKeyStorageContainer> comparer = new ColumnComparer(1);
+            var container = new ColumnKeyStorageContainer(1, GlobalMemoryManager.Instance);
+            var keys = new ColumnRowReference[] { CreateKey(5) };
+
+            comparer.FindBoundriesBulk(keys, Array.Empty<int>(), container, Array.Empty<int>(), Array.Empty<int>(), Array.Empty<int>());
+        }
+
+        [Fact]
+        public void FindBoundriesFindsTheRowInANonEmptyContainer()
+        {
+            var comparer = new ColumnComparer(1);
+            var container = new ColumnKeyStorageContainer(1, GlobalMemoryManager.Instance);
+            container.Add(CreateKey(1));
+            container.Add(CreateKey(3));
+            container.Add(CreateKey(5));
+
+            var found = comparer.FindBoundries(CreateKey(3), container, 0, container.Count - 1);
+            Assert.Equal(1, found.lowerBounds);
+            Assert.Equal(1, found.upperBounds);
+
+            var missing = comparer.FindBoundries(CreateKey(4), container, 0, container.Count - 1);
+            Assert.True(missing.lowerBounds < 0);
+            Assert.Equal(2, ~missing.lowerBounds);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Core.Tests/OptimizerTests/DistributedPlanModifierTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/OptimizerTests/DistributedPlanModifierTests.cs
@@ -1,4 +1,4 @@
-// Licensed under the Apache License, Version 2.0 (the "License")
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -12,6 +12,7 @@
 
 using FlowtideDotNet.Core.Optimizer;
 using FlowtideDotNet.Core.Optimizer.DistributedMode;
+using FlowtideDotNet.Substrait.Expressions;
 using FlowtideDotNet.Substrait.Relations;
 using FlowtideDotNet.Substrait.Sql;
 
@@ -362,6 +363,101 @@ namespace FlowtideDotNet.Core.Tests.OptimizerTests
                     Assert.Equal(iterationRoot.Name, consumerRoot.Name);
                 }
             }
+        }
+
+        /// <summary>
+        /// A set operation is distributed with one scatter exchange per input, both scattered
+        /// on the whole row so equal rows from both inputs land in the same substream.
+        /// </summary>
+        [Fact]
+        public void DistributedSetOperationScattersEveryInput()
+        {
+            var sqlPlanBuilder = new SqlPlanBuilder();
+            sqlPlanBuilder.Sql(@"
+            CREATE TABLE users (userkey any);
+            CREATE TABLE orders (orderkey any, userkey any);
+
+            INSERT INTO output
+            SELECT userkey FROM users
+            EXCEPT DISTINCT
+            SELECT userkey FROM orders;
+            ");
+            var plan = sqlPlanBuilder.GetPlan();
+
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings()
+            {
+                DistributedPlanOptions = new DistributedPlanOptions()
+                {
+                    SubstreamCount = 2
+                }
+            });
+
+            // Sink root, one scatter exchange per input and one gather exchange
+            Assert.Equal(4, plan.Relations.Count);
+
+            var scatterRoots = plan.Relations
+                .OfType<SubStreamRootRelation>()
+                .Where(x => x.Input is ExchangeRelation exchange && exchange.PartitionCount == 2)
+                .ToList();
+            Assert.Equal(2, scatterRoots.Count);
+
+            foreach (var scatterRoot in scatterRoots)
+            {
+                var exchange = (ExchangeRelation)scatterRoot.Input;
+                var scatter = Assert.IsType<ScatterExchangeKind>(exchange.ExchangeKind);
+                // Both inputs carry a single column, the whole row is the key
+                var field = Assert.Single(scatter.Fields);
+                var segment = Assert.IsType<StructReferenceSegment>(Assert.IsType<DirectFieldReference>(field).ReferenceSegment);
+                Assert.Equal(0, segment.Field);
+            }
+
+            // The partition copy in the other substream runs inside its gather exchange
+            var gatherRoot = plan.Relations
+                .OfType<SubStreamRootRelation>()
+                .Single(x => x.Input is ExchangeRelation exchange && exchange.PartitionCount == 1);
+            var gatherExchange = (ExchangeRelation)gatherRoot.Input;
+            var copy = Assert.IsType<SetRelation>(gatherExchange.Input);
+            Assert.Equal(SetOperation.MinusPrimary, copy.Operation);
+            Assert.Equal(2, copy.Inputs.Count);
+        }
+
+        /// <summary>
+        /// A distinct on the join key should stay in the partition lanes, the key is the whole
+        /// row so it always covers the lane partition keys.
+        /// </summary>
+        [Fact]
+        public void CoPartitionedDistinctStaysInLane()
+        {
+            var sqlPlanBuilder = new SqlPlanBuilder();
+            sqlPlanBuilder.Sql(@"
+            CREATE TABLE users (userkey any);
+            CREATE TABLE orders (orderkey any, userkey any);
+
+            INSERT INTO output
+            SELECT DISTINCT o.userkey FROM orders o
+            INNER JOIN users u ON o.userkey = u.userkey;
+            ");
+            var plan = sqlPlanBuilder.GetPlan();
+
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings()
+            {
+                DistributedPlanOptions = new DistributedPlanOptions()
+                {
+                    SubstreamCount = 2
+                }
+            });
+
+            // Sink root, two join scatter exchanges and one gather exchange.
+            // There must be no separate scatter exchange for the distinct.
+            Assert.Equal(4, plan.Relations.Count);
+
+            var gatherRoot = plan.Relations
+                .OfType<SubStreamRootRelation>()
+                .Single(x => x.Input is ExchangeRelation exchange && exchange.PartitionCount == 1);
+            var gatherExchange = (ExchangeRelation)gatherRoot.Input;
+            var laneDistinct = Assert.IsType<SetRelation>(gatherExchange.Input);
+            Assert.Equal(SetOperation.UnionDistinct, laneDistinct.Operation);
+            Assert.True(ContainsRelation<MergeJoinRelation>(gatherExchange.Input), "The join partition should run inside the lane");
         }
 
         private static bool ContainsRelation<T>(Relation root) where T : Relation

--- a/tests/FlowtideDotNet.Core.Tests/OptimizerTests/GroupByToDistinctTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/OptimizerTests/GroupByToDistinctTests.cs
@@ -1,0 +1,275 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.Optimizer;
+using FlowtideDotNet.Substrait.Expressions;
+using FlowtideDotNet.Substrait.FunctionExtensions;
+using FlowtideDotNet.Substrait.Relations;
+using FlowtideDotNet.Substrait.Sql;
+
+namespace FlowtideDotNet.Core.Tests.OptimizerTests
+{
+    public class GroupByToDistinctTests
+    {
+        private const string CreateTable = "CREATE TABLE table1 (col1 any, col2 any, col3 any);";
+
+        private static Substrait.Plan BuildPlan(string sql)
+        {
+            var sqlPlanBuilder = new SqlPlanBuilder();
+            sqlPlanBuilder.Sql(CreateTable + sql);
+            return sqlPlanBuilder.GetPlan();
+        }
+
+        private static List<Relation> CollectRelations(Relation root)
+        {
+            var result = new List<Relation>();
+            void Collect(Relation relation)
+            {
+                result.Add(relation);
+                switch (relation)
+                {
+                    case FilterRelation r: Collect(r.Input); break;
+                    case ProjectRelation r: Collect(r.Input); break;
+                    case AggregateRelation r: Collect(r.Input); break;
+                    case JoinRelation r: Collect(r.Left); Collect(r.Right); break;
+                    case MergeJoinRelation r: Collect(r.Left); Collect(r.Right); break;
+                    case SetRelation r: r.Inputs.ForEach(Collect); break;
+                    case SortRelation r: Collect(r.Input); break;
+                    case WriteRelation r: Collect(r.Input); break;
+                    case RootRelation r: Collect(r.Input); break;
+                    case TableFunctionRelation r when r.Input != null: Collect(r.Input); break;
+                    case ExchangeRelation r: Collect(r.Input); break;
+                }
+            }
+            Collect(root);
+            return result;
+        }
+
+        private static List<Relation> CollectRelations(Substrait.Plan plan)
+        {
+            return plan.Relations.SelectMany(CollectRelations).ToList();
+        }
+
+        [Fact]
+        public void GroupByWithoutMeasuresBecomesDistinct()
+        {
+            var plan = BuildPlan(@"
+                INSERT INTO output
+                SELECT col1, col2, col3 FROM table1 GROUP BY col1, col2, col3");
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings());
+
+            var relations = CollectRelations(plan);
+
+            Assert.Empty(relations.OfType<AggregateRelation>());
+            var setRelation = Assert.Single(relations.OfType<SetRelation>());
+            Assert.Equal(SetOperation.UnionDistinct, setRelation.Operation);
+            Assert.Single(setRelation.Inputs);
+            Assert.Equal(3, setRelation.OutputLength);
+        }
+
+        /// <summary>
+        /// The rewrite gives the same input as DISTINCT.
+        /// </summary>
+        [Fact]
+        public void RewrittenGroupByFeedsTheSameInputAsDistinct()
+        {
+            var groupByPlan = BuildPlan(@"
+                INSERT INTO output
+                SELECT col1, col2 FROM table1 GROUP BY col1, col2");
+            groupByPlan = PlanOptimizer.Optimize(groupByPlan, new PlanOptimizerSettings());
+
+            var distinctPlan = BuildPlan(@"
+                INSERT INTO output
+                SELECT DISTINCT col1, col2 FROM table1");
+            distinctPlan = PlanOptimizer.Optimize(distinctPlan, new PlanOptimizerSettings());
+
+            var groupBySet = Assert.Single(CollectRelations(groupByPlan).OfType<SetRelation>());
+            var distinctSet = Assert.Single(CollectRelations(distinctPlan).OfType<SetRelation>());
+
+            Assert.Equal(distinctSet.Operation, groupBySet.Operation);
+            Assert.Equal(distinctSet.Inputs.Count, groupBySet.Inputs.Count);
+            Assert.Equal(distinctSet.Inputs[0], groupBySet.Inputs[0]);
+            Assert.Equal(distinctSet.OutputLength, groupBySet.OutputLength);
+        }
+
+        [Fact]
+        public void GroupByOnExpressionBecomesDistinct()
+        {
+            var plan = BuildPlan(@"
+                INSERT INTO output
+                SELECT col1 + col2 FROM table1 GROUP BY col1 + col2");
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings());
+
+            var relations = CollectRelations(plan);
+
+            Assert.Empty(relations.OfType<AggregateRelation>());
+            var setRelation = Assert.Single(relations.OfType<SetRelation>());
+            Assert.Equal(SetOperation.UnionDistinct, setRelation.Operation);
+            Assert.Equal(1, setRelation.OutputLength);
+
+            // The addition is computed before the distinct
+            var project = Assert.IsType<ProjectRelation>(setRelation.Inputs[0]);
+            var expression = Assert.Single(project.Expressions);
+            var function = Assert.IsType<ScalarFunction>(expression);
+            Assert.Equal(FunctionsArithmetic.Add, function.ExtensionName);
+            Assert.Equal(1, project.OutputLength);
+        }
+
+        /// <summary>
+        /// Having filter uses the same output positions.
+        /// </summary>
+        [Fact]
+        public void GroupByWithHavingBecomesDistinctWithFilter()
+        {
+            var plan = BuildPlan(@"
+                INSERT INTO output
+                SELECT col1 FROM table1 GROUP BY col1 HAVING col1 > 5");
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings());
+
+            var relations = CollectRelations(plan);
+
+            Assert.Empty(relations.OfType<AggregateRelation>());
+            var setRelation = Assert.Single(relations.OfType<SetRelation>());
+            Assert.Equal(SetOperation.UnionDistinct, setRelation.Operation);
+
+            var filter = Assert.Single(relations.OfType<FilterRelation>());
+            var condition = Assert.IsType<ScalarFunction>(filter.Condition);
+            Assert.Equal(FunctionsComparison.GreaterThan, condition.ExtensionName);
+            var field = Assert.IsType<DirectFieldReference>(condition.Arguments[0]);
+            var segment = Assert.IsType<StructReferenceSegment>(field.ReferenceSegment);
+            Assert.Equal(0, segment.Field);
+        }
+
+        [Fact]
+        public void GroupByWithMeasureIsNotRewritten()
+        {
+            var plan = BuildPlan(@"
+                INSERT INTO output
+                SELECT col1, count(*) FROM table1 GROUP BY col1");
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings());
+
+            var relations = CollectRelations(plan);
+
+            Assert.Single(relations.OfType<AggregateRelation>());
+            Assert.Empty(relations.OfType<SetRelation>());
+        }
+
+        [Fact]
+        public void AggregateWithoutGroupingIsNotRewritten()
+        {
+            var plan = BuildPlan(@"
+                INSERT INTO output
+                SELECT count(*) FROM table1");
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings());
+
+            var relations = CollectRelations(plan);
+
+            Assert.Single(relations.OfType<AggregateRelation>());
+            Assert.Empty(relations.OfType<SetRelation>());
+        }
+
+        /// <summary>
+        /// Grouping sets add a grouping id column.
+        /// </summary>
+        [Fact]
+        public void MultipleGroupingSetsAreNotRewritten()
+        {
+            var readRelation = new ReadRelation()
+            {
+                NamedTable = new Substrait.Type.NamedTable() { Names = new List<string>() { "table1" } },
+                BaseSchema = new Substrait.Type.NamedStruct()
+                {
+                    Names = new List<string>() { "col1", "col2" },
+                    Struct = new Substrait.Type.Struct()
+                    {
+                        Types = new List<Substrait.Type.SubstraitBaseType>()
+                        {
+                            new Substrait.Type.AnyType(),
+                            new Substrait.Type.AnyType()
+                        }
+                    }
+                }
+            };
+            var aggregateRelation = new AggregateRelation()
+            {
+                Input = readRelation,
+                Groupings = new List<AggregateGrouping>()
+                {
+                    new AggregateGrouping()
+                    {
+                        GroupingExpressions = new List<Expression>() { CreateFieldReference(0) }
+                    },
+                    new AggregateGrouping()
+                    {
+                        GroupingExpressions = new List<Expression>() { CreateFieldReference(1) }
+                    }
+                },
+                Measures = new List<AggregateMeasure>()
+            };
+            var plan = new Substrait.Plan()
+            {
+                Relations = new List<Relation>()
+                {
+                    new RootRelation()
+                    {
+                        Input = aggregateRelation,
+                        Names = new List<string>() { "col1", "col2", "groupingid" }
+                    }
+                }
+            };
+
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings());
+
+            var relations = CollectRelations(plan);
+            Assert.Single(relations.OfType<AggregateRelation>());
+            Assert.Empty(relations.OfType<SetRelation>());
+        }
+
+        [Fact]
+        public void SettingDisablesRewrite()
+        {
+            var plan = BuildPlan(@"
+                INSERT INTO output
+                SELECT col1, col2 FROM table1 GROUP BY col1, col2");
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings() { GroupByToDistinct = false });
+
+            var relations = CollectRelations(plan);
+
+            Assert.Single(relations.OfType<AggregateRelation>());
+            Assert.Empty(relations.OfType<SetRelation>());
+        }
+
+        /// <summary>
+        /// Aggregates are partitioned, set operations are not.
+        /// </summary>
+        [Fact]
+        public void ParallelizedPlanKeepsAggregate()
+        {
+            var plan = BuildPlan(@"
+                INSERT INTO output
+                SELECT col1, col2 FROM table1 GROUP BY col1, col2");
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings() { Parallelization = 2 });
+
+            var relations = CollectRelations(plan);
+
+            Assert.NotEmpty(relations.OfType<AggregateRelation>());
+        }
+
+        private static DirectFieldReference CreateFieldReference(int field)
+        {
+            return new DirectFieldReference()
+            {
+                ReferenceSegment = new StructReferenceSegment() { Field = field }
+            };
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Core.Tests/OptimizerTests/GroupByToDistinctTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/OptimizerTests/GroupByToDistinctTests.cs
@@ -1,4 +1,4 @@
-// Licensed under the Apache License, Version 2.0 (the "License")
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -249,10 +249,10 @@ namespace FlowtideDotNet.Core.Tests.OptimizerTests
         }
 
         /// <summary>
-        /// Aggregates are partitioned, set operations are not.
+        /// The distinct is partitioned the same way the aggregate was.
         /// </summary>
         [Fact]
-        public void ParallelizedPlanKeepsAggregate()
+        public void ParallelizedPlanPartitionsTheDistinct()
         {
             var plan = BuildPlan(@"
                 INSERT INTO output
@@ -261,7 +261,51 @@ namespace FlowtideDotNet.Core.Tests.OptimizerTests
 
             var relations = CollectRelations(plan);
 
-            Assert.NotEmpty(relations.OfType<AggregateRelation>());
+            Assert.Empty(relations.OfType<AggregateRelation>());
+
+            var sets = relations.OfType<SetRelation>().ToList();
+            Assert.Equal(2, sets.Count(x => x.Operation == SetOperation.UnionDistinct));
+            var combine = Assert.Single(sets.Where(x => x.Operation == SetOperation.UnionAll));
+            Assert.Equal(2, combine.Inputs.Count);
+
+            // The rows are scattered on both columns, the key is the whole row
+            var exchange = Assert.Single(relations.OfType<ExchangeRelation>());
+            Assert.Equal(2, exchange.PartitionCount);
+            var scatter = Assert.IsType<ScatterExchangeKind>(exchange.ExchangeKind);
+            Assert.Equal(2, scatter.Fields.Count);
+        }
+
+        /// <summary>
+        /// Every input of a multi input set operation gets its own exchange.
+        /// </summary>
+        [Fact]
+        public void ParallelizedExceptScattersBothInputs()
+        {
+            var plan = BuildPlan(@"
+                INSERT INTO output
+                SELECT col1 FROM table1
+                EXCEPT DISTINCT
+                SELECT col2 FROM table1");
+            plan = PlanOptimizer.Optimize(plan, new PlanOptimizerSettings() { Parallelization = 3 });
+
+            var relations = CollectRelations(plan);
+
+            var sets = relations.OfType<SetRelation>().ToList();
+            Assert.Equal(3, sets.Count(x => x.Operation == SetOperation.MinusPrimary));
+            var combine = Assert.Single(sets.Where(x => x.Operation == SetOperation.UnionAll));
+            Assert.Equal(3, combine.Inputs.Count);
+
+            // One exchange per input, both scattered on the same single column
+            var exchanges = relations.OfType<ExchangeRelation>().ToList();
+            Assert.Equal(2, exchanges.Count);
+            foreach (var exchange in exchanges)
+            {
+                Assert.Equal(3, exchange.PartitionCount);
+                var scatter = Assert.IsType<ScatterExchangeKind>(exchange.ExchangeKind);
+                var field = Assert.Single(scatter.Fields);
+                var segment = Assert.IsType<StructReferenceSegment>(Assert.IsType<DirectFieldReference>(field).ReferenceSegment);
+                Assert.Equal(0, segment.Field);
+            }
         }
 
         private static DirectFieldReference CreateFieldReference(int field)

--- a/tests/FlowtideDotNet.Nexmark/Program.cs
+++ b/tests/FlowtideDotNet.Nexmark/Program.cs
@@ -13,13 +13,13 @@
 using BenchmarkDotNet.Running;
 using FlowtideDotNet.Nexmark;
 
-//Query5 query3 = new Query5();
+//Query8 query3 = new Query8();
 //query3.Setup();
 
 //for (int i = 0; i < 10000; i++)
 //{
 //    query3.IterationSetup();
-//    await query3.Q5();
+//    await query3.Q8();
 //    query3.IterationCleanup();
 //}
 

--- a/tests/FlowtideDotNet.Nexmark/Query8.cs
+++ b/tests/FlowtideDotNet.Nexmark/Query8.cs
@@ -1,0 +1,56 @@
+﻿// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using BenchmarkDotNet.Attributes;
+using FlowtideDotNet.Nexmark.Internal.Diagnosers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlowtideDotNet.Nexmark
+{
+    [EventCountDiagnoser]
+    public class Query8 : QueryBase
+    {
+        [Benchmark]
+        public async Task Q8()
+        {
+            await Stream.StartStream(@"
+            INSERT INTO output
+            SELECT P.id, P.name, P.starttime
+            FROM (
+              SELECT P.id, P.name,
+                     window_start AS starttime,
+                     window_end AS endtime
+              FROM person P
+              INNER JOIN tumbling_window(P.datetime, 10, 'SECOND') wind
+              GROUP BY P.id, P.name, window_start, window_end
+            ) P
+            JOIN (
+              SELECT A.seller,
+                     window_start AS starttime,
+                     window_end AS endtime
+              FROM auction A
+              INNER JOIN tumbling_window(A.datetime, 10, 'SECOND') wind
+              GROUP BY A.seller, window_start, window_end
+            ) A
+            ON P.id = A.seller AND P.starttime = A.starttime AND P.endtime = A.endtime;
+            ", planOptimizerSettings: new Core.Optimizer.PlanOptimizerSettings()
+            {
+                Parallelization = 1
+            });
+            await Stream.WaitForUpdate();
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Nexmark/Query8.cs
+++ b/tests/FlowtideDotNet.Nexmark/Query8.cs
@@ -12,10 +12,6 @@
 
 using BenchmarkDotNet.Attributes;
 using FlowtideDotNet.Nexmark.Internal.Diagnosers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace FlowtideDotNet.Nexmark


### PR DESCRIPTION
This helps improve performance of the set operator to be more inline of the performance of merge join and aggregates.

This change also includes an optimizer to change a group by without measures into a set operator distinct.