### PR TITLE
Seal columns for updates after being sent out by an operator

### DIFF
--- a/src/FlowtideDotNet.Core/ColumnStore/Column.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/Column.cs
@@ -62,6 +62,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         private ArrowTypeId _type = ArrowTypeId.Null;
         private bool disposedValue;
         private int _rentCounter;
+        private bool _handoffSealed;
 
         public int ByteSize => GetByteSize();
 
@@ -78,6 +79,7 @@ namespace FlowtideDotNet.Core.ColumnStore
             _type = ArrowTypeId.Null;
             _rentCounter = 0;
             disposedValue = false;
+            _handoffSealed = false;
         }
 
         internal void Assign(int nullCounter, IDataColumn? dataColumn, BitmapList validityList, ArrowTypeId type, IMemoryAllocator memoryAllocator)
@@ -92,6 +94,24 @@ namespace FlowtideDotNet.Core.ColumnStore
             _memoryAllocator = memoryAllocator;
             _rentCounter = 0;
             disposedValue = false;
+            _handoffSealed = false;
+        }
+
+        /// <summary>
+        /// Blocks further writes, called when the column is handed downstream in a batch.
+        /// </summary>
+        internal void SealForHandoff()
+        {
+            _handoffSealed = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ThrowIfSealed([CallerMemberName] string? member = null)
+        {
+            if (HandoffSeal.Enabled && _handoffSealed)
+            {
+                HandoffSeal.Throw(nameof(Column), member);
+            }
         }
 
         public static Column Create(IMemoryAllocator memoryAllocator)
@@ -276,6 +296,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void Add<T>(in T value)
             where T : IDataValue
         {
+            ThrowIfSealed();
             if (!CompareValueType(value))
             {
                 if (_type == ArrowTypeId.Null)
@@ -379,6 +400,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void InsertAt<T>(in int index, in T value)
             where T : IDataValue
         {
+            ThrowIfSealed();
             if (!CompareValueType(value))
             {
                 if (_type == ArrowTypeId.Null)
@@ -452,6 +474,7 @@ namespace FlowtideDotNet.Core.ColumnStore
         public void UpdateAt<T>(in int index, in T value)
             where T : IDataValue
         {
+            ThrowIfSealed();
             if (_type == ArrowTypeId.Union)
             {
                 _dataColumn!.Update<T>(index, value, _memoryAllocator!);
@@ -512,6 +535,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void RemoveAt(in int index)
         {
+            ThrowIfSealed();
             if (_nullCounter > 0)
             {
                 if (_type == ArrowTypeId.Null)
@@ -535,6 +559,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void RemoveRange(in int index, in int count)
         {
+            ThrowIfSealed();
             if (count == 0)
             {
                 return;
@@ -855,6 +880,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void Clear()
         {
+            ThrowIfSealed();
             if (_nullCounter > 0)
             {
                 _validityList.Clear();
@@ -868,6 +894,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void AddToNewList<T>(in T value) where T : IDataValue
         {
+            ThrowIfSealed();
             if (_type == ArrowTypeId.List)
             {
                 _dataColumn!.AddToNewList(value, _memoryAllocator!);
@@ -908,6 +935,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public int EndNewList()
         {
+            ThrowIfSealed();
             if (_type == ArrowTypeId.List)
             {
                 return _dataColumn!.EndNewList(_memoryAllocator!);
@@ -994,6 +1022,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void InsertNullRange(int index, int count)
         {
+            ThrowIfSealed();
             if (_type == ArrowTypeId.Null)
             {
                 _nullCounter += count;
@@ -1018,6 +1047,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void InsertRangeFrom(int index, IColumn otherColumn, int start, int count)
         {
+            ThrowIfSealed();
             if (count == 0)
             {
                 return;
@@ -1381,6 +1411,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void InsertFrom(IColumn column, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
+            ThrowIfSealed();
 
             if (column is Column other)
             {
@@ -1589,6 +1620,7 @@ namespace FlowtideDotNet.Core.ColumnStore
 
         public void DeleteBatch(ReadOnlySpan<int> targets)
         {
+            ThrowIfSealed();
 
             if (targets.Length == 0) return;
 

--- a/src/FlowtideDotNet.Core/ColumnStore/EventBatchData.cs
+++ b/src/FlowtideDotNet.Core/ColumnStore/EventBatchData.cs
@@ -38,6 +38,32 @@ namespace FlowtideDotNet.Core.ColumnStore
         }
 
         /// <summary>
+        /// Seals every column so later writes throw, called when the batch is handed downstream.
+        /// </summary>
+        internal void SealForHandoff()
+        {
+            for (int i = 0; i < columns.Length; i++)
+            {
+                SealColumn(columns[i]);
+            }
+        }
+
+        private static void SealColumn(IColumn column)
+        {
+            switch (column)
+            {
+                case Column c:
+                    c.SealForHandoff();
+                    break;
+                case ColumnWithOffset columnWithOffset:
+                    // The wrapper shares both the offsets and the inner column with other holders.
+                    columnWithOffset.Offsets.SealForHandoff();
+                    SealColumn(columnWithOffset.InnerColumn);
+                    break;
+            }
+        }
+
+        /// <summary>
         /// Returns the raw array of columns, this array MUST not be modified
         /// since that will break thread safety.
         /// </summary>

--- a/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
+++ b/src/FlowtideDotNet.Core/Operators/Read/ColumnBatchReadBaseOperator.cs
@@ -796,12 +796,14 @@ namespace FlowtideDotNet.Core.Operators.Read
             PrimitiveList<int> weights = new PrimitiveList<int>(MemoryAllocator);
             PrimitiveList<uint> iterations = new PrimitiveList<uint>(MemoryAllocator);
 
-            IColumn[] deleteBatchColumns = new IColumn[_readRelation.BaseSchema.Names.Count];
-
-            for (int i = 0; i < _readRelation.BaseSchema.Names.Count; i++)
+            // Indexed by base schema, only the emitted slots are built since only they are sent.
+            var isEmitted = new bool[_readRelation.BaseSchema.Names.Count];
+            for (int k = 0; k < _emitList.Count; k++)
             {
-                deleteBatchColumns[i] = Column.Create(MemoryAllocator);
+                isEmitted[_emitList[k]] = true;
             }
+            IColumn[] deleteBatchColumns = new IColumn[_readRelation.BaseSchema.Names.Count];
+            CreateEmittedColumns();
 
             using var deleteIterator = _deleteTree.CreateIterator();
             await deleteIterator.SeekFirst();
@@ -828,7 +830,10 @@ namespace FlowtideDotNet.Core.Operators.Read
                             // Output delete event
                             for (int k = 0; k < _otherColumns.Count; k++)
                             {
-                                deleteBatchColumns[_otherColumns[k]].Add(current.referenceBatch.Columns[k].GetValueAt(current.RowIndex, default));
+                                if (isEmitted[_otherColumns[k]])
+                                {
+                                    deleteBatchColumns[_otherColumns[k]].Add(current.referenceBatch.Columns[k].GetValueAt(current.RowIndex, default));
+                                }
                             }
                             return (current, GenericWriteOperation.Delete);
                         }
@@ -842,7 +847,10 @@ namespace FlowtideDotNet.Core.Operators.Read
                         // If it is a delete, add the key values as well
                         for (int i = 0; i < _primaryKeyColumns.Count; i++)
                         {
-                            deleteBatchColumns[_primaryKeyColumns[i]].Add(kv.Key.referenceBatch.Columns[i].GetValueAt(kv.Key.RowIndex, default));
+                            if (isEmitted[_primaryKeyColumns[i]])
+                            {
+                                deleteBatchColumns[_primaryKeyColumns[i]].Add(kv.Key.referenceBatch.Columns[i].GetValueAt(kv.Key.RowIndex, default));
+                            }
                         }
                     }
                     if (weights.Count >= 100)
@@ -860,10 +868,8 @@ namespace FlowtideDotNet.Core.Operators.Read
                         // Reset
                         weights = new PrimitiveList<int>(MemoryAllocator);
                         iterations = new PrimitiveList<uint>(MemoryAllocator);
-                        for (int i = 0; i < _readRelation.OutputLength; i++)
-                        {
-                            deleteBatchColumns[i] = Column.Create(MemoryAllocator);
-                        }
+                        // The sent columns belong to the batch now, every emitted slot needs a new one.
+                        CreateEmittedColumns();
                     }
                 }
             }
@@ -885,14 +891,28 @@ namespace FlowtideDotNet.Core.Operators.Read
                 weights.Dispose();
                 iterations.Dispose();
 
-                for (int i = 0; i < _readRelation.OutputLength; i++)
+                for (int i = 0; i < deleteBatchColumns.Length; i++)
                 {
-                    deleteBatchColumns[i].Dispose();
+                    if (isEmitted[i])
+                    {
+                        deleteBatchColumns[i].Dispose();
+                    }
                 }
             }
 
             await _deleteTree.Clear();
             return sentData;
+
+            void CreateEmittedColumns()
+            {
+                for (int i = 0; i < deleteBatchColumns.Length; i++)
+                {
+                    if (isEmitted[i])
+                    {
+                        deleteBatchColumns[i] = Column.Create(MemoryAllocator);
+                    }
+                }
+            }
         }
 
         protected override async Task SendInitial(IngressOutput<StreamEventBatch> output)

--- a/src/FlowtideDotNet.Core/StreamEventBatch.cs
+++ b/src/FlowtideDotNet.Core/StreamEventBatch.cs
@@ -74,6 +74,11 @@ namespace FlowtideDotNet.Core
         {
             _data = data;
             _columnCount = _data.EventBatchData.Columns.Count;
+
+            // From here the data is shared with downstream readers, so writes to it are bugs.
+            data.EventBatchData.SealForHandoff();
+            data.Weights.SealForHandoff();
+            data.Iterations.SealForHandoff();
         }
 
         public StreamEventBatch(List<RowEvent> events, int columnCount)

--- a/src/FlowtideDotNet.Storage/DataStructures/HandoffSeal.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/HandoffSeal.cs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace FlowtideDotNet.Storage.DataStructures
+{
+    /// <summary>
+    /// Rejects writes to data that was handed downstream, set <c>FlowtideDotNet.DisableHandoffSeal</c> to turn it off.
+    /// </summary>
+    internal static class HandoffSeal
+    {
+        public const string DisableSwitchName = "FlowtideDotNet.DisableHandoffSeal";
+
+        // Read once so the JIT folds the check away when it is disabled.
+        public static readonly bool Enabled = !(AppContext.TryGetSwitch(DisableSwitchName, out var disabled) && disabled);
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void Throw(string owner, string? member)
+        {
+            throw new InvalidOperationException(
+                $"{owner}.{member} was called on data that was already handed downstream in a batch. " +
+                "Downstream operators may be reading it concurrently, so writing to it corrupts their reads.");
+        }
+    }
+}

--- a/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
+++ b/src/FlowtideDotNet.Storage/DataStructures/PrimitiveList.cs
@@ -31,6 +31,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         // Not readonly, mutations would run on a copy.
         private NativeList<T> _list;
         private bool _disposedValue;
+        private bool _handoffSealed;
         private readonly IMemoryAllocator _memoryAllocator;
         private int _rentCounter;
 
@@ -80,6 +81,23 @@ namespace FlowtideDotNet.Storage.DataStructures
 #pragma warning restore RS0042
 
         /// <summary>
+        /// Blocks further writes, called when the list is handed downstream in a batch.
+        /// </summary>
+        internal void SealForHandoff()
+        {
+            _handoffSealed = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ThrowIfSealed([CallerMemberName] string? member = null)
+        {
+            if (HandoffSeal.Enabled && _handoffSealed)
+            {
+                HandoffSeal.Throw(nameof(PrimitiveList<T>), member);
+            }
+        }
+
+        /// <summary>
         /// A span over the current elements of the list.
         /// </summary>
         public Span<T> Span => _list.Span;
@@ -111,6 +129,7 @@ namespace FlowtideDotNet.Storage.DataStructures
 
         internal void EnsureCapacity(int length)
         {
+            ThrowIfSealed();
             _list.EnsureCapacity(length, _memoryAllocator);
         }
 
@@ -120,6 +139,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="value">The value to append.</param>
         public void Add(T value)
         {
+            ThrowIfSealed();
             _list.Add(value, _memoryAllocator);
         }
 
@@ -131,6 +151,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="count">The number of elements to copy.</param>
         public void AddRangeFrom(PrimitiveList<T> list, int index, int count)
         {
+            ThrowIfSealed();
             _list.AddRangeFrom(in list._list, index, count, _memoryAllocator);
         }
 
@@ -141,6 +162,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="value">The value to insert.</param>
         public void InsertAt(int index, T value)
         {
+            ThrowIfSealed();
             _list.InsertAt(index, value, _memoryAllocator);
         }
 
@@ -153,6 +175,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="count">The number of elements to copy.</param>
         public void InsertRangeFrom(int index, PrimitiveList<T> other, int start, int count)
         {
+            ThrowIfSealed();
             _list.InsertRangeFrom(index, in other._list, start, count, _memoryAllocator);
         }
 
@@ -164,6 +187,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="count">The number of copies to insert.</param>
         public void InsertStaticRange(int index, T value, int count)
         {
+            ThrowIfSealed();
             _list.InsertStaticRange(index, value, count, _memoryAllocator);
         }
 
@@ -180,6 +204,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="lookupNullIndex">A sentinel value in <paramref name="sortedLookup"/> that inserts a default element instead of reading from <paramref name="other"/>.</param>
         public void InsertFrom(ref readonly PrimitiveList<T> other, ref readonly ReadOnlySpan<int> sortedLookup, ref readonly ReadOnlySpan<int> insertPositions, in int lookupNullIndex)
         {
+            ThrowIfSealed();
             _list.InsertFrom(in other._list, in sortedLookup, in insertPositions, in lookupNullIndex, _memoryAllocator);
         }
 
@@ -191,6 +216,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="targets">A span of sorted indices (ascending) of elements to delete.</param>
         public void DeleteBatch(ReadOnlySpan<int> targets)
         {
+            ThrowIfSealed();
             _list.DeleteBatch(targets, _memoryAllocator);
         }
 
@@ -206,6 +232,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="insertPositions">A span containing the positions at which to insert the elements in the current list. Must be in non-decreasing order.</param>
         public void InsertFrom(T[] keys, ReadOnlySpan<int> sortedLookup, ReadOnlySpan<int> insertPositions)
         {
+            ThrowIfSealed();
             _list.InsertFrom(keys, sortedLookup, insertPositions, _memoryAllocator);
         }
 
@@ -217,6 +244,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="count">The number of element slots to open.</param>
         public void MoveAtIndex(int index, int count)
         {
+            ThrowIfSealed();
             _list.MoveAtIndex(index, count, _memoryAllocator);
         }
 
@@ -226,6 +254,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="index">The zero based index of the element to remove.</param>
         public void RemoveAt(int index)
         {
+            ThrowIfSealed();
             _list.RemoveAt(index, _memoryAllocator);
         }
 
@@ -236,6 +265,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="count">The number of elements to remove.</param>
         public void RemoveRange(int index, int count)
         {
+            ThrowIfSealed();
             _list.RemoveRange(index, count, _memoryAllocator);
         }
 
@@ -265,6 +295,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="value">The new value.</param>
         public void Update(in int index, in T value)
         {
+            ThrowIfSealed();
             _list.Update(in index, in value);
         }
 
@@ -280,6 +311,7 @@ namespace FlowtideDotNet.Storage.DataStructures
             }
             set
             {
+                ThrowIfSealed();
                 _list.Update(index, value);
             }
         }
@@ -357,6 +389,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// </summary>
         public void Clear()
         {
+            ThrowIfSealed();
             _list.Clear();
         }
 
@@ -391,6 +424,7 @@ namespace FlowtideDotNet.Storage.DataStructures
         /// <param name="newLength">The new element count.</param>
         public void SetLength(int newLength)
         {
+            ThrowIfSealed();
             _list.SetLength(newLength);
         }
 

--- a/tests/FlowtideDotNet.Core.Tests/ColumnStore/HandoffSealTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/ColumnStore/HandoffSealTests.cs
@@ -1,0 +1,182 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Core.ColumnStore;
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+
+namespace FlowtideDotNet.Core.Tests.ColumnStore
+{
+    public class HandoffSealTests
+    {
+        private static Column IntColumn(params long[] values)
+        {
+            var column = Column.Create(GlobalMemoryManager.Instance);
+            foreach (var value in values)
+            {
+                column.Add(new Int64Value(value));
+            }
+            return column;
+        }
+
+        private static StreamEventBatch Send(params IColumn[] columns)
+        {
+            var weights = new PrimitiveList<int>(GlobalMemoryManager.Instance);
+            var iterations = new PrimitiveList<uint>(GlobalMemoryManager.Instance);
+            for (int i = 0; i < columns[0].Count; i++)
+            {
+                weights.Add(1);
+                iterations.Add(0);
+            }
+            return new StreamEventBatch(new EventBatchWeighted(weights, iterations, new EventBatchData(columns)));
+        }
+
+        private static void Mutate(Column column, string mutator)
+        {
+            switch (mutator)
+            {
+                case "Add":
+                    column.Add(new Int64Value(4));
+                    break;
+                case "InsertAt":
+                    column.InsertAt(0, new Int64Value(4));
+                    break;
+                case "UpdateAt":
+                    column.UpdateAt(0, new Int64Value(4));
+                    break;
+                case "RemoveAt":
+                    column.RemoveAt(0);
+                    break;
+                case "RemoveRange":
+                    column.RemoveRange(0, 1);
+                    break;
+                case "Clear":
+                    column.Clear();
+                    break;
+                case "InsertNullRange":
+                    column.InsertNullRange(0, 1);
+                    break;
+                case "InsertRangeFrom":
+                    column.InsertRangeFrom(0, IntColumn(9), 0, 1);
+                    break;
+                case "InsertFrom":
+                    ReadOnlySpan<int> lookup = [0];
+                    ReadOnlySpan<int> positions = [0];
+                    column.InsertFrom(IntColumn(9), in lookup, in positions, -1);
+                    break;
+                case "DeleteBatch":
+                    column.DeleteBatch([0]);
+                    break;
+                case "AddToNewList":
+                    column.AddToNewList(new Int64Value(4));
+                    break;
+                case "EndNewList":
+                    column.EndNewList();
+                    break;
+                default:
+                    throw new ArgumentException(mutator);
+            }
+        }
+
+        [Theory]
+        [InlineData("Add")]
+        [InlineData("InsertAt")]
+        [InlineData("UpdateAt")]
+        [InlineData("RemoveAt")]
+        [InlineData("RemoveRange")]
+        [InlineData("Clear")]
+        [InlineData("InsertNullRange")]
+        [InlineData("InsertRangeFrom")]
+        [InlineData("InsertFrom")]
+        [InlineData("DeleteBatch")]
+        [InlineData("AddToNewList")]
+        [InlineData("EndNewList")]
+        public void EveryColumnMutatorThrowsAfterSend(string mutator)
+        {
+            var column = IntColumn(1, 2, 3);
+            Send(column);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => Mutate(column, mutator));
+
+            Assert.Contains($"Column.{mutator} was called on data that was already handed downstream", ex.Message);
+        }
+
+        /// <summary>
+        /// A union reallocates its offsets on append, the case that corrupts a concurrent reader.
+        /// </summary>
+        [Fact]
+        public void UnionColumnThrowsAfterSend()
+        {
+            var column = IntColumn(1);
+            column.Add(new StringValue("two"));
+            Assert.Equal(ArrowTypeId.Union, column.Type);
+            Send(column);
+
+            Assert.Throws<InvalidOperationException>(() => column.Add(new StringValue("three")));
+        }
+
+        [Fact]
+        public void WeightsAndIterationsThrowAfterSend()
+        {
+            var batch = Send(IntColumn(1));
+
+            Assert.Throws<InvalidOperationException>(() => batch.Data.Weights.Add(1));
+            Assert.Throws<InvalidOperationException>(() => batch.Data.Weights[0] = 5);
+            Assert.Throws<InvalidOperationException>(() => batch.Data.Iterations.Add(0));
+        }
+
+        [Fact]
+        public void ColumnWithOffsetSealsBothOffsetsAndInnerColumn()
+        {
+            var inner = IntColumn(1, 2);
+            var offsets = new PrimitiveList<int>(GlobalMemoryManager.Instance);
+            offsets.Add(1);
+            offsets.Add(0);
+            Send(new ColumnWithOffset(inner, offsets));
+
+            Assert.Throws<InvalidOperationException>(() => inner.Add(new Int64Value(3)));
+            Assert.Throws<InvalidOperationException>(() => offsets.Add(0));
+        }
+
+        [Fact]
+        public void WritesBeforeSendAreAllowed()
+        {
+            var column = IntColumn(1, 2);
+            column.RemoveAt(0);
+            column.Add(new Int64Value(3));
+
+            Assert.Equal(2, column.Count);
+        }
+
+        [Fact]
+        public void TheLastOwnerCanStillDisposeAfterSend()
+        {
+            var batch = Send(IntColumn(1, 2));
+
+            batch.Data.EventBatchData.Dispose();
+            batch.Data.Weights.Dispose();
+            batch.Data.Iterations.Dispose();
+        }
+
+        [Fact]
+        public void AssignClearsTheSeal()
+        {
+            var column = IntColumn(1);
+            Send(column);
+
+            column.Assign(GlobalMemoryManager.Instance);
+            column.Add(new Int64Value(2));
+
+            Assert.Equal(1, column.Count);
+        }
+    }
+}

--- a/tests/FlowtideDotNet.Core.Tests/GenericDataTests/GenericReadOperatorTests.cs
+++ b/tests/FlowtideDotNet.Core.Tests/GenericDataTests/GenericReadOperatorTests.cs
@@ -143,6 +143,44 @@ namespace FlowtideDotNet.Core.Tests.GenericDataTests
 
     public class GenericReadOperatorTests
     {
+        /// <summary>
+        /// A full reload sends its deletes in batches of 100, and an emitted column at or past the emit count used to be appended to after its batch was sent.
+        /// </summary>
+        [Fact]
+        public async Task FullLoadDeletesSpanningBatchesWithSparseEmit()
+        {
+            var source = new TestDataSource(default);
+            for (int i = 1; i <= 150; i++)
+            {
+                source.AddChange(new FlowtideGenericObject<User>(i.ToString(), new User { UserKey = i, FirstName = "F", LastName = $"Last{i}" }, i, false));
+            }
+
+            var stream = new GenericDataTestStream<User>(source, nameof(FullLoadDeletesSpanningBatchesWithSparseEmit));
+            stream.RegisterTableProviders(builder =>
+            {
+                builder.AddGenericDataTable<User>("users");
+            });
+
+            // The pushed down filter keeps FirstName in the base schema without emitting it, so LastName is base index 2 of 2 emitted.
+            await stream.StartStream(@"
+                INSERT INTO output
+                SELECT
+                    UserKey,
+                    LastName
+                FROM users
+                WHERE FirstName = 'F'
+            ");
+            await stream.WaitForUpdate();
+            stream.AssertCurrentDataEqual(Enumerable.Range(1, 150).Select(i => new { UserKey = i, LastName = $"Last{i}" }));
+
+            // Every row disappears, so the next full load emits 150 deletes across two batches.
+            source.ClearChanges();
+            await stream.Trigger("full_load");
+            await stream.WaitForUpdate();
+
+            stream.AssertCurrentDataEqual(Enumerable.Empty<object>().Select(x => new { UserKey = 0, LastName = "" }));
+        }
+
         [Fact]
         public async Task TestGenericDataSource()
         {

--- a/tests/FlowtideDotNet.Storage.Tests/DataStructures/PrimitiveListHandoffSealTests.cs
+++ b/tests/FlowtideDotNet.Storage.Tests/DataStructures/PrimitiveListHandoffSealTests.cs
@@ -1,0 +1,140 @@
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FlowtideDotNet.Storage.DataStructures;
+using FlowtideDotNet.Storage.Memory;
+
+namespace FlowtideDotNet.Storage.Tests.DataStructures
+{
+    public class PrimitiveListHandoffSealTests
+    {
+        private static PrimitiveList<int> SealedList()
+        {
+            var list = new PrimitiveList<int>(GlobalMemoryManager.Instance);
+            for (int i = 0; i < 4; i++)
+            {
+                list.Add(i);
+            }
+            list.SealForHandoff();
+            return list;
+        }
+
+        private static void Mutate(PrimitiveList<int> list, string mutator)
+        {
+            using var other = new PrimitiveList<int>(GlobalMemoryManager.Instance);
+            other.Add(9);
+            switch (mutator)
+            {
+                case "EnsureCapacity":
+                    list.EnsureCapacity(1024);
+                    break;
+                case "Add":
+                    list.Add(5);
+                    break;
+                case "AddRangeFrom":
+                    list.AddRangeFrom(other, 0, 1);
+                    break;
+                case "InsertAt":
+                    list.InsertAt(0, 5);
+                    break;
+                case "InsertRangeFrom":
+                    list.InsertRangeFrom(0, other, 0, 1);
+                    break;
+                case "InsertStaticRange":
+                    list.InsertStaticRange(0, 5, 2);
+                    break;
+                case "InsertFromList":
+                    ReadOnlySpan<int> lookup = [0];
+                    ReadOnlySpan<int> positions = [0];
+                    list.InsertFrom(in other, in lookup, in positions, -1);
+                    break;
+                case "InsertFromArray":
+                    list.InsertFrom([9], [0], [0]);
+                    break;
+                case "DeleteBatch":
+                    list.DeleteBatch([0]);
+                    break;
+                case "MoveAtIndex":
+                    list.MoveAtIndex(0, 1);
+                    break;
+                case "RemoveAt":
+                    list.RemoveAt(0);
+                    break;
+                case "RemoveRange":
+                    list.RemoveRange(0, 1);
+                    break;
+                case "Update":
+                    list.Update(0, 5);
+                    break;
+                case "Indexer":
+                    list[0] = 5;
+                    break;
+                case "Clear":
+                    list.Clear();
+                    break;
+                case "SetLength":
+                    list.SetLength(1);
+                    break;
+                default:
+                    throw new ArgumentException(mutator);
+            }
+        }
+
+        [Theory]
+        [InlineData("EnsureCapacity")]
+        [InlineData("Add")]
+        [InlineData("AddRangeFrom")]
+        [InlineData("InsertAt")]
+        [InlineData("InsertRangeFrom")]
+        [InlineData("InsertStaticRange")]
+        [InlineData("InsertFromList")]
+        [InlineData("InsertFromArray")]
+        [InlineData("DeleteBatch")]
+        [InlineData("MoveAtIndex")]
+        [InlineData("RemoveAt")]
+        [InlineData("RemoveRange")]
+        [InlineData("Update")]
+        [InlineData("Indexer")]
+        [InlineData("Clear")]
+        [InlineData("SetLength")]
+        public void EveryMutatorThrowsWhenSealed(string mutator)
+        {
+            using var list = SealedList();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => Mutate(list, mutator));
+
+            Assert.Contains("already handed downstream", ex.Message);
+            Assert.Equal(4, list.Count);
+        }
+
+        [Fact]
+        public void ReadsStillWorkWhenSealed()
+        {
+            using var list = SealedList();
+
+            Assert.Equal(2, list.Get(2));
+            Assert.Equal(3, list[3]);
+            Assert.Equal(4, list.Span.Length);
+        }
+
+        [Fact]
+        public void UnsealedListIsUnaffected()
+        {
+            using var list = new PrimitiveList<int>(GlobalMemoryManager.Instance);
+            list.Add(1);
+            list[0] = 2;
+            list.RemoveAt(0);
+
+            Assert.Equal(0, list.Count);
+        }
+    }
+}


### PR DESCRIPTION
This is done to find any potential bugs where a column is reused